### PR TITLE
cli: fix infinite loop in `grafbase dev`

### DIFF
--- a/cli/changelog/unreleased.md
+++ b/cli/changelog/unreleased.md
@@ -1,0 +1,3 @@
+## Fixes
+
+- Fixed infinite loops in file watcher causing `grafbase dev` to become unresponsive


### PR DESCRIPTION
Sometimes, the command becomes unresponsive. That happens because of the file watcher receiving too many events, causing the gateway embedded in grafbase dev to restart over and over again.

The reason for the flood of events is that the watcher doesn't only watch for created, modified or deleted file events, but also any file access. Other processes and other watchers can cause these events.

I confirmed that the reload behaviour is more reasonable now with manual testing.

closes GB-8626
closes GB-8625