### PR TITLE
Release gateway 0.35.0 and CLI 0.91.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.90.0"
+version = "0.91.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -3874,7 +3874,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "ascii",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.90.0"
+version = "0.91.0"
 name = "grafbase"
 description = "The Grafbase command line interface"
 categories = ["command-line-utilities"]

--- a/cli/changelog/0.91.0.md
+++ b/cli/changelog/0.91.0.md
@@ -1,0 +1,3 @@
+## Features
+
+- Compatibility with version 0.14.0 of grafbase-sdk.

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.90.0",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.90.0",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.90.0",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.90.0",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.90.0"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.91.0",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.91.0",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.91.0",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.91.0",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.91.0"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.35.0] - 2025-04-25
+
+[CHANGELOG](changelog/0.35.0.md)
+
 ## [0.30.2] - 2025-03-12
 
 [CHANGELOG](changelog/0.30.2.md)

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.34.0"
+version = "0.35.0"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/changelog/0.35.0.md
+++ b/gateway/changelog/0.35.0.md
@@ -1,3 +1,7 @@
+## Breaking change
+
+- Dropping support for `@authorized`. It is simpler to develop your own directive with extensions, see [Customize your GraphQL Federation authentication and authorization with Grafbase Extensions](https://grafbase.com/blog/custom-authentication-and-authorization-in-graphql-federation)
+
 ## Features
 
 - Compatibility with version 0.14.0 of grafbase-sdk.

--- a/gateway/changelog/0.35.0.md
+++ b/gateway/changelog/0.35.0.md
@@ -1,0 +1,3 @@
+## Features
+
+- Compatibility with version 0.14.0 of grafbase-sdk.


### PR DESCRIPTION
For compatibility with the new 0.14.0 release of grafbase-sdk.