### PR TITLE
Release grafbase 0.93.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.92.0"
+version = "0.93.0"
 dependencies = [
  "anyhow",
  "askama",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.93.0] - 2025-04-28
+
+[CHANGELOG](changelog/0.93.0.md)
+
 ## [0.88.0] - 2025-03-19
 
 [CHANGELOG](changelog/0.88.0.md)

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.92.0"
+version = "0.93.0"
 name = "grafbase"
 description = "The Grafbase command line interface"
 categories = ["command-line-utilities"]

--- a/cli/changelog/0.93.0.md
+++ b/cli/changelog/0.93.0.md
@@ -1,6 +1,8 @@
 ## Features
 
+- This release introduces the new revamped web UI exposed by `grafbase dev`. In addition to the GraphQL explorer, it now includes the schema explorer and the AI chat features.
 - Introducing a new `grafbase compose` command to compose a federated graph from subgraph schemas. The input subgraphs are discovered in the same way as in `grafbase dev`, that is to say through the `subgraphs.$subgraph_name.schema_path` and `subgraph.$subgraph_name.introspection_url` configuration options, as well as the `--graph-ref` argument.
+- Support Postgres extensions in `grafbase dev`
 
 ## Fixes
 

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.92.0",
+  "version": "0.93.0",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.92.0",
+  "version": "0.93.0",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.92.0",
+  "version": "0.93.0",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.92.0",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.92.0",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.92.0",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.92.0",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.92.0"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.93.0",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.93.0",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.93.0",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.93.0",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.93.0"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.92.0",
+  "version": "0.93.0",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.92.0",
+  "version": "0.93.0",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.92.0",
+  "version": "0.93.0",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
## Features

- This release introduces the new revamped web UI exposed by `grafbase dev`. In addition to the GraphQL explorer, it now includes the schema explorer and the AI chat features.
- Introducing a new `grafbase compose` command to compose a federated graph from subgraph schemas. The input subgraphs are discovered in the same way as in `grafbase dev`, that is to say through the `subgraphs.$subgraph_name.schema_path` and `subgraph.$subgraph_name.introspection_url` configuration options, as well as the `--graph-ref` argument.
- Support Postgres extensions in `grafbase dev`

## Fixes

- Fixed infinite loops in file watcher causing `grafbase dev` to become unresponsive
- Fixed schemas from locally running subgraphs not being updated anymore after the first hot reload in `grafbase dev` (https://github.com/grafbase/grafbase/pull/3081).
- Various federated GraphQL composition fixes and improvements