### PR TITLE
gateway: accept the `extension` argument to `@join__type`

### DIFF
--- a/crates/engine/schema/src/builder/sdl/directives.rs
+++ b/crates/engine/schema/src/builder/sdl/directives.rs
@@ -69,6 +69,9 @@ pub(crate) fn as_join_type<'a>(dir: &ast::Directive<'a>) -> Option<Result<(JoinT
 pub(crate) struct JoinTypeDirective<'a> {
     pub graph: GraphName<'a>,
     pub key: Option<&'a str>,
+    #[expect(unused)]
+    #[deser(default = false)]
+    pub extension: bool,
     #[deser(default = true)]
     pub resolvable: bool,
     #[deser(default = false, rename = "isInterfaceObject")]

--- a/crates/graphql-composition/CHANGELOG.md
+++ b/crates/graphql-composition/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Corrected the definition of `@join__type` in federated SDL to include the `isInterfaceObject` and `extension` arguments, as per the spec.
+
 ## 0.7.0 - 2025-04-25
 
 ### Changes

--- a/crates/graphql-composition/src/emit_federated_graph/federation_builtins.rs
+++ b/crates/graphql-composition/src/emit_federated_graph/federation_builtins.rs
@@ -7,6 +7,8 @@ pub(super) fn emit_federation_builtins(ctx: &mut Context<'_>, join_graph_enum_id
     let graph_str = ctx.insert_str("graph");
     let name_str = ctx.insert_str("name");
     let url_str = ctx.insert_str("url");
+    let is_interface_object_str = ctx.insert_str("isInterfaceObject");
+    let extension_str = ctx.insert_str("extension");
     let join_namespace = Some(ctx.insert_str("join"));
 
     // join__FieldSet
@@ -258,11 +260,15 @@ pub(super) fn emit_federation_builtins(ctx: &mut Context<'_>, join_graph_enum_id
             .push_directive_definition_argument(directive_definition_id, argument);
     }
 
+    // https://specs.apollo.dev/join/v0.3/#@type
+    //
     // directive @join__type(
-    //     graph: join__Graph
-    //     key: join__FieldSet
-    //     resolvable: Boolean = true
-    // ) on OBJECT | INTERFACE
+    //   graph: join__Graph!,
+    //   key: join__FieldSet,
+    //   extension: Boolean! = false,
+    //   resolvable: Boolean! = true,
+    //   isInterfaceObject: Boolean! = false
+    // ) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
     {
         let name = ctx.insert_str("type");
         let key_str = ctx.insert_str("key");
@@ -306,6 +312,20 @@ pub(super) fn emit_federation_builtins(ctx: &mut Context<'_>, join_graph_enum_id
         ctx.out.push_directive_definition_argument(
             directive_definition_id,
             federated::InputValueDefinition {
+                name: extension_str,
+                r#type: federated::Type {
+                    wrapping: Wrapping::new(false),
+                    definition: boolean_definition,
+                },
+                directives: Vec::new(),
+                description: None,
+                default: Some(federated::Value::Boolean(false)),
+            },
+        );
+
+        ctx.out.push_directive_definition_argument(
+            directive_definition_id,
+            federated::InputValueDefinition {
                 name: resolvable_str,
                 r#type: federated::Type {
                     wrapping: Wrapping::new(false),
@@ -314,6 +334,20 @@ pub(super) fn emit_federation_builtins(ctx: &mut Context<'_>, join_graph_enum_id
                 directives: Vec::new(),
                 description: None,
                 default: Some(federated::Value::Boolean(true)),
+            },
+        );
+
+        ctx.out.push_directive_definition_argument(
+            directive_definition_id,
+            federated::InputValueDefinition {
+                name: is_interface_object_str,
+                r#type: federated::Type {
+                    wrapping: Wrapping::new(false),
+                    definition: boolean_definition,
+                },
+                directives: Vec::new(),
+                description: None,
+                default: Some(federated::Value::Boolean(false)),
             },
         );
     }

--- a/crates/graphql-composition/tests/composition/authenticated_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/authenticated_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/authorized_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/authorized_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/authorized_with_composeDirective/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/authorized_with_composeDirective/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/composed_directives_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/composed_directives_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/composite_schema/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/composite_schema/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/cost_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/cost_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/custom_query_root/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/custom_query_root/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/custom_query_root_as_non_root_in_other_subgraph/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/custom_query_root_as_non_root_in_other_subgraph/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/custom_scalars_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/custom_scalars_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/default_values/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/default_values/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/descriptions_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/descriptions_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/disjoint_keys/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/disjoint_keys/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/entity_composite_key_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_composite_key_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/entity_composite_key_nested/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_composite_key_nested/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/entity_interface_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_interface_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/entity_interfaces_multi_subgraph/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_interfaces_multi_subgraph/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/entity_interfaces_with_requires/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_interfaces_with_requires/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/entity_multiple_keys_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_multiple_keys_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/entity_staggered_composite_key/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_staggered_composite_key/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/entity_unresolvable_keys/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_unresolvable_keys/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/enum_only_inputs/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/enum_only_inputs/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/enum_only_outputs/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/enum_only_outputs/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/enum_unused/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/enum_unused/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/extensions_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/extensions_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/extensions_directives_on_schema_definition/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/extensions_directives_on_schema_definition/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/field_type_composition/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/field_type_composition/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/inaccessible_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/inaccessible_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/inaccessible_in_one_subgraph_is_enough/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/inaccessible_in_one_subgraph_is_enough/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/input_object_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/input_object_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/interface_implementing_interface_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/interface_implementing_interface_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/interfaces_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/interfaces_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/interfaces_single_subgraph/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/interfaces_single_subgraph/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/kebab_case_subgraph_names/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/kebab_case_subgraph_names/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/link_import_as_valid/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/link_import_as_valid/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/list_size/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/list_size/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/namespaced_directive_without_import_are_ignored/subgraphs/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/namespaced_directive_without_import_are_ignored/subgraphs/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/namespaced_directives_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/namespaced_directives_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/object_field_arguments_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/object_field_arguments_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/objects_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/objects_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/override_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/override_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/override_label/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/override_label/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/policy_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/policy_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/provides_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/provides_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/requiresScopes_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/requiresScopes_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/requires_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/requires_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/requires_with_arguments/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/requires_with_arguments/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/requires_with_nested_inline_fragment/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/requires_with_nested_inline_fragment/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/shareable_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/shareable_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/shareable_is_repeatable/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/shareable_is_repeatable/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/subgraph_query_fields_service_entities/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/subgraph_query_fields_service_entities/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/subscriptions_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/subscriptions_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/tag_directive_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/tag_directive_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/unions_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/unions_basic/federated.graphql.snap
@@ -11,7 +11,7 @@ directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
 directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, resolvable: Boolean = true) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/gateway/changelog/unreleased.md
+++ b/gateway/changelog/unreleased.md
@@ -1,0 +1,3 @@
+## Fixes
+
+- The gateway now accepts the `extension` directive on the `@join__type` federated directive. It is valid but previously caused a validation error on startup.


### PR DESCRIPTION
In addition, fix the definition in graphql-composition to include the missing `isInterfaceObject` and `extension` arguments.

closes GB-8943
closes https://github.com/grafbase/grafbase/issues/3079