### PR TITLE
remove duplicated USER in Dockerfile

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -63,4 +63,3 @@ ENTRYPOINT ["/bin/grafbase-gateway"]
 CMD ["--config", "/etc/grafbase.toml", "--listen-address", "0.0.0.0:5000"]
 
 EXPOSE 5000
-USER 1000


### PR DESCRIPTION
remove duplicated USER in Dockerfile: user is already set to `USER grafbase`