### PR TITLE
graphql-composition: limited native composite schemas spec support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4256,6 +4256,7 @@ name = "graphql-composition"
 version = "0.7.0"
 dependencies = [
  "anyhow",
+ "bitflags 2.9.0",
  "cynic-parser",
  "cynic-parser-deser",
  "fixedbitset",

--- a/crates/graphql-composition/Cargo.toml
+++ b/crates/graphql-composition/Cargo.toml
@@ -15,6 +15,7 @@ grafbase-extensions = []
 workspace = true
 
 [dependencies]
+bitflags.workspace = true
 cynic-parser = { workspace = true, features = ["report"] }
 cynic-parser-deser.workspace = true
 fixedbitset.workspace = true

--- a/crates/graphql-composition/src/compose/directives.rs
+++ b/crates/graphql-composition/src/compose/directives.rs
@@ -62,6 +62,10 @@ pub(super) fn collect_composed_directives<'a>(
         cost = cost.or(site.cost());
         list_size = list_size.or(site.list_size());
 
+        for directive in site.iter_ir_directives() {
+            extra_directives.push(directive.clone());
+        }
+
         for directive in site.iter_extra_directives() {
             let provenance = match directive.provenance {
                 subgraphs::DirectiveProvenance::ComposedDirective => Some(ir::DirectiveProvenance::ComposeDirective),

--- a/crates/graphql-composition/src/composition_ir/directive.rs
+++ b/crates/graphql-composition/src/composition_ir/directive.rs
@@ -10,6 +10,13 @@ pub enum Directive {
     Inaccessible,
     Policy(Vec<Vec<federated::StringId>>),
     RequiresScopes(Vec<Vec<federated::StringId>>),
+    /// @composite__require
+    CompositeRequire {
+        subgraph_id: federated::SubgraphId,
+        field: subgraphs::StringId,
+    },
+    /// @composite__lookup
+    CompositeLookup(federated::SubgraphId),
     Cost {
         weight: i32,
     },

--- a/crates/graphql-composition/src/emit_federated_graph.rs
+++ b/crates/graphql-composition/src/emit_federated_graph.rs
@@ -10,6 +10,7 @@ mod field_types_map;
 use self::{
     context::Context,
     directive::{
+        emit_composite_spec_directive_definitions, emit_cost_directive_definition, emit_list_size_directive_definition,
         transform_arbitray_type_directives, transform_enum_value_directives, transform_field_directives,
         transform_input_value_directives, transform_type_directives,
     },
@@ -21,7 +22,6 @@ use crate::{
     composition_ir::{CompositionIr, FieldIr, InputValueDefinitionIr},
     subgraphs,
 };
-use directive::{emit_cost_directive_definition, emit_list_size_directive_definition};
 use graphql_federated_graph::{self as federated};
 use itertools::Itertools;
 use std::collections::BTreeSet;
@@ -135,6 +135,7 @@ fn emit_directives_and_implements_interface(ctx: &mut Context<'_>, mut ir: Compo
 
     emit_cost_directive_definition(ctx);
     emit_list_size_directive_definition(ctx);
+    emit_composite_spec_directive_definitions(ctx);
     emit_interface_after_directives(ctx);
 }
 

--- a/crates/graphql-composition/src/emit_federated_graph/context.rs
+++ b/crates/graphql-composition/src/emit_federated_graph/context.rs
@@ -1,3 +1,7 @@
+mod used_directives;
+
+pub(super) use self::used_directives::UsedDirectives;
+
 use super::field_types_map::FieldTypesMap;
 use crate::{composition_ir as ir, subgraphs};
 use graphql_federated_graph as federated;
@@ -10,8 +14,7 @@ pub(super) struct Context<'a> {
     pub(super) selection_map: HashMap<(federated::Definition, federated::StringId), federated::FieldId>,
     pub(super) definitions: HashMap<federated::StringId, federated::Definition>,
 
-    pub(super) uses_cost_directive: bool,
-    pub(super) uses_list_size_directive: bool,
+    pub(super) used_directives: UsedDirectives,
 
     used_extensions: fixedbitset::FixedBitSet,
     strings_ir: ir::StringsIr,
@@ -31,8 +34,7 @@ impl<'a> Context<'a> {
             selection_map: HashMap::with_capacity(ir.fields.len()),
             field_types_map: FieldTypesMap::default(),
             used_extensions: ir.used_extensions.clone(),
-            uses_cost_directive: false,
-            uses_list_size_directive: false,
+            used_directives: UsedDirectives::empty(),
         }
     }
 

--- a/crates/graphql-composition/src/emit_federated_graph/context/used_directives.rs
+++ b/crates/graphql-composition/src/emit_federated_graph/context/used_directives.rs
@@ -1,0 +1,10 @@
+use bitflags::bitflags;
+
+bitflags! {
+    pub(crate) struct UsedDirectives: u8 {
+        const COST = 1;
+        const LIST_SIZE = 1 << 1;
+        const COMPOSITE_LOOKUP = 1 << 2;
+        const COMPOSITE_REQUIRE = 1 << 3;
+    }
+}

--- a/crates/graphql-composition/src/ingest_subgraph/directives/consts.rs
+++ b/crates/graphql-composition/src/ingest_subgraph/directives/consts.rs
@@ -1,17 +1,21 @@
 pub(super) const AUTHENTICATED: &str = "authenticated";
 pub(super) const AUTHORIZED: &str = "authorized";
 pub(super) const COMPOSE_DIRECTIVE: &str = "composeDirective";
+pub(super) const COST: &str = "cost";
 pub(super) const EXTERNAL: &str = "external";
 pub(super) const INACCESSIBLE: &str = "inaccessible";
 pub(super) const INTERFACE_OBJECT: &str = "interfaceObject";
 pub(super) const KEY: &str = "key";
 pub(super) const LINK: &str = "link";
+pub(super) const LIST_SIZE: &str = "listSize";
+pub(super) const LOOKUP: &str = "lookup";
 pub(super) const OVERRIDE: &str = "override";
 pub(super) const POLICY: &str = "policy";
 pub(super) const PROVIDES: &str = "provides";
+/// The composite schema spec `@require`.
+pub(super) const REQUIRE: &str = "require";
+/// The federation spec `@requires`.
 pub(super) const REQUIRES: &str = "requires";
 pub(super) const REQUIRES_SCOPES: &str = "requiresScopes";
 pub(super) const SHAREABLE: &str = "shareable";
 pub(super) const TAG: &str = "tag";
-pub(super) const COST: &str = "cost";
-pub(super) const LIST_SIZE: &str = "listSize";

--- a/crates/graphql-composition/src/subgraphs.rs
+++ b/crates/graphql-composition/src/subgraphs.rs
@@ -65,12 +65,6 @@ impl Default for Subgraphs {
             strings.intern(scalar);
         });
 
-        let composite_schema_extension = ExtensionRecord {
-            url: strings.intern("https://specs.grafbase.com/composite-schema/v1"),
-            // Marketplace extensions cannot start with `-` or `_`.
-            name: strings.intern("_composite_schema"),
-        };
-
         Self {
             strings,
             subgraphs: Default::default(),
@@ -84,7 +78,7 @@ impl Default for Subgraphs {
             ingestion_diagnostics: Default::default(),
             definition_names: Default::default(),
             linked_schemas: Default::default(),
-            extensions: vec![composite_schema_extension],
+            extensions: Vec::new(),
         }
     }
 }

--- a/crates/graphql-composition/src/subgraphs/linked_schemas.rs
+++ b/crates/graphql-composition/src/subgraphs/linked_schemas.rs
@@ -35,6 +35,11 @@ impl LinkedSchemaRecord {
         let url = subgraphs.strings.resolve(self.url);
         url.contains("dev/federation/v2")
     }
+
+    pub(crate) fn is_composite_schemas(&self, subgraphs: &Subgraphs) -> bool {
+        let url = subgraphs.strings.resolve(self.url);
+        url == "https://specs.grafbase.com/composite-schema/v1"
+    }
 }
 
 /// A definition from a schema imported with `@link`.

--- a/crates/graphql-composition/tests/composition/composite_schema/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/composite_schema/federated.graphql.snap
@@ -15,37 +15,36 @@ directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolea
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 
+directive @composite__lookup on FIELD_DEFINITION
+
+directive @composite__require(field: composite__FieldSelectionMap!) on ARGUMENT_DEFINITION
+
 scalar join__FieldSet
 
+scalar composite__FieldSelectionMap
+
 type User
-  @extension__directive(graph: A, extension: _COMPOSITE_SCHEMA, name: "key", arguments: {fields: "id"})
-  @join__type(graph: A)
+  @join__type(graph: A, key: "id", resolvable: false)
 {
   id: ID!
   name: String
 }
 
 type Account
-  @extension__directive(graph: B, extension: _COMPOSITE_SCHEMA, name: "key", arguments: {fields: "id"})
-  @join__type(graph: B)
+  @join__type(graph: B, key: "id", resolvable: false)
 {
   id: ID!
-  name: String
+  name: String @composite__require(graph: B, field: "ploop")
 }
 
 type Query
 {
-  accountById(id: ID!): Account @extension__directive(graph: B, extension: _COMPOSITE_SCHEMA, name: "lookup", arguments: {}) @join__field(graph: B)
-  userById(id: ID!): User @extension__directive(graph: A, extension: _COMPOSITE_SCHEMA, name: "lookup", arguments: {}) @join__field(graph: A)
+  accountById(id: ID!): Account @composite__lookup(graph: B) @join__field(graph: B)
+  userById(id: ID!): User @composite__lookup(graph: A) @join__field(graph: A)
 }
 
 enum join__Graph
 {
   A @join__graph(name: "a", url: "http://example.com/a")
   B @join__graph(name: "b", url: "http://example.com/b")
-}
-
-enum extension__Link
-{
-  _COMPOSITE_SCHEMA @extension__link(url: "https://specs.grafbase.com/composite-schema/v1")
 }

--- a/crates/graphql-composition/tests/composition/composite_schema/subgraphs/b.graphql
+++ b/crates/graphql-composition/tests/composition/composite_schema/subgraphs/b.graphql
@@ -1,4 +1,4 @@
-extend schema @link(url: "https://specs.grafbase.com/composite-schema/v1", import: ["@lookup", "@key"])
+extend schema @link(url: "https://specs.grafbase.com/composite-schema/v1", import: ["@lookup", "@key", "@require"])
 
 type Query {
   accountById(id: ID!): Account @lookup
@@ -6,5 +6,5 @@ type Query {
 
 type Account @key(fields: "id") {
   id: ID!
-  name: String
+  name: String @require(field: "ploop")
 }

--- a/crates/graphql-federated-graph/src/directives/mod.rs
+++ b/crates/graphql-federated-graph/src/directives/mod.rs
@@ -3,12 +3,14 @@ mod complexity_control;
 mod deprecated;
 mod extension;
 mod federation;
+mod require;
 
-use crate::{ListSize, StringId, Value};
+use crate::{ListSize, StringId, SubgraphId, Value};
 
 pub use self::{
     complexity_control::{CostDirective, ListSizeDirective},
     deprecated::DeprecatedDirective,
+    require::RequireDirective,
 };
 pub use authorized::*;
 pub use extension::*;
@@ -17,6 +19,13 @@ pub use federation::*;
 #[derive(PartialEq, PartialOrd, Clone, Debug)]
 pub enum Directive {
     Authenticated,
+    CompositeLookup {
+        graph: SubgraphId,
+    },
+    CompositeRequire {
+        graph: SubgraphId,
+        field: StringId,
+    },
     Deprecated {
         reason: Option<StringId>,
     },

--- a/crates/graphql-federated-graph/src/directives/require.rs
+++ b/crates/graphql-federated-graph/src/directives/require.rs
@@ -1,0 +1,57 @@
+use cynic_parser_deser::{ConstDeserializer as _, ValueDeserialize};
+
+/// The composite spec `@require` directive, but in the context of a federated schema. Not to be confused with the federation `@requires` directive.
+///
+/// Reference: https://github.com/graphql/composite-schemas-spec/blob/main/spec/Section%202%20--%20Source%20Schema.md#require
+pub struct RequireDirective<'a> {
+    pub field: &'a str,
+}
+
+impl<'a> ValueDeserialize<'a> for RequireDirective<'a> {
+    fn deserialize(input: cynic_parser_deser::DeserValue<'a>) -> Result<Self, cynic_parser_deser::Error> {
+        let cynic_parser_deser::DeserValue::Object(obj) = input else {
+            return Err(cynic_parser_deser::Error::unexpected_type(
+                cynic_parser_deser::value::ValueType::Object,
+                input,
+            ));
+        };
+
+        let mut field_field = None;
+
+        for field in obj.fields() {
+            match field.name() {
+                "field" => field_field = Some(field.value().deserialize()?),
+                other => {
+                    return Err(cynic_parser_deser::Error::UnknownField {
+                        name: other.to_string(),
+                        field_type: field.value().into(),
+                        field_span: field.name_span(),
+                    });
+                }
+            }
+        }
+
+        let Some(field) = field_field else {
+            return Err(cynic_parser_deser::Error::MissingField {
+                name: "field".to_owned(),
+                object_span: obj.span(),
+            });
+        };
+
+        Ok(RequireDirective { field })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::directives::{directive_test_document, parse_from_test_document};
+
+    #[test]
+    fn test_require_directive() {
+        let doc = directive_test_document("@require(field: \"someField\")");
+        let value = parse_from_test_document::<RequireDirective<'_>>(&doc).unwrap();
+
+        assert_eq!(value.field, "someField");
+    }
+}

--- a/crates/graphql-federated-graph/src/render_sdl/directive.rs
+++ b/crates/graphql-federated-graph/src/render_sdl/directive.rs
@@ -22,6 +22,18 @@ pub(crate) fn write_directive<'a, 'b: 'a>(
         Directive::Inaccessible => {
             DirectiveWriter::new("inaccessible", f, graph)?;
         }
+        Directive::CompositeLookup { graph: subgraph_id } => {
+            DirectiveWriter::new("composite__lookup", f, graph)?
+                .arg("graph", Value::EnumValue(graph.at(*subgraph_id).join_graph_enum_value))?;
+        }
+        Directive::CompositeRequire {
+            graph: subgraph_id,
+            field,
+        } => {
+            DirectiveWriter::new("composite__require", f, graph)?
+                .arg("graph", Value::EnumValue(graph.at(*subgraph_id).join_graph_enum_value))?
+                .arg("field", Value::String(*field))?;
+        }
         Directive::Deprecated { reason } => {
             let directive = DirectiveWriter::new("deprecated", f, graph)?;
 

--- a/crates/graphql-federated-graph/src/render_sdl/render_api_sdl.rs
+++ b/crates/graphql-federated-graph/src/render_sdl/render_api_sdl.rs
@@ -253,6 +253,8 @@ fn public_directives_filter(directive: &Directive, graph: &FederatedGraph) -> bo
         | Directive::Authorized(_)
         | Directive::ListSize(_)
         | Directive::JoinGraph(_)
+        | Directive::CompositeLookup { .. }
+        | Directive::CompositeRequire { .. }
         | Directive::ExtensionDirective { .. } => false,
 
         Directive::Other { name, .. } if graph[*name] == "tag" => false,


### PR DESCRIPTION
Before this PR, we supported integrating [composite schemas spec](https://github.com/graphql/composite-schemas-spec/) directives in the federated SDL as a special case of Grafbase extensions by linking "https://specs.grafbase.com/composite-schema/v1".

This worked as a first shallow integration, but we now need to consider `@key`s and `@lookup` directives from the composite schemas spec as defining entities, just like directives from the federation spec.

This PR bakes the composite spec into graphql-composition's understanding of entitiess for validation and federated graph purposes, and emits `@composite__lookup()` and `@composite__require` directives in the federated graph where appropriate.

closes GB-8947