### PR TITLE
ci: fix gateway and cli release pipelines

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -80,7 +80,8 @@ runs:
       run: |
         RUST_BACKTRACE=1 cargo nextest run --workspace --no-run --profile ci \
           --exclude grafbase-gateway \
-          --exclude federation-audit-tests
+          --exclude federation-audit-tests \
+          --exclude protoc-gen-grafbase-subgraph
         docker compose -f crates/integration-tests/compose.yaml stop -t 3
 
     - name: Run all non-gateway tests
@@ -91,7 +92,8 @@ runs:
         docker compose -f crates/integration-tests/compose.yaml up -d
         RUST_BACKTRACE=1 cargo nextest run --workspace --profile ci \
           --exclude grafbase-gateway \
-          --exclude federation-audit-tests
+          --exclude federation-audit-tests \
+          --exclude protoc-gen-grafbase-subgraph
         docker compose -f crates/integration-tests/compose.yaml stop -t 3
 
     - name: Build gateway tests
@@ -124,6 +126,7 @@ runs:
           --exclude grafbase-gateway \
           --exclude wasi-component-loader \
           --exclude federation-audit-tests \
+          --exclude protoc-gen-grafbase-subgraph \
           --profile ci
 
     - name: Run tests without integration
@@ -136,4 +139,5 @@ runs:
           --exclude grafbase-gateway \
           --exclude wasi-component-loader \
           --exclude federation-audit-tests \
+          --exclude protoc-gen-grafbase-subgraph \
           --profile ci


### PR DESCRIPTION
Exclude irrelevant crate that depends on the protoc binary from the tests in the release pipeline.