### PR TITLE
protoc-gen-grafbase-subgraph: well-known types support

### DIFF
--- a/.github/workflows/rust-prs.yml
+++ b/.github/workflows/rust-prs.yml
@@ -327,6 +327,9 @@ jobs:
             protobuf_release_arch="osx-aarch_64"
           fi
 
+          sudo mkdir -p /usr/local/include/google
+          sudo chown -R $USER /usr/local/include/google
+
           curl -L https://github.com/protocolbuffers/protobuf/releases/download/v30.2/protoc-30.2-${protobuf_release_arch}.zip -o protoc.zip
           unzip protoc.zip -d /usr/local
           chmod +x /usr/local/bin/protoc

--- a/crates/protoc-gen-grafbase-subgraph/src/render_graphql_sdl/graphql_types.rs
+++ b/crates/protoc-gen-grafbase-subgraph/src/render_graphql_sdl/graphql_types.rs
@@ -1,3 +1,5 @@
+use crate::schema::ScalarType;
+
 use super::*;
 
 pub(super) fn render_graphql_types(
@@ -37,6 +39,25 @@ fn render_message(
 ) -> fmt::Result {
     let message = schema.view(message_id);
 
+    match message.name.as_str() {
+        ".google.protobuf.Duration"
+        | ".google.protobuf.Timestamp"
+        | ".google.protobuf.FieldMask"
+        | ".google.protobuf.BoolValue"
+        | ".google.protobuf.BytesValue"
+        | ".google.protobuf.DoubleValue"
+        | ".google.protobuf.FloatValue"
+        | ".google.protobuf.Int32Value"
+        | ".google.protobuf.Int64Value"
+        | ".google.protobuf.StringValue"
+        | ".google.protobuf.UInt32Value"
+        | ".google.protobuf.UInt64Value" => return Ok(()),
+
+        ".google.protobuf.Empty" => f.write_str("\n\"An empty object \" scalar EmptyObject\n")?,
+
+        _ => (),
+    }
+
     f.write_str("\n")?;
 
     if let Some(description) = message.description.as_deref() {
@@ -57,7 +78,13 @@ fn render_message(
         f.write_str(INDENT)?;
         f.write_str(&field.name)?;
         f.write_str(": ")?;
-        render_output_field_type(schema, &field.r#type, field.repeated, f)?;
+
+        if input {
+            render_input_field_type(schema, &field.r#type, field.repeated, f)?;
+        } else {
+            render_output_field_type(schema, &field.r#type, field.repeated, f)?;
+        }
+
         f.write_str("\n")?;
     }
 
@@ -76,7 +103,7 @@ pub(super) fn render_output_field_type(
 
     match ty {
         FieldType::Scalar(scalar_type) => scalar_type.render_graphql_type(f)?,
-        FieldType::Message(proto_message_id) => schema.view(*proto_message_id).graphql_output_name().fmt(f)?,
+        FieldType::Message(proto_message_id) => render_message_type_name(schema, *proto_message_id, false, f)?,
         FieldType::Enum(proto_enum_id) => schema.view(*proto_enum_id).graphql_name().fmt(f)?,
     }
 
@@ -99,7 +126,7 @@ pub(super) fn render_input_field_type(
 
     match ty {
         FieldType::Scalar(scalar_type) => scalar_type.render_graphql_type(f)?,
-        FieldType::Message(proto_message_id) => schema.view(*proto_message_id).graphql_input_name().fmt(f)?,
+        FieldType::Message(proto_message_id) => render_message_type_name(schema, *proto_message_id, true, f)?,
         FieldType::Enum(proto_enum_id) => schema.view(*proto_enum_id).graphql_name().fmt(f)?,
     }
 
@@ -136,4 +163,38 @@ fn render_enum_definition(schema: &GrpcSchema, enum_id: ProtoEnumId, f: &mut fmt
 
 pub(super) fn render_description(f: &mut fmt::Formatter<'_>, description: &str) -> fmt::Result {
     writeln!(f, "\"\"\"\n{description}\n\"\"\"", description = description.trim())
+}
+
+fn render_message_type_name(
+    schema: &GrpcSchema,
+    proto_message_id: ProtoMessageId,
+    is_input: bool,
+    f: &mut fmt::Formatter<'_>,
+) -> fmt::Result {
+    let message = schema.view(proto_message_id);
+
+    // See the docs for the mapping of well-known types: https://protobuf.dev/programming-guides/json/
+    match message.name.as_str() {
+        ".google.protobuf.Duration" => f.write_str("String"),
+        ".google.protobuf.Timestamp" => f.write_str("String"),
+        ".google.protobuf.FieldMask" => f.write_str("String"),
+        ".google.protobuf.Empty" => f.write_str("EmptyObject"),
+        ".google.protobuf.BoolValue" => ScalarType::Bool.render_graphql_type(f),
+        ".google.protobuf.BytesValue" => ScalarType::Bytes.render_graphql_type(f),
+        ".google.protobuf.DoubleValue" => ScalarType::Double.render_graphql_type(f),
+        ".google.protobuf.FloatValue" => ScalarType::Float.render_graphql_type(f),
+        ".google.protobuf.Int32Value" => ScalarType::Int32.render_graphql_type(f),
+        ".google.protobuf.Int64Value" => ScalarType::Int64.render_graphql_type(f),
+        ".google.protobuf.StringValue" => ScalarType::String.render_graphql_type(f),
+        ".google.protobuf.UInt32Value" => ScalarType::UInt32.render_graphql_type(f),
+        ".google.protobuf.UInt64Value" => ScalarType::UInt64.render_graphql_type(f),
+
+        _ => {
+            if is_input {
+                message.graphql_input_name().fmt(f)
+            } else {
+                message.graphql_output_name().fmt(f)
+            }
+        }
+    }
 }

--- a/crates/protoc-gen-grafbase-subgraph/src/render_graphql_sdl/services.rs
+++ b/crates/protoc-gen-grafbase-subgraph/src/render_graphql_sdl/services.rs
@@ -103,10 +103,10 @@ fn collect_message_id_and_enum_ids_recursively(
             enum_ids.insert(*proto_enum_id);
         }
         FieldType::Message(proto_message_id) => {
-            message_ids.insert(*proto_message_id);
-
-            for field in proto_message_id.fields(schema) {
-                collect_message_id_and_enum_ids_recursively(schema, &field.r#type, message_ids, enum_ids);
+            if message_ids.insert(*proto_message_id) {
+                for field in proto_message_id.fields(schema) {
+                    collect_message_id_and_enum_ids_recursively(schema, &field.r#type, message_ids, enum_ids);
+                }
             }
         }
     }

--- a/crates/protoc-gen-grafbase-subgraph/tests/codegen/well-known-types/wkt.proto
+++ b/crates/protoc-gen-grafbase-subgraph/tests/codegen/well-known-types/wkt.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/any.proto";
+import "google/protobuf/wrappers.proto";
+import "google/protobuf/api.proto";
+import "google/protobuf/type.proto";
+import "google/protobuf/source_context.proto";
+import "google/protobuf/field_mask.proto";
+import "google/protobuf/struct.proto";
+
+message AllWellKnownTypes {
+  google.protobuf.Any any_valueany = 1;
+  google.protobuf.Api api_value = 2;
+  google.protobuf.BoolValue bool_value = 3;
+  google.protobuf.BytesValue bytes_value = 4;
+  google.protobuf.DoubleValue double_value = 5;
+  google.protobuf.Duration duration_value = 6;
+  google.protobuf.Empty empty_value = 7;
+  google.protobuf.Enum enum_value = 8;
+  google.protobuf.EnumValue enum_value_value = 9;
+  google.protobuf.Field field_value = 10;
+  google.protobuf.FieldMask field_mask_value = 11;
+  google.protobuf.FloatValue float_value = 12;
+  google.protobuf.Int32Value int32_value = 13;
+  google.protobuf.Int64Value int64_value = 14;
+  google.protobuf.ListValue list_value = 15;
+  google.protobuf.Method method_value = 16;
+  google.protobuf.Mixin mixin_value = 17;
+  google.protobuf.NullValue null_value = 18;
+  google.protobuf.Option option_value = 19;
+  google.protobuf.SourceContext source_context_value = 20;
+  google.protobuf.StringValue string_value = 21;
+  google.protobuf.Struct struct_value = 22;
+  google.protobuf.Timestamp timestamp_value = 23;
+  google.protobuf.Type type_value = 24;
+  google.protobuf.UInt32Value uint32_value = 25;
+  google.protobuf.UInt64Value uint64_value = 26;
+  google.protobuf.Value value = 27;
+}
+
+service TestService {
+  rpc TestMethod(AllWellKnownTypes) returns (google.protobuf.Empty);
+}

--- a/crates/protoc-gen-grafbase-subgraph/tests/snapshots/codegen_tests__graphql file@routeguide__route_guide.proto.snap
+++ b/crates/protoc-gen-grafbase-subgraph/tests/snapshots/codegen_tests__graphql file@routeguide__route_guide.proto.snap
@@ -197,11 +197,11 @@ input routeguide_RectangleInput {
 """
 One corner of the rectangle.
 """
-  lo: routeguide_Point
+  lo: routeguide_PointInput
 """
 The other corner of the rectangle.
 """
-  hi: routeguide_Point
+  hi: routeguide_PointInput
 }
 
 """
@@ -211,7 +211,7 @@ input routeguide_RouteNoteInput {
 """
 The location from which the message is sent.
 """
-  location: routeguide_Point
+  location: routeguide_PointInput
 """
 The message to be sent.
 """

--- a/crates/protoc-gen-grafbase-subgraph/tests/snapshots/codegen_tests__graphql file@taqueria__tacotruck.proto.snap
+++ b/crates/protoc-gen-grafbase-subgraph/tests/snapshots/codegen_tests__graphql file@taqueria__tacotruck.proto.snap
@@ -532,13 +532,13 @@ Order message
 """
 input taqueria_OrderInput {
   customer_id: String
-  items: [taqueria_OrderItem!]
+  items: [taqueria_OrderItemInput!]
   is_takeout: Boolean
 """
 Map of item_id to customization options
 """
-  customizations: [taqueria_Order_CustomizationsEntry!]
-  payment_info: taqueria_PaymentInfo
+  customizations: [taqueria_Order_CustomizationsEntryInput!]
+  payment_info: taqueria_PaymentInfoInput
 }
 
 input taqueria_Order_CustomizationsEntryInput {

--- a/crates/protoc-gen-grafbase-subgraph/tests/snapshots/codegen_tests__graphql file@well-known-types__wkt.proto.snap
+++ b/crates/protoc-gen-grafbase-subgraph/tests/snapshots/codegen_tests__graphql file@well-known-types__wkt.proto.snap
@@ -1,0 +1,1632 @@
+---
+source: crates/protoc-gen-grafbase-subgraph/tests/codegen_tests.rs
+expression: "fs::read_to_string(entry.path()).unwrap()"
+input_file: crates/protoc-gen-grafbase-subgraph/tests/codegen/well-known-types/wkt.proto
+---
+extend schema
+  @protoServices(
+    services: [
+      {
+        name: "TestService"
+        methods: [
+          {
+            name: "TestMethod"
+            inputType: ".AllWellKnownTypes"
+            outputType: ".google.protobuf.Empty"
+          }
+        ]
+      }
+    ]
+  )
+  @protoMessages(
+    messages: [
+      {
+        name: ".google.protobuf.Timestamp"
+        fields: [
+          {
+            name: "seconds"
+            number: "1"
+            repeated: "false"
+            type: "int64"
+          }
+          {
+            name: "nanos"
+            number: "2"
+            repeated: "false"
+            type: "int32"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.Duration"
+        fields: [
+          {
+            name: "seconds"
+            number: "1"
+            repeated: "false"
+            type: "int64"
+          }
+          {
+            name: "nanos"
+            number: "2"
+            repeated: "false"
+            type: "int32"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.Empty"
+        fields: [
+        ]
+      }
+      {
+        name: ".google.protobuf.Any"
+        fields: [
+          {
+            name: "type_url"
+            number: "1"
+            repeated: "false"
+            type: "string"
+          }
+          {
+            name: "value"
+            number: "2"
+            repeated: "false"
+            type: "bytes"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.DoubleValue"
+        fields: [
+          {
+            name: "value"
+            number: "1"
+            repeated: "false"
+            type: "double"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.FloatValue"
+        fields: [
+          {
+            name: "value"
+            number: "1"
+            repeated: "false"
+            type: "float"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.Int64Value"
+        fields: [
+          {
+            name: "value"
+            number: "1"
+            repeated: "false"
+            type: "int64"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.UInt64Value"
+        fields: [
+          {
+            name: "value"
+            number: "1"
+            repeated: "false"
+            type: "uint64"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.Int32Value"
+        fields: [
+          {
+            name: "value"
+            number: "1"
+            repeated: "false"
+            type: "int32"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.UInt32Value"
+        fields: [
+          {
+            name: "value"
+            number: "1"
+            repeated: "false"
+            type: "uint32"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.BoolValue"
+        fields: [
+          {
+            name: "value"
+            number: "1"
+            repeated: "false"
+            type: "bool"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.StringValue"
+        fields: [
+          {
+            name: "value"
+            number: "1"
+            repeated: "false"
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.BytesValue"
+        fields: [
+          {
+            name: "value"
+            number: "1"
+            repeated: "false"
+            type: "bytes"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.SourceContext"
+        fields: [
+          {
+            name: "file_name"
+            number: "1"
+            repeated: "false"
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.Type"
+        fields: [
+          {
+            name: "name"
+            number: "1"
+            repeated: "false"
+            type: "string"
+          }
+          {
+            name: "fields"
+            number: "2"
+            repeated: "true"
+            type: ".google.protobuf.Field"
+          }
+          {
+            name: "oneofs"
+            number: "3"
+            repeated: "true"
+            type: "string"
+          }
+          {
+            name: "options"
+            number: "4"
+            repeated: "true"
+            type: ".google.protobuf.Option"
+          }
+          {
+            name: "source_context"
+            number: "5"
+            repeated: "false"
+            type: ".google.protobuf.SourceContext"
+          }
+          {
+            name: "syntax"
+            number: "6"
+            repeated: "false"
+            type: ".google.protobuf.Syntax"
+          }
+          {
+            name: "edition"
+            number: "7"
+            repeated: "false"
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.Field"
+        fields: [
+          {
+            name: "kind"
+            number: "1"
+            repeated: "false"
+            type: ".google.protobuf.Field.Kind"
+          }
+          {
+            name: "cardinality"
+            number: "2"
+            repeated: "false"
+            type: ".google.protobuf.Field.Cardinality"
+          }
+          {
+            name: "number"
+            number: "3"
+            repeated: "false"
+            type: "int32"
+          }
+          {
+            name: "name"
+            number: "4"
+            repeated: "false"
+            type: "string"
+          }
+          {
+            name: "type_url"
+            number: "6"
+            repeated: "false"
+            type: "string"
+          }
+          {
+            name: "oneof_index"
+            number: "7"
+            repeated: "false"
+            type: "int32"
+          }
+          {
+            name: "packed"
+            number: "8"
+            repeated: "false"
+            type: "bool"
+          }
+          {
+            name: "options"
+            number: "9"
+            repeated: "true"
+            type: ".google.protobuf.Option"
+          }
+          {
+            name: "json_name"
+            number: "10"
+            repeated: "false"
+            type: "string"
+          }
+          {
+            name: "default_value"
+            number: "11"
+            repeated: "false"
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.Enum"
+        fields: [
+          {
+            name: "name"
+            number: "1"
+            repeated: "false"
+            type: "string"
+          }
+          {
+            name: "enumvalue"
+            number: "2"
+            repeated: "true"
+            type: ".google.protobuf.EnumValue"
+          }
+          {
+            name: "options"
+            number: "3"
+            repeated: "true"
+            type: ".google.protobuf.Option"
+          }
+          {
+            name: "source_context"
+            number: "4"
+            repeated: "false"
+            type: ".google.protobuf.SourceContext"
+          }
+          {
+            name: "syntax"
+            number: "5"
+            repeated: "false"
+            type: ".google.protobuf.Syntax"
+          }
+          {
+            name: "edition"
+            number: "6"
+            repeated: "false"
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.EnumValue"
+        fields: [
+          {
+            name: "name"
+            number: "1"
+            repeated: "false"
+            type: "string"
+          }
+          {
+            name: "number"
+            number: "2"
+            repeated: "false"
+            type: "int32"
+          }
+          {
+            name: "options"
+            number: "3"
+            repeated: "true"
+            type: ".google.protobuf.Option"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.Option"
+        fields: [
+          {
+            name: "name"
+            number: "1"
+            repeated: "false"
+            type: "string"
+          }
+          {
+            name: "value"
+            number: "2"
+            repeated: "false"
+            type: ".google.protobuf.Any"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.Api"
+        fields: [
+          {
+            name: "name"
+            number: "1"
+            repeated: "false"
+            type: "string"
+          }
+          {
+            name: "methods"
+            number: "2"
+            repeated: "true"
+            type: ".google.protobuf.Method"
+          }
+          {
+            name: "options"
+            number: "3"
+            repeated: "true"
+            type: ".google.protobuf.Option"
+          }
+          {
+            name: "version"
+            number: "4"
+            repeated: "false"
+            type: "string"
+          }
+          {
+            name: "source_context"
+            number: "5"
+            repeated: "false"
+            type: ".google.protobuf.SourceContext"
+          }
+          {
+            name: "mixins"
+            number: "6"
+            repeated: "true"
+            type: ".google.protobuf.Mixin"
+          }
+          {
+            name: "syntax"
+            number: "7"
+            repeated: "false"
+            type: ".google.protobuf.Syntax"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.Method"
+        fields: [
+          {
+            name: "name"
+            number: "1"
+            repeated: "false"
+            type: "string"
+          }
+          {
+            name: "request_type_url"
+            number: "2"
+            repeated: "false"
+            type: "string"
+          }
+          {
+            name: "request_streaming"
+            number: "3"
+            repeated: "false"
+            type: "bool"
+          }
+          {
+            name: "response_type_url"
+            number: "4"
+            repeated: "false"
+            type: "string"
+          }
+          {
+            name: "response_streaming"
+            number: "5"
+            repeated: "false"
+            type: "bool"
+          }
+          {
+            name: "options"
+            number: "6"
+            repeated: "true"
+            type: ".google.protobuf.Option"
+          }
+          {
+            name: "syntax"
+            number: "7"
+            repeated: "false"
+            type: ".google.protobuf.Syntax"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.Mixin"
+        fields: [
+          {
+            name: "name"
+            number: "1"
+            repeated: "false"
+            type: "string"
+          }
+          {
+            name: "root"
+            number: "2"
+            repeated: "false"
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.FieldMask"
+        fields: [
+          {
+            name: "paths"
+            number: "1"
+            repeated: "true"
+            type: "string"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.Struct"
+        fields: [
+          {
+            name: "fields"
+            number: "1"
+            repeated: "true"
+            type: ".google.protobuf.Struct.FieldsEntry"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.Struct.FieldsEntry"
+        fields: [
+          {
+            name: "key"
+            number: "1"
+            repeated: "false"
+            type: "string"
+          }
+          {
+            name: "value"
+            number: "2"
+            repeated: "false"
+            type: ".google.protobuf.Value"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.Value"
+        fields: [
+          {
+            name: "null_value"
+            number: "1"
+            repeated: "false"
+            type: ".google.protobuf.NullValue"
+          }
+          {
+            name: "number_value"
+            number: "2"
+            repeated: "false"
+            type: "double"
+          }
+          {
+            name: "string_value"
+            number: "3"
+            repeated: "false"
+            type: "string"
+          }
+          {
+            name: "bool_value"
+            number: "4"
+            repeated: "false"
+            type: "bool"
+          }
+          {
+            name: "struct_value"
+            number: "5"
+            repeated: "false"
+            type: ".google.protobuf.Struct"
+          }
+          {
+            name: "list_value"
+            number: "6"
+            repeated: "false"
+            type: ".google.protobuf.ListValue"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.ListValue"
+        fields: [
+          {
+            name: "values"
+            number: "1"
+            repeated: "true"
+            type: ".google.protobuf.Value"
+          }
+        ]
+      }
+      {
+        name: ".AllWellKnownTypes"
+        fields: [
+          {
+            name: "any_valueany"
+            number: "1"
+            repeated: "false"
+            type: ".google.protobuf.Any"
+          }
+          {
+            name: "api_value"
+            number: "2"
+            repeated: "false"
+            type: ".google.protobuf.Api"
+          }
+          {
+            name: "bool_value"
+            number: "3"
+            repeated: "false"
+            type: ".google.protobuf.BoolValue"
+          }
+          {
+            name: "bytes_value"
+            number: "4"
+            repeated: "false"
+            type: ".google.protobuf.BytesValue"
+          }
+          {
+            name: "double_value"
+            number: "5"
+            repeated: "false"
+            type: ".google.protobuf.DoubleValue"
+          }
+          {
+            name: "duration_value"
+            number: "6"
+            repeated: "false"
+            type: ".google.protobuf.Duration"
+          }
+          {
+            name: "empty_value"
+            number: "7"
+            repeated: "false"
+            type: ".google.protobuf.Empty"
+          }
+          {
+            name: "enum_value"
+            number: "8"
+            repeated: "false"
+            type: ".google.protobuf.Enum"
+          }
+          {
+            name: "enum_value_value"
+            number: "9"
+            repeated: "false"
+            type: ".google.protobuf.EnumValue"
+          }
+          {
+            name: "field_value"
+            number: "10"
+            repeated: "false"
+            type: ".google.protobuf.Field"
+          }
+          {
+            name: "field_mask_value"
+            number: "11"
+            repeated: "false"
+            type: ".google.protobuf.FieldMask"
+          }
+          {
+            name: "float_value"
+            number: "12"
+            repeated: "false"
+            type: ".google.protobuf.FloatValue"
+          }
+          {
+            name: "int32_value"
+            number: "13"
+            repeated: "false"
+            type: ".google.protobuf.Int32Value"
+          }
+          {
+            name: "int64_value"
+            number: "14"
+            repeated: "false"
+            type: ".google.protobuf.Int64Value"
+          }
+          {
+            name: "list_value"
+            number: "15"
+            repeated: "false"
+            type: ".google.protobuf.ListValue"
+          }
+          {
+            name: "method_value"
+            number: "16"
+            repeated: "false"
+            type: ".google.protobuf.Method"
+          }
+          {
+            name: "mixin_value"
+            number: "17"
+            repeated: "false"
+            type: ".google.protobuf.Mixin"
+          }
+          {
+            name: "null_value"
+            number: "18"
+            repeated: "false"
+            type: ".google.protobuf.NullValue"
+          }
+          {
+            name: "option_value"
+            number: "19"
+            repeated: "false"
+            type: ".google.protobuf.Option"
+          }
+          {
+            name: "source_context_value"
+            number: "20"
+            repeated: "false"
+            type: ".google.protobuf.SourceContext"
+          }
+          {
+            name: "string_value"
+            number: "21"
+            repeated: "false"
+            type: ".google.protobuf.StringValue"
+          }
+          {
+            name: "struct_value"
+            number: "22"
+            repeated: "false"
+            type: ".google.protobuf.Struct"
+          }
+          {
+            name: "timestamp_value"
+            number: "23"
+            repeated: "false"
+            type: ".google.protobuf.Timestamp"
+          }
+          {
+            name: "type_value"
+            number: "24"
+            repeated: "false"
+            type: ".google.protobuf.Type"
+          }
+          {
+            name: "uint32_value"
+            number: "25"
+            repeated: "false"
+            type: ".google.protobuf.UInt32Value"
+          }
+          {
+            name: "uint64_value"
+            number: "26"
+            repeated: "false"
+            type: ".google.protobuf.UInt64Value"
+          }
+          {
+            name: "value"
+            number: "27"
+            repeated: "false"
+            type: ".google.protobuf.Value"
+          }
+        ]
+      }
+    ]
+  )
+  @protoEnums(
+    enums: [
+      {
+        name: ".google.protobuf.Syntax"
+        values: [
+          {
+            name: "SYNTAX_PROTO2"
+            number: "0"
+          }
+          {
+            name: "SYNTAX_PROTO3"
+            number: "1"
+          }
+          {
+            name: "SYNTAX_EDITIONS"
+            number: "2"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.Field.Kind"
+        values: [
+          {
+            name: "TYPE_UNKNOWN"
+            number: "0"
+          }
+          {
+            name: "TYPE_DOUBLE"
+            number: "1"
+          }
+          {
+            name: "TYPE_FLOAT"
+            number: "2"
+          }
+          {
+            name: "TYPE_INT64"
+            number: "3"
+          }
+          {
+            name: "TYPE_UINT64"
+            number: "4"
+          }
+          {
+            name: "TYPE_INT32"
+            number: "5"
+          }
+          {
+            name: "TYPE_FIXED64"
+            number: "6"
+          }
+          {
+            name: "TYPE_FIXED32"
+            number: "7"
+          }
+          {
+            name: "TYPE_BOOL"
+            number: "8"
+          }
+          {
+            name: "TYPE_STRING"
+            number: "9"
+          }
+          {
+            name: "TYPE_GROUP"
+            number: "10"
+          }
+          {
+            name: "TYPE_MESSAGE"
+            number: "11"
+          }
+          {
+            name: "TYPE_BYTES"
+            number: "12"
+          }
+          {
+            name: "TYPE_UINT32"
+            number: "13"
+          }
+          {
+            name: "TYPE_ENUM"
+            number: "14"
+          }
+          {
+            name: "TYPE_SFIXED32"
+            number: "15"
+          }
+          {
+            name: "TYPE_SFIXED64"
+            number: "16"
+          }
+          {
+            name: "TYPE_SINT32"
+            number: "17"
+          }
+          {
+            name: "TYPE_SINT64"
+            number: "18"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.Field.Cardinality"
+        values: [
+          {
+            name: "CARDINALITY_UNKNOWN"
+            number: "0"
+          }
+          {
+            name: "CARDINALITY_OPTIONAL"
+            number: "1"
+          }
+          {
+            name: "CARDINALITY_REQUIRED"
+            number: "2"
+          }
+          {
+            name: "CARDINALITY_REPEATED"
+            number: "3"
+          }
+        ]
+      }
+      {
+        name: ".google.protobuf.NullValue"
+        values: [
+          {
+            name: "NULL_VALUE"
+            number: "0"
+          }
+        ]
+      }
+    ]
+  )
+
+type Mutation {
+  TestService_TestMethod(input: AllWellKnownTypesInput): EmptyObject @grpcMethod(service: "TestService", method: "TestMethod")
+}
+
+"64 bit signed integer" scalar I64
+"64 bit unsigned integer" scalar U64
+
+"An empty object " scalar EmptyObject
+
+"""
+A generic empty message that you can re-use to avoid defining duplicated
+ empty messages in your APIs. A typical example is to use it as the request
+ or the response type of an API method. For instance:
+
+     service Foo {
+       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+     }
+"""
+input google_protobuf_EmptyInput {
+}
+
+"""
+`Any` contains an arbitrary serialized protocol buffer message along with a
+ URL that describes the type of the serialized message.
+
+ Protobuf library provides support to pack/unpack Any values in the form
+ of utility functions or additional generated methods of the Any type.
+
+ Example 1: Pack and unpack a message in C++.
+
+     Foo foo = ...;
+     Any any;
+     any.PackFrom(foo);
+     ...
+     if (any.UnpackTo(&foo)) {
+       ...
+     }
+
+ Example 2: Pack and unpack a message in Java.
+
+     Foo foo = ...;
+     Any any = Any.pack(foo);
+     ...
+     if (any.is(Foo.class)) {
+       foo = any.unpack(Foo.class);
+     }
+     // or ...
+     if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+       foo = any.unpack(Foo.getDefaultInstance());
+     }
+
+  Example 3: Pack and unpack a message in Python.
+
+     foo = Foo(...)
+     any = Any()
+     any.Pack(foo)
+     ...
+     if any.Is(Foo.DESCRIPTOR):
+       any.Unpack(foo)
+       ...
+
+  Example 4: Pack and unpack a message in Go
+
+      foo := &pb.Foo{...}
+      any, err := anypb.New(foo)
+      if err != nil {
+        ...
+      }
+      ...
+      foo := &pb.Foo{}
+      if err := any.UnmarshalTo(foo); err != nil {
+        ...
+      }
+
+ The pack methods provided by protobuf library will by default use
+ 'type.googleapis.com/full.type.name' as the type URL and the unpack
+ methods only use the fully qualified type name after the last '/'
+ in the type URL, for example "foo.bar.com/x/y.z" will yield type
+ name "y.z".
+
+ JSON
+ ====
+ The JSON representation of an `Any` value uses the regular
+ representation of the deserialized, embedded message, with an
+ additional field `@type` which contains the type URL. Example:
+
+     package google.profile;
+     message Person {
+       string first_name = 1;
+       string last_name = 2;
+     }
+
+     {
+       "@type": "type.googleapis.com/google.profile.Person",
+       "firstName": <string>,
+       "lastName": <string>
+     }
+
+ If the embedded message type is well-known and has a custom JSON
+ representation, that representation will be embedded adding a field
+ `value` which holds the custom JSON in addition to the `@type`
+ field. Example (for message [google.protobuf.Duration][]):
+
+     {
+       "@type": "type.googleapis.com/google.protobuf.Duration",
+       "value": "1.212s"
+     }
+"""
+input google_protobuf_AnyInput {
+"""
+A URL/resource name that uniquely identifies the type of the serialized
+ protocol buffer message. This string must contain at least
+ one "/" character. The last segment of the URL's path must represent
+ the fully qualified name of the type (as in
+ `path/google.protobuf.Duration`). The name should be in a canonical form
+ (e.g., leading "." is not accepted).
+
+ In practice, teams usually precompile into the binary all types that they
+ expect it to use in the context of Any. However, for URLs which use the
+ scheme `http`, `https`, or no scheme, one can optionally set up a type
+ server that maps type URLs to message definitions as follows:
+
+ * If no scheme is provided, `https` is assumed.
+ * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+   value in binary format, or produce an error.
+ * Applications are allowed to cache lookup results based on the
+   URL, or have them precompiled into a binary to avoid any
+   lookup. Therefore, binary compatibility needs to be preserved
+   on changes to types. (Use versioned type names to manage
+   breaking changes.)
+
+ Note: this functionality is not currently available in the official
+ protobuf release, and it is not used for type URLs beginning with
+ type.googleapis.com. As of May 2023, there are no widely used type server
+ implementations and no plans to implement one.
+
+ Schemes other than `http`, `https` (or the empty scheme) might be
+ used with implementation specific semantics.
+"""
+  type_url: String
+"""
+Must be a valid serialized protocol buffer of the above specified type.
+"""
+  value: Bytes
+}
+
+"""
+`SourceContext` represents information about the source of a
+ protobuf element, like the file in which it is defined.
+"""
+input google_protobuf_SourceContextInput {
+"""
+The path-qualified name of the .proto file that contained the associated
+ protobuf element.  For example: `"google/protobuf/source_context.proto"`.
+"""
+  file_name: String
+}
+
+"""
+A protocol buffer message type.
+"""
+input google_protobuf_TypeInput {
+"""
+The fully qualified message name.
+"""
+  name: String
+"""
+The list of fields.
+"""
+  fields: [google_protobuf_FieldInput!]
+"""
+The list of types appearing in `oneof` definitions in this type.
+"""
+  oneofs: [String!]
+"""
+The protocol buffer options.
+"""
+  options: [google_protobuf_OptionInput!]
+"""
+The source context.
+"""
+  source_context: google_protobuf_SourceContextInput
+"""
+The source syntax.
+"""
+  syntax: google_protobuf_Syntax
+"""
+The source edition string, only valid when syntax is SYNTAX_EDITIONS.
+"""
+  edition: String
+}
+
+"""
+A single field of a message type.
+"""
+input google_protobuf_FieldInput {
+"""
+The field type.
+"""
+  kind: google_protobuf_Field_Kind
+"""
+The field cardinality.
+"""
+  cardinality: google_protobuf_Field_Cardinality
+"""
+The field number.
+"""
+  number: Int
+"""
+The field name.
+"""
+  name: String
+"""
+The field type URL, without the scheme, for message or enumeration
+ types. Example: `"type.googleapis.com/google.protobuf.Timestamp"`.
+"""
+  type_url: String
+"""
+The index of the field type in `Type.oneofs`, for message or enumeration
+ types. The first type has index 1; zero means the type is not in the list.
+"""
+  oneof_index: Int
+"""
+Whether to use alternative packed wire representation.
+"""
+  packed: Boolean
+"""
+The protocol buffer options.
+"""
+  options: [google_protobuf_OptionInput!]
+"""
+The field JSON name.
+"""
+  json_name: String
+"""
+The string value of the default value of this field. Proto2 syntax only.
+"""
+  default_value: String
+}
+
+"""
+Enum type definition.
+"""
+input google_protobuf_EnumInput {
+"""
+Enum type name.
+"""
+  name: String
+"""
+Enum value definitions.
+"""
+  enumvalue: [google_protobuf_EnumValueInput!]
+"""
+Protocol buffer options.
+"""
+  options: [google_protobuf_OptionInput!]
+"""
+The source context.
+"""
+  source_context: google_protobuf_SourceContextInput
+"""
+The source syntax.
+"""
+  syntax: google_protobuf_Syntax
+"""
+The source edition string, only valid when syntax is SYNTAX_EDITIONS.
+"""
+  edition: String
+}
+
+"""
+Enum value definition.
+"""
+input google_protobuf_EnumValueInput {
+"""
+Enum value name.
+"""
+  name: String
+"""
+Enum value number.
+"""
+  number: Int
+"""
+Protocol buffer options.
+"""
+  options: [google_protobuf_OptionInput!]
+}
+
+"""
+A protocol buffer option, which can be attached to a message, field,
+ enumeration, etc.
+"""
+input google_protobuf_OptionInput {
+"""
+The option's name. For protobuf built-in options (options defined in
+ descriptor.proto), this is the short name. For example, `"map_entry"`.
+ For custom options, it should be the fully-qualified name. For example,
+ `"google.api.http"`.
+"""
+  name: String
+"""
+The option's value packed in an Any message. If the value is a primitive,
+ the corresponding wrapper type defined in google/protobuf/wrappers.proto
+ should be used. If the value is an enum, it should be stored as an int32
+ value using the google.protobuf.Int32Value type.
+"""
+  value: google_protobuf_AnyInput
+}
+
+"""
+Api is a light-weight descriptor for an API Interface.
+
+ Interfaces are also described as "protocol buffer services" in some contexts,
+ such as by the "service" keyword in a .proto file, but they are different
+ from API Services, which represent a concrete implementation of an interface
+ as opposed to simply a description of methods and bindings. They are also
+ sometimes simply referred to as "APIs" in other contexts, such as the name of
+ this message itself. See https://cloud.google.com/apis/design/glossary for
+ detailed terminology.
+"""
+input google_protobuf_ApiInput {
+"""
+The fully qualified name of this interface, including package name
+ followed by the interface's simple name.
+"""
+  name: String
+"""
+The methods of this interface, in unspecified order.
+"""
+  methods: [google_protobuf_MethodInput!]
+"""
+Any metadata attached to the interface.
+"""
+  options: [google_protobuf_OptionInput!]
+"""
+A version string for this interface. If specified, must have the form
+ `major-version.minor-version`, as in `1.10`. If the minor version is
+ omitted, it defaults to zero. If the entire version field is empty, the
+ major version is derived from the package name, as outlined below. If the
+ field is not empty, the version in the package name will be verified to be
+ consistent with what is provided here.
+
+ The versioning schema uses [semantic
+ versioning](http://semver.org) where the major version number
+ indicates a breaking change and the minor version an additive,
+ non-breaking change. Both version numbers are signals to users
+ what to expect from different versions, and should be carefully
+ chosen based on the product plan.
+
+ The major version is also reflected in the package name of the
+ interface, which must end in `v<major-version>`, as in
+ `google.feature.v1`. For major versions 0 and 1, the suffix can
+ be omitted. Zero major versions must only be used for
+ experimental, non-GA interfaces.
+"""
+  version: String
+"""
+Source context for the protocol buffer service represented by this
+ message.
+"""
+  source_context: google_protobuf_SourceContextInput
+"""
+Included interfaces. See [Mixin][].
+"""
+  mixins: [google_protobuf_MixinInput!]
+"""
+The source syntax of the service.
+"""
+  syntax: google_protobuf_Syntax
+}
+
+"""
+Method represents a method of an API interface.
+"""
+input google_protobuf_MethodInput {
+"""
+The simple name of this method.
+"""
+  name: String
+"""
+A URL of the input message type.
+"""
+  request_type_url: String
+"""
+If true, the request is streamed.
+"""
+  request_streaming: Boolean
+"""
+The URL of the output message type.
+"""
+  response_type_url: String
+"""
+If true, the response is streamed.
+"""
+  response_streaming: Boolean
+"""
+Any metadata attached to the method.
+"""
+  options: [google_protobuf_OptionInput!]
+"""
+The source syntax of this method.
+"""
+  syntax: google_protobuf_Syntax
+}
+
+"""
+Declares an API Interface to be included in this interface. The including
+ interface must redeclare all the methods from the included interface, but
+ documentation and options are inherited as follows:
+
+ - If after comment and whitespace stripping, the documentation
+   string of the redeclared method is empty, it will be inherited
+   from the original method.
+
+ - Each annotation belonging to the service config (http,
+   visibility) which is not set in the redeclared method will be
+   inherited.
+
+ - If an http annotation is inherited, the path pattern will be
+   modified as follows. Any version prefix will be replaced by the
+   version of the including interface plus the [root][] path if
+   specified.
+
+ Example of a simple mixin:
+
+     package google.acl.v1;
+     service AccessControl {
+       // Get the underlying ACL object.
+       rpc GetAcl(GetAclRequest) returns (Acl) {
+         option (google.api.http).get = "/v1/{resource=**}:getAcl";
+       }
+     }
+
+     package google.storage.v2;
+     service Storage {
+       rpc GetAcl(GetAclRequest) returns (Acl);
+
+       // Get a data record.
+       rpc GetData(GetDataRequest) returns (Data) {
+         option (google.api.http).get = "/v2/{resource=**}";
+       }
+     }
+
+ Example of a mixin configuration:
+
+     apis:
+     - name: google.storage.v2.Storage
+       mixins:
+       - name: google.acl.v1.AccessControl
+
+ The mixin construct implies that all methods in `AccessControl` are
+ also declared with same name and request/response types in
+ `Storage`. A documentation generator or annotation processor will
+ see the effective `Storage.GetAcl` method after inheriting
+ documentation and annotations as follows:
+
+     service Storage {
+       // Get the underlying ACL object.
+       rpc GetAcl(GetAclRequest) returns (Acl) {
+         option (google.api.http).get = "/v2/{resource=**}:getAcl";
+       }
+       ...
+     }
+
+ Note how the version in the path pattern changed from `v1` to `v2`.
+
+ If the `root` field in the mixin is specified, it should be a
+ relative path under which inherited HTTP paths are placed. Example:
+
+     apis:
+     - name: google.storage.v2.Storage
+       mixins:
+       - name: google.acl.v1.AccessControl
+         root: acls
+
+ This implies the following inherited HTTP annotation:
+
+     service Storage {
+       // Get the underlying ACL object.
+       rpc GetAcl(GetAclRequest) returns (Acl) {
+         option (google.api.http).get = "/v2/acls/{resource=**}:getAcl";
+       }
+       ...
+     }
+"""
+input google_protobuf_MixinInput {
+"""
+The fully qualified name of the interface which is included.
+"""
+  name: String
+"""
+If non-empty specifies a path under which inherited HTTP paths
+ are rooted.
+"""
+  root: String
+}
+
+"""
+`Struct` represents a structured data value, consisting of fields
+ which map to dynamically typed values. In some languages, `Struct`
+ might be supported by a native representation. For example, in
+ scripting languages like JS a struct is represented as an
+ object. The details of that representation are described together
+ with the proto support for the language.
+
+ The JSON representation for `Struct` is JSON object.
+"""
+input google_protobuf_StructInput {
+"""
+Unordered map of dynamically typed values.
+"""
+  fields: [google_protobuf_Struct_FieldsEntryInput!]
+}
+
+input google_protobuf_Struct_FieldsEntryInput {
+"""
+Unordered map of dynamically typed values.
+"""
+  key: String
+  value: google_protobuf_ValueInput
+}
+
+"""
+`Value` represents a dynamically typed value which can be either
+ null, a number, a string, a boolean, a recursive struct value, or a
+ list of values. A producer of value is expected to set one of these
+ variants. Absence of any variant indicates an error.
+
+ The JSON representation for `Value` is JSON value.
+"""
+input google_protobuf_ValueInput {
+"""
+Represents a null value.
+"""
+  null_value: google_protobuf_NullValue
+"""
+Represents a double value.
+"""
+  number_value: Float
+"""
+Represents a string value.
+"""
+  string_value: String
+"""
+Represents a boolean value.
+"""
+  bool_value: Boolean
+"""
+Represents a structured value.
+"""
+  struct_value: google_protobuf_StructInput
+"""
+Represents a repeated `Value`.
+"""
+  list_value: google_protobuf_ListValueInput
+}
+
+"""
+`ListValue` is a wrapper around a repeated field of values.
+
+ The JSON representation for `ListValue` is JSON array.
+"""
+input google_protobuf_ListValueInput {
+"""
+Repeated field of dynamically typed values.
+"""
+  values: [google_protobuf_ValueInput!]
+}
+
+input AllWellKnownTypesInput {
+  any_valueany: google_protobuf_AnyInput
+  api_value: google_protobuf_ApiInput
+  bool_value: Boolean
+  bytes_value: Bytes
+  double_value: Float
+  duration_value: String
+  empty_value: EmptyObject
+  enum_value: google_protobuf_EnumInput
+  enum_value_value: google_protobuf_EnumValueInput
+  field_value: google_protobuf_FieldInput
+  field_mask_value: String
+  float_value: Float
+  int32_value: Int
+  int64_value: I64
+  list_value: google_protobuf_ListValueInput
+  method_value: google_protobuf_MethodInput
+  mixin_value: google_protobuf_MixinInput
+  null_value: google_protobuf_NullValue
+  option_value: google_protobuf_OptionInput
+  source_context_value: google_protobuf_SourceContextInput
+  string_value: String
+  struct_value: google_protobuf_StructInput
+  timestamp_value: String
+  type_value: google_protobuf_TypeInput
+  uint32_value: Int
+  uint64_value: U64
+  value: google_protobuf_ValueInput
+}
+
+"An empty object " scalar EmptyObject
+
+"""
+A generic empty message that you can re-use to avoid defining duplicated
+ empty messages in your APIs. A typical example is to use it as the request
+ or the response type of an API method. For instance:
+
+     service Foo {
+       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+     }
+"""
+type google_protobuf_Empty {
+}
+
+"""
+The syntax in which a protocol buffer element is defined.
+"""
+enum google_protobuf_Syntax {
+"""
+Syntax `proto2`.
+"""
+  SYNTAX_PROTO2,
+"""
+Syntax `proto3`.
+"""
+  SYNTAX_PROTO3,
+"""
+Syntax `editions`.
+"""
+  SYNTAX_EDITIONS,
+}
+
+"""
+Basic field types.
+"""
+enum google_protobuf_Field_Kind {
+"""
+Field type unknown.
+"""
+  TYPE_UNKNOWN,
+"""
+Field type double.
+"""
+  TYPE_DOUBLE,
+"""
+Field type float.
+"""
+  TYPE_FLOAT,
+"""
+Field type int64.
+"""
+  TYPE_INT64,
+"""
+Field type uint64.
+"""
+  TYPE_UINT64,
+"""
+Field type int32.
+"""
+  TYPE_INT32,
+"""
+Field type fixed64.
+"""
+  TYPE_FIXED64,
+"""
+Field type fixed32.
+"""
+  TYPE_FIXED32,
+"""
+Field type bool.
+"""
+  TYPE_BOOL,
+"""
+Field type string.
+"""
+  TYPE_STRING,
+"""
+Field type group. Proto2 syntax only, and deprecated.
+"""
+  TYPE_GROUP,
+"""
+Field type message.
+"""
+  TYPE_MESSAGE,
+"""
+Field type bytes.
+"""
+  TYPE_BYTES,
+"""
+Field type uint32.
+"""
+  TYPE_UINT32,
+"""
+Field type enum.
+"""
+  TYPE_ENUM,
+"""
+Field type sfixed32.
+"""
+  TYPE_SFIXED32,
+"""
+Field type sfixed64.
+"""
+  TYPE_SFIXED64,
+"""
+Field type sint32.
+"""
+  TYPE_SINT32,
+"""
+Field type sint64.
+"""
+  TYPE_SINT64,
+}
+
+"""
+Whether a field is optional, required, or repeated.
+"""
+enum google_protobuf_Field_Cardinality {
+"""
+For fields with unknown cardinality.
+"""
+  CARDINALITY_UNKNOWN,
+"""
+For optional fields.
+"""
+  CARDINALITY_OPTIONAL,
+"""
+For required fields. Proto2 syntax only.
+"""
+  CARDINALITY_REQUIRED,
+"""
+For repeated fields.
+"""
+  CARDINALITY_REPEATED,
+}
+
+"""
+`NullValue` is a singleton enumeration to represent the null value for the
+ `Value` type union.
+
+ The JSON representation for `NullValue` is JSON `null`.
+"""
+enum google_protobuf_NullValue {
+"""
+Null value.
+"""
+  NULL_VALUE,
+}


### PR DESCRIPTION
Not _everything_, but the types we support in the extension so far.

See [the ProtoJSON format docs](https://protobuf.dev/programming-guides/json/) for the canonical mapping to JSON.

Also fix the field types of input types being rendered as output types.

closes GB-8845