### PR TITLE
composition: no auto-importing federation directives in virtual subgraphs

### DIFF
--- a/crates/graphql-composition/src/ingest_subgraph/directives/match_name.rs
+++ b/crates/graphql-composition/src/ingest_subgraph/directives/match_name.rs
@@ -95,8 +95,10 @@ fn match_directive_name_inner(
     }
 
     let federation_schema_has_been_linked = ctx.subgraphs.subgraph_links_federation_v2(ctx.subgraph_id);
+    let is_virtual_subgraph = ctx.subgraphs.at(ctx.subgraph_id).is_virtual();
 
-    if !federation_schema_has_been_linked {
+    // We auto-import federation directives only in cases where the federation spec hasn't been `@link`ed, to match federation v1 behaviour, or when the subgraph is virtual, because there is no legacy use case there, these are a new Grafbase feature.
+    if !federation_schema_has_been_linked && !is_virtual_subgraph {
         return match_federation_directive_by_original_name(directive_name);
     }
 

--- a/crates/graphql-composition/src/subgraphs/definitions.rs
+++ b/crates/graphql-composition/src/subgraphs/definitions.rs
@@ -48,7 +48,7 @@ impl Subgraphs {
         name: StringId,
     ) -> impl Iterator<Item = (SubgraphId, DefinitionId)> + '_ {
         self.definition_names
-            .range((name, SubgraphId::MIN)..(name, SubgraphId::MAX))
+            .range((name, SubgraphId::from(usize::MIN))..(name, SubgraphId::from(usize::MAX)))
             .map(|((_, subgraph_id), definition_id)| (*subgraph_id, *definition_id))
     }
 

--- a/crates/graphql-composition/src/subgraphs/ids.rs
+++ b/crates/graphql-composition/src/subgraphs/ids.rs
@@ -34,4 +34,5 @@ make_ids! {
     extensions[ExtensionId] -> ExtensionRecord,
     linked_schemas,definitions[LinkedDefinitionId] -> LinkedDefinitionRecord,
     linked_schemas,schemas[LinkedSchemaId] -> LinkedSchemaRecord,
+    subgraphs[SubgraphId] -> Subgraph,
 }

--- a/crates/graphql-composition/src/subgraphs/top.rs
+++ b/crates/graphql-composition/src/subgraphs/top.rs
@@ -1,8 +1,8 @@
 use super::*;
 
 impl Subgraphs {
-    pub(super) fn is_root_type(&self, SubgraphId(subgraph_idx): SubgraphId, definition: DefinitionId) -> bool {
-        let subgraph = &self.subgraphs[subgraph_idx];
+    pub(super) fn is_root_type(&self, subgraph_id: SubgraphId, definition: DefinitionId) -> bool {
+        let subgraph = &self.subgraphs[usize::from(subgraph_id)];
         subgraph.query_type == Some(definition)
             || subgraph.mutation_type == Some(definition)
             || subgraph.subscription_type == Some(definition)
@@ -10,7 +10,7 @@ impl Subgraphs {
 
     pub(crate) fn iter_subgraphs(&self) -> impl ExactSizeIterator<Item = SubgraphWalker<'_>> {
         self.subgraphs.iter().enumerate().map(|(idx, subgraph)| SubgraphWalker {
-            id: (SubgraphId(idx), subgraph),
+            id: (SubgraphId::from(idx), subgraph),
             subgraphs: self,
         })
     }
@@ -27,24 +27,24 @@ impl Subgraphs {
             subscription_type: None,
         };
 
-        SubgraphId(self.subgraphs.push_return_idx(subgraph))
+        SubgraphId::from(self.subgraphs.push_return_idx(subgraph))
     }
 
     pub(crate) fn set_query_type(&mut self, subgraph: SubgraphId, query_type: DefinitionId) {
-        self.subgraphs[subgraph.0].query_type = Some(query_type);
+        self.subgraphs[usize::from(subgraph)].query_type = Some(query_type);
     }
 
     pub(crate) fn set_mutation_type(&mut self, subgraph: SubgraphId, mutation_type: DefinitionId) {
-        self.subgraphs[subgraph.0].mutation_type = Some(mutation_type);
+        self.subgraphs[usize::from(subgraph)].mutation_type = Some(mutation_type);
     }
 
     pub(crate) fn set_subscription_type(&mut self, subgraph: SubgraphId, subscription_type: DefinitionId) {
-        self.subgraphs[subgraph.0].subscription_type = Some(subscription_type);
+        self.subgraphs[usize::from(subgraph)].subscription_type = Some(subscription_type);
     }
 
     pub(crate) fn walk_subgraph(&self, subgraph_id: SubgraphId) -> SubgraphWalker<'_> {
         SubgraphWalker {
-            id: (subgraph_id, &self.subgraphs[subgraph_id.0]),
+            id: (subgraph_id, &self.subgraphs[usize::from(subgraph_id)]),
             subgraphs: self,
         }
     }
@@ -61,15 +61,15 @@ pub(crate) struct Subgraph {
     subscription_type: Option<DefinitionId>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct SubgraphId(usize);
+impl Subgraph {
+    pub(crate) fn is_virtual(&self) -> bool {
+        self.url.is_none()
+    }
+}
 
 impl SubgraphId {
-    pub(crate) const MIN: SubgraphId = SubgraphId(usize::MIN);
-    pub(crate) const MAX: SubgraphId = SubgraphId(usize::MAX);
-
     pub(crate) fn idx(self) -> usize {
-        self.0
+        self.into()
     }
 }
 

--- a/crates/integration-tests/tests/gateway/extensions/selection_set_resolver/subgraph_schema.rs
+++ b/crates/integration-tests/tests/gateway/extensions/selection_set_resolver/subgraph_schema.rs
@@ -7,7 +7,9 @@ fn receive_subgraph_schema() {
             .with_subgraph_sdl(
                 "echo-schema",
                 r#"
-                extend schema @link(url: "selection-set-resolver-014-1.0.0", import: ["@init", "@meta"]) @init @meta(data: "Schema")
+                extend schema
+                    @link(url: "selection-set-resolver-014-1.0.0", import: ["@init", "@meta"]) @init @meta(data: "Schema")
+                    @link(url: "https://specs.grafbase.com/composite-schema/v1", import: ["@key"])
 
                 # Scalar types
                 scalar JSON
@@ -145,17 +147,17 @@ fn receive_subgraph_schema() {
                 "other",
                 r#"
                 extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
- 
+
                 type Query {
                     metrics: Metrics!
                 }
- 
+
                 type Metrics {
                     visitors: Int!
                     pageViews: Int!
                     conversionRate: Float!
                 }
- 
+
                 extend type Product @key(fields: "id") {
                     id: ID! @external
                     reviews: [Review!]


### PR DESCRIPTION
That behaviour is for backwards compatibility. Virtual subgraphs are new, let's start clean there.