### PR TITLE
fix(engine): Fix incorrect interprestation of resolvable: false in join__type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2915,6 +2915,7 @@ dependencies = [
  "engine-operation",
  "engine-schema",
  "engine-walker",
+ "extension-catalog",
  "fixedbitset",
  "fxhash",
  "grafbase-workspace-hack",
@@ -2924,12 +2925,15 @@ dependencies = [
  "itertools 0.14.0",
  "petgraph",
  "serde",
+ "serde_json",
  "similar",
  "strum 0.27.1",
+ "tempfile",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/cli/tests/extension/authorization.rs
+++ b/cli/tests/extension/authorization.rs
@@ -44,13 +44,13 @@ fn init() {
     codegen-units = 1
 
     [dependencies]
-    grafbase-sdk = "0.15.2"
+    grafbase-sdk = "0.15.3"
     serde = { version = "1", features = ["derive"] }
 
     [dev-dependencies]
     indoc = "2"
     insta = { version = "1", features = ["json"] }
-    grafbase-sdk = { version = "0.15.2", features = ["test-utils"] }
+    grafbase-sdk = { version = "0.15.3", features = ["test-utils"] }
     tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
     serde_json = "1"
     "#);

--- a/cli/tests/extension/mod.rs
+++ b/cli/tests/extension/mod.rs
@@ -50,13 +50,13 @@ fn init_resolver() {
     codegen-units = 1
 
     [dependencies]
-    grafbase-sdk = "0.15.2"
+    grafbase-sdk = "0.15.3"
     serde = { version = "1", features = ["derive"] }
 
     [dev-dependencies]
     indoc = "2"
     insta = { version = "1", features = ["json"] }
-    grafbase-sdk = { version = "0.15.2", features = ["test-utils"] }
+    grafbase-sdk = { version = "0.15.3", features = ["test-utils"] }
     tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
     serde_json = "1"
     "#);
@@ -310,13 +310,13 @@ fn init_auth() {
     codegen-units = 1
 
     [dependencies]
-    grafbase-sdk = "0.15.2"
+    grafbase-sdk = "0.15.3"
     serde = { version = "1", features = ["derive"] }
 
     [dev-dependencies]
     indoc = "2"
     insta = { version = "1", features = ["json"] }
-    grafbase-sdk = { version = "0.15.2", features = ["test-utils"] }
+    grafbase-sdk = { version = "0.15.3", features = ["test-utils"] }
     tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
     serde_json = "1"
     "#);

--- a/cli/tests/integration/data/Cargo.lock
+++ b/cli/tests/integration/data/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "chrono",
  "document-features",

--- a/crates/engine/query-solver/Cargo.toml
+++ b/crates/engine/query-solver/Cargo.toml
@@ -32,8 +32,11 @@ walker = { path = "../walker", package = "engine-walker" }
 
 [dev-dependencies]
 ctor.workspace = true
+extension-catalog.workspace = true
 insta.workspace = true
+serde_json.workspace = true
 similar.workspace = true
+tempfile.workspace = true
 tokio.workspace = true
 tracing-subscriber = { workspace = true, features = [
     "fmt",
@@ -41,3 +44,4 @@ tracing-subscriber = { workspace = true, features = [
     "env-filter",
     "ansi",
 ] }
+url.workspace = true

--- a/crates/engine/query-solver/src/tests/lookup.rs
+++ b/crates/engine/query-solver/src/tests/lookup.rs
@@ -1,0 +1,75 @@
+use schema::Schema;
+
+use crate::assert_solving_snapshots;
+
+#[tokio::test]
+async fn direct_lookup_call() {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let manifest = extension_catalog::Manifest {
+        id: "ext-1.0.0".parse().unwrap(),
+        r#type: extension_catalog::Type::SelectionSetResolver(Default::default()),
+        sdk_version: "0.0.0".parse().unwrap(),
+        minimum_gateway_version: "0.0.0".parse().unwrap(),
+        description: String::new(),
+        sdl: Some(
+            r#"
+            directive @init on SCHEMA
+            "#
+            .into(),
+        ),
+        readme: None,
+        homepage_url: None,
+        repository_url: None,
+        license: None,
+        permissions: Default::default(),
+    };
+
+    std::fs::write(
+        tmpdir.path().join("manifest.json"),
+        serde_json::to_vec(&manifest.clone().into_versioned()).unwrap(),
+    )
+    .unwrap();
+
+    let mut catalog = extension_catalog::ExtensionCatalog::default();
+    let wasm_path = tmpdir.path().join("extension.wasm");
+    std::fs::write(&wasm_path, b"wasm").unwrap();
+    catalog.push(extension_catalog::Extension { manifest, wasm_path });
+
+    let sdl = format!(
+        r#"
+        enum join__Graph {{
+            PG @join__graph(name: "pg")
+        }}
+
+        enum extension__Link
+        {{
+          EXT @extension__link(url: "{}", schemaDirectives: [{{graph: PG, name: "init", arguments: {{}}}}])
+        }}
+
+        type Query @join__type(graph: PG) {{
+            userLookup(id: [ID!]): [User!] @composite__lookup(graph: PG)
+        }}
+
+        type User @join__type(graph: PG, key: "id", resolvable: false) {{
+            id: ID!
+            name: String!
+        }}
+        "#,
+        url::Url::from_file_path(tmpdir.path()).unwrap()
+    );
+
+    let schema = Schema::build(None, &sdl, &Default::default(), &catalog).await.unwrap();
+
+    assert_solving_snapshots!(
+        "direct_lookup_call",
+        schema,
+        r#"
+        query {
+            userLookup(id: ["1"]) {
+                id
+                name
+            }
+        }
+        "#
+    );
+}

--- a/crates/engine/query-solver/src/tests/sibling_dependencies.rs
+++ b/crates/engine/query-solver/src/tests/sibling_dependencies.rs
@@ -65,7 +65,7 @@ type Product
     price: Int! @join__field(graph: PRODUCTS)
     reviews: [Review!]! @join__field(graph: REVIEWS)
     shippingEstimate: Int! @join__field(graph: INVENTORY, requires: "weight(unit: KILOGRAM)")
-    upc: String!
+    upc: String! @join__field(graph: PRODUCTS) @join__field(graph: INVENTORY) @join__field(graph: REVIEWS)
     weight(unit: WeightUnit!): Float! @join__field(graph: PRODUCTS)
 }
 

--- a/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__lookup__direct_lookup_call-finalized-solution.snap
+++ b/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__lookup__direct_lookup_call-finalized-solution.snap
@@ -1,0 +1,15 @@
+---
+source: crates/engine/query-solver/src/tests/lookup.rs
+expression: "digraph {\n    0 [ label = \"root\" ]\n    1 [ label = \"SelectionSetResolver#0#pg\", color=royalblue,shape=parallelogram ]\n    2 [ label = \"Query.userLookup\" ]\n    3 [ label = \"User.id\" ]\n    4 [ label = \"User.name\" ]\n    0 -> 1 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    2 -> 4 [ label = \"\" ]\n    2 -> 3 [ label = \"\" ]\n    1 -> 2 [ label = \"\" ]\n}\n"
+---
+digraph {
+    0 [ label = "root" ]
+    1 [ label = "SelectionSetResolver#0#pg" ]
+    2 [ label = "Query.userLookup" ]
+    3 [ label = "User.id" ]
+    4 [ label = "User.name" ]
+    0 -> 1 [ label = "QueryPartition" ]
+    2 -> 4 [ label = "Field" ]
+    2 -> 3 [ label = "Field" ]
+    1 -> 2 [ label = "Field" ]
+}

--- a/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__lookup__direct_lookup_call-graph.snap
+++ b/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__lookup__direct_lookup_call-graph.snap
@@ -1,0 +1,25 @@
+---
+source: crates/engine/query-solver/src/tests/lookup.rs
+expression: "digraph {\n    0 [ label = \"root\" ]\n    1 [ label = \"Query.userLookup\" ]\n    2 [ label = \"User.id\" ]\n    3 [ label = \"User.name\" ]\n    4 [ label = \"SelectionSetResolver#0#pg\", shape=parallelogram, color=dodgerblue ]\n    5 [ label = \"userLookup#pg\", shape=box, color=dodgerblue ]\n    6 [ label = \"id#pg\", shape=box, color=dodgerblue ]\n    7 [ label = \"name#pg\", shape=box, color=dodgerblue ]\n    0 -> 1 [ label = \"\" ]\n    1 -> 2 [ label = \"\" ]\n    1 -> 3 [ label = \"\" ]\n    0 -> 4 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    0 -> 4 [ label = \"\", style=dashed,arrowhead=none ]\n    4 -> 5 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    5 -> 1 [ label = \"\", color=violet,arrowhead=none ]\n    5 -> 6 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    6 -> 2 [ label = \"\", color=violet,arrowhead=none ]\n    5 -> 7 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    7 -> 3 [ label = \"\", color=violet,arrowhead=none ]\n}\n"
+---
+digraph {
+    0 [ root]
+    1 [ Query.userLookup]
+    2 [ User.id]
+    3 [ User.name]
+    4 [ SelectionSetResolver#0#pg]
+    5 [ userLookup#pg]
+    6 [ id#pg]
+    7 [ name#pg]
+    0 -> 1 [ label = "Field" ]
+    1 -> 2 [ label = "Field" ]
+    1 -> 3 [ label = "Field" ]
+    0 -> 4 [ label = "CreateChildResolver" ]
+    0 -> 4 [ label = "HasChildResolver" ]
+    4 -> 5 [ label = "CanProvide" ]
+    5 -> 1 [ label = "Provides" ]
+    5 -> 6 [ label = "CanProvide" ]
+    6 -> 2 [ label = "Provides" ]
+    5 -> 7 [ label = "CanProvide" ]
+    7 -> 3 [ label = "Provides" ]
+}

--- a/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__lookup__direct_lookup_call-partial-solution.snap
+++ b/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__lookup__direct_lookup_call-partial-solution.snap
@@ -1,0 +1,15 @@
+---
+source: crates/engine/query-solver/src/tests/lookup.rs
+expression: "digraph {\n    0 [ label = \"root\" ]\n    1 [ label = \"SelectionSetResolver#0#pg\", color=royalblue,shape=parallelogram ]\n    2 [ label = \"Query.userLookup\" ]\n    3 [ label = \"User.id\" ]\n    4 [ label = \"User.name\" ]\n    0 -> 1 [ label = \"\", color=royalblue,fontcolor=royalblue ]\n    1 -> 2 [ label = \"\" ]\n    2 -> 3 [ label = \"\" ]\n    2 -> 4 [ label = \"\" ]\n}\n"
+---
+digraph {
+    0 [ label = "root" ]
+    1 [ label = "SelectionSetResolver#0#pg" ]
+    2 [ label = "Query.userLookup" ]
+    3 [ label = "User.id" ]
+    4 [ label = "User.name" ]
+    0 -> 1 [ label = "QueryPartition" ]
+    1 -> 2 [ label = "Field" ]
+    2 -> 3 [ label = "Field" ]
+    2 -> 4 [ label = "Field" ]
+}

--- a/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__lookup__direct_lookup_call-solved.snap
+++ b/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__lookup__direct_lookup_call-solved.snap
@@ -1,0 +1,21 @@
+---
+source: crates/engine/query-solver/src/tests/lookup.rs
+expression: "digraph {\n    0 [ label = \"root\", color=forestgreen ]\n    1 [ label = \"User.id\", color=forestgreen ]\n    2 [ label = \"User.name\", color=forestgreen ]\n    3 [ label = \"SelectionSetResolver#0#pg\", shape=parallelogram, color=dodgerblue, color=forestgreen ]\n    4 [ label = \"userLookup#pg\", shape=box, color=dodgerblue, color=forestgreen ]\n    5 [ label = \"id#pg\", shape=box, color=dodgerblue, color=forestgreen ]\n    6 [ label = \"name#pg\", shape=box, color=dodgerblue, color=forestgreen ]\n    7 [ label=\"\", style=dashed]\n    0 -> 3 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    3 -> 4 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    4 -> 5 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    5 -> 1 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    4 -> 6 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    6 -> 2 [ label = \"\", color=forestgreen,fontcolor=forestgreen ]\n    7 -> 0 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n}\n"
+---
+digraph {
+    0 [ label = "root", steiner=1 ]
+    1 [ label = "User.id", steiner=1 ]
+    2 [ label = "User.name", steiner=1 ]
+    3 [ label = "SelectionSetResolver#0#pg", steiner=1 ]
+    4 [ label = "userLookup#pg", steiner=1 ]
+    5 [ label = "id#pg", steiner=1 ]
+    6 [ label = "name#pg", steiner=1 ]
+    7 [ label="", style=dashed]
+    0 -> 3 [ cost=0, steiner=1]
+    3 -> 4 [ cost=0, steiner=1]
+    4 -> 5 [ cost=0, steiner=1]
+    5 -> 1 [ cost=0, steiner=1]
+    4 -> 6 [ cost=0, steiner=1]
+    6 -> 2 [ cost=0, steiner=1]
+    7 -> 0 [ cost=0, steiner=0]
+}

--- a/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__lookup__direct_lookup_call-solver.snap
+++ b/crates/engine/query-solver/src/tests/snapshots/engine_query_solver__tests__lookup__direct_lookup_call-solver.snap
@@ -1,0 +1,21 @@
+---
+source: crates/engine/query-solver/src/tests/lookup.rs
+expression: "digraph {\n    0 [ label = \"root\", color=forestgreen ]\n    1 [ label = \"User.id\", style=dashed ]\n    2 [ label = \"User.name\", style=dashed ]\n    3 [ label = \"SelectionSetResolver#0#pg\", shape=parallelogram, color=dodgerblue, style=dashed ]\n    4 [ label = \"userLookup#pg\", shape=box, color=dodgerblue, style=dashed ]\n    5 [ label = \"id#pg\", shape=box, color=dodgerblue, style=dashed ]\n    6 [ label = \"name#pg\", shape=box, color=dodgerblue, style=dashed ]\n    7 [ label=\"\", style=dashed]\n    0 -> 3 [ label = <<b>1</b>>, color=royalblue,fontcolor=royalblue,style=dashed ]\n    3 -> 4 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n    4 -> 5 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n    5 -> 1 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n    4 -> 6 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n    6 -> 2 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n    7 -> 0 [ label = \"\", color=royalblue,fontcolor=royalblue,style=dashed ]\n}\n"
+---
+digraph {
+    0 [ label = "root", steiner=1 ]
+    1 [ label = "User.id", steiner=0 ]
+    2 [ label = "User.name", steiner=0 ]
+    3 [ label = "SelectionSetResolver#0#pg", steiner=0 ]
+    4 [ label = "userLookup#pg", steiner=0 ]
+    5 [ label = "id#pg", steiner=0 ]
+    6 [ label = "name#pg", steiner=0 ]
+    7 [ label="", style=dashed]
+    0 -> 3 [ cost=1, steiner=0]
+    3 -> 4 [ cost=0, steiner=0]
+    4 -> 5 [ cost=0, steiner=0]
+    5 -> 1 [ cost=0, steiner=0]
+    4 -> 6 [ cost=0, steiner=0]
+    6 -> 2 [ cost=0, steiner=0]
+    7 -> 0 [ cost=0, steiner=0]
+}

--- a/crates/engine/schema/src/builder/graph/directives/federation.rs
+++ b/crates/engine/schema/src/builder/graph/directives/federation.rs
@@ -293,7 +293,7 @@ impl<'sdl> DirectivesIngester<'_, 'sdl> {
             let (dir, span) = result?;
 
             parent_has_join_type = true;
-            if !has_join_field && dir.resolvable {
+            if !has_join_field {
                 let subgraph_id = self.subgraphs.try_get(dir.graph, span)?;
                 // If there is no @join__field we rely solely @join__type to define the subgraphs
                 // in which this field is resolvable in.

--- a/crates/integration-tests/data/extensions/Cargo.lock
+++ b/crates/integration-tests/data/extensions/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
 name = "authenticated"
 version = "0.1.0"
 dependencies = [
- "grafbase-sdk 0.15.0",
+ "grafbase-sdk 0.15.3",
  "serde",
  "serde_json",
 ]
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.15.0"
+version = "0.15.3"
 dependencies = [
  "chrono",
  "document-features",
@@ -2069,7 +2069,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "placeholder"
 version = "0.1.0"
 dependencies = [
- "grafbase-sdk 0.15.0",
+ "grafbase-sdk 0.15.3",
  "serde",
  "serde_json",
 ]
@@ -2614,7 +2614,7 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 name = "selection-set-resolver-014"
 version = "0.1.0"
 dependencies = [
- "grafbase-sdk 0.15.0",
+ "grafbase-sdk 0.15.3",
  "http",
  "rkyv 0.8.10",
  "serde",


### PR DESCRIPTION
Julius noticed the issue when calling a lookup field directly. Somehow
the engine decided to retrieve the key fields and then to an entity join
to retrieve the rest. The problem was that we weren't interpreting
`@join__type(resolvable: Boolean, ...)` correctly. It represents whether the entity is
available through Apollo `_entities` field, not whether any field exists
within a subgraph.
