### PR TITLE
cli: release 0.93.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.93.0"
+version = "0.93.1"
 dependencies = [
  "anyhow",
  "askama",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.93.1] - 2025-04-29
+
+[CHANGELOG](changelog/0.93.1.md)
+
 ## [0.93.0] - 2025-04-28
 
 [CHANGELOG](changelog/0.93.0.md)

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.93.0"
+version = "0.93.1"
 name = "grafbase"
 description = "The Grafbase command line interface"
 categories = ["command-line-utilities"]

--- a/cli/changelog/0.93.1.md
+++ b/cli/changelog/0.93.1.md
@@ -1,0 +1,3 @@
+## Fixes
+
+- The `grafbase dev` web app now correctly injects the MCP server url into the chat page.

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.93.0",
+  "version": "0.93.1",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.93.0",
+  "version": "0.93.1",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.93.0",
+  "version": "0.93.1",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.93.0",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.93.0",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.93.0",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.93.0",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.93.0"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.93.1",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.93.1",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.93.1",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.93.1",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.93.1"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.93.0",
+  "version": "0.93.1",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.93.0",
+  "version": "0.93.1",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.93.0",
+  "version": "0.93.1",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/tests/extension/authorization.rs
+++ b/cli/tests/extension/authorization.rs
@@ -44,13 +44,13 @@ fn init() {
     codegen-units = 1
 
     [dependencies]
-    grafbase-sdk = "0.15.2"
+    grafbase-sdk = "0.15.3"
     serde = { version = "1", features = ["derive"] }
 
     [dev-dependencies]
     indoc = "2"
     insta = { version = "1", features = ["json"] }
-    grafbase-sdk = { version = "0.15.2", features = ["test-utils"] }
+    grafbase-sdk = { version = "0.15.3", features = ["test-utils"] }
     tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
     serde_json = "1"
     "#);

--- a/cli/tests/extension/mod.rs
+++ b/cli/tests/extension/mod.rs
@@ -50,13 +50,13 @@ fn init_resolver() {
     codegen-units = 1
 
     [dependencies]
-    grafbase-sdk = "0.15.2"
+    grafbase-sdk = "0.15.3"
     serde = { version = "1", features = ["derive"] }
 
     [dev-dependencies]
     indoc = "2"
     insta = { version = "1", features = ["json"] }
-    grafbase-sdk = { version = "0.15.2", features = ["test-utils"] }
+    grafbase-sdk = { version = "0.15.3", features = ["test-utils"] }
     tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
     serde_json = "1"
     "#);
@@ -310,13 +310,13 @@ fn init_auth() {
     codegen-units = 1
 
     [dependencies]
-    grafbase-sdk = "0.15.2"
+    grafbase-sdk = "0.15.3"
     serde = { version = "1", features = ["derive"] }
 
     [dev-dependencies]
     indoc = "2"
     insta = { version = "1", features = ["json"] }
-    grafbase-sdk = { version = "0.15.2", features = ["test-utils"] }
+    grafbase-sdk = { version = "0.15.3", features = ["test-utils"] }
     tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
     serde_json = "1"
     "#);

--- a/cli/tests/integration/data/Cargo.lock
+++ b/cli/tests/integration/data/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "chrono",
  "document-features",


### PR DESCRIPTION

## Fixes

- The `grafbase dev` web app now correctly injects the MCP server url into the chat page.