### PR TITLE
composition: fix handling of extra directives on enums

### DIFF
--- a/crates/graphql-composition/CHANGELOG.md
+++ b/crates/graphql-composition/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Do not warn on `@specifiedBy` directive when it is not imported. It is a GraphQL built-in. (https://github.com/grafbase/grafbase/pull/2673)
+- Fixed directives from extensions on enum definitions sometimes not being rendered in the federated graph. (https://github.com/grafbase/grafbase/pull/3073)
 
 ## 0.6.1 - 2025-02-13
 

--- a/crates/graphql-composition/src/ingest_subgraph.rs
+++ b/crates/graphql-composition/src/ingest_subgraph.rs
@@ -64,6 +64,8 @@ fn ingest_top_level_definitions(ctx: &mut Context<'_>) {
                     .map(|description| ctx.subgraphs.strings.intern(description.to_cow()));
 
                 let directives = ctx.subgraphs.new_directive_site();
+                // Order matters: we ingest enum values in the following block. We have to ingest the enum's directives first, so directives are ingested in order of directive site id.
+                directives::ingest_directives(ctx, directives, type_definition.directives(), |_| type_name.to_owned());
 
                 let definition_id = match type_definition {
                     ast::TypeDefinition::Object(_) if type_name == SERVICE_TYPE_NAME => continue,
@@ -138,8 +140,6 @@ fn ingest_top_level_definitions(ctx: &mut Context<'_>) {
                         definition_id
                     }
                 };
-
-                directives::ingest_directives(ctx, directives, type_definition.directives(), |_| type_name.to_owned());
 
                 directives::ingest_keys(definition_id, type_definition.directives(), ctx);
             }

--- a/crates/graphql-composition/src/lib.rs
+++ b/crates/graphql-composition/src/lib.rs
@@ -100,7 +100,7 @@ mod tests {
     #[test]
     fn grafbase_schema_can_be_composed() {
         use std::{fs, path::Path};
-        let schema_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../cli/src/backend/api/graphql/api.graphql");
+        let schema_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../cli/src/api/graphql/api.graphql");
         let schema = fs::read_to_string(schema_path).unwrap();
 
         let mut subgraphs = Subgraphs::default();

--- a/crates/graphql-composition/src/subgraphs/directives.rs
+++ b/crates/graphql-composition/src/subgraphs/directives.rs
@@ -146,6 +146,10 @@ impl Subgraphs {
     }
 
     pub(crate) fn push_directive(&mut self, directive: ExtraDirectiveRecord) {
+        if let Some(last) = self.directives.extra_directives.last() {
+            assert!(last.directive_site_id <= directive.directive_site_id);
+        }
+
         self.directives.extra_directives.push(directive);
     }
 
@@ -235,7 +239,7 @@ impl<'a> DirectiveSiteWalker<'a> {
     ///                             ^^^^^^^^^^^^^^^^^^^^^^^^^
     /// }
     /// ```
-    pub fn r#override(self) -> Option<&'a OverrideDirective> {
+    pub(crate) fn r#override(self) -> Option<&'a OverrideDirective> {
         self.subgraphs.directives.r#override.get(&self.id)
     }
 

--- a/crates/graphql-composition/tests/composition/extensions_basic/api.graphql.snap
+++ b/crates/graphql-composition/tests/composition/extensions_basic/api.graphql.snap
@@ -9,6 +9,12 @@ enum AppointmentStatus {
   CANCELLED
 }
 
+enum DoctorType {
+  CARDIOLOGIST
+  PEDIATRICIAN
+  SURGEON
+}
+
 type Appointment {
   datetime: String!
   doctor: Doctor!
@@ -36,6 +42,7 @@ type Doctor {
   lastName: String!
   phone: String
   specialty: String!
+  type: DoctorType
 }
 
 type Query {

--- a/crates/graphql-composition/tests/composition/extensions_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/extensions_basic/federated.graphql.snap
@@ -54,6 +54,7 @@ type Doctor
   lastName: String! @join__field(graph: DOCTORS)
   phone: String @extension__directive(graph: DOCTORS, extension: REST_CONNECTOR, name: "call", arguments: {method: GET, url: "https://my-phone_registry/doctors/{id}"}) @join__field(graph: DOCTORS)
   specialty: String! @join__field(graph: DOCTORS)
+  type: DoctorType @join__field(graph: DOCTORS)
 }
 
 type Query
@@ -87,6 +88,15 @@ enum AppointmentStatus
   SCHEDULED
   COMPLETED
   CANCELLED
+}
+
+enum DoctorType
+  @extension__directive(graph: DOCTORS, extension: ORACLE_CONNECTOR, name: "databaseEnum", arguments: {name: "dr_type"})
+  @join__type(graph: DOCTORS)
+{
+  CARDIOLOGIST @extension__directive(graph: DOCTORS, extension: ORACLE_CONNECTOR, name: "databaseEnumValue", arguments: {value: "cardiologist_t"})
+  PEDIATRICIAN @extension__directive(graph: DOCTORS, extension: ORACLE_CONNECTOR, name: "databaseEnumValue", arguments: {value: "pediatrician_t"})
+  SURGEON
 }
 
 enum join__Graph

--- a/crates/graphql-composition/tests/composition/extensions_basic/subgraphs/doctors.graphql
+++ b/crates/graphql-composition/tests/composition/extensions_basic/subgraphs/doctors.graphql
@@ -26,6 +26,7 @@ type Doctor @key(fields: "id") {
   specialty: String!
   email: String!
   phone: String @rest__call(method: GET, url: "https://my-phone_registry/doctors/{id}")
+  type: DoctorType
 }
 
 input DoctorInput {
@@ -38,4 +39,10 @@ input DoctorInput {
 
 type Appointment @key(fields: "id") {
   id: ID!
+}
+
+enum DoctorType @oracle__databaseEnum(name: "dr_type") {
+  CARDIOLOGIST @oracle__databaseEnumValue(value: "cardiologist_t")
+  PEDIATRICIAN @oracle__databaseEnumValue(value: "pediatrician_t")
+  SURGEON
 }


### PR DESCRIPTION
Directives from extensions on enum definitions would sometimes fail to appear in the federated SDL.

Extra directives are sorted by directive site id. For every top level type definition, we ingest the type and its directives in a first pass, then the fields / union members in a second pass. Enums are the exception: we ingest the enum values right away. That lead the enum value's directives to come before the enum's directives although their directive side ids are greater. A binary search would then fail to find the enum's directives.

The fix is to ingest directives right after we generate the directive site id.

closes GB-8935