### PR TITLE
graphql-composition: release 0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4253,7 +4253,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-composition"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "bitflags 2.9.0",

--- a/crates/graphql-composition/Cargo.toml
+++ b/crates/graphql-composition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graphql-composition"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 license = "MPL-2.0"
 description = "An implementation of GraphQL federated schema composition"


### PR DESCRIPTION
Fixes

- Corrected a bug that made directive imports with `@link(imports:)` sometimes exceed the scope of their subgraph.

Changelog is already up to date.