### PR TITLE
cli: release 0.93.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3790,7 +3790,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.93.1"
+version = "0.93.2"
 dependencies = [
  "anyhow",
  "askama",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.93.2] - 2025-04-29
+
+[CHANGELOG](changelog/0.93.2.md)
+
 ## [0.93.1] - 2025-04-29
 
 [CHANGELOG](changelog/0.93.1.md)

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.93.1"
+version = "0.93.2"
 name = "grafbase"
 description = "The Grafbase command line interface"
 categories = ["command-line-utilities"]

--- a/cli/changelog/0.93.2.md
+++ b/cli/changelog/0.93.2.md
@@ -1,0 +1,3 @@
+## Fixes
+
+- The `grafbase dev` web app now correctly injects the MCP server url into the chat page.

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.93.1",
+  "version": "0.93.2",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.93.1",
+  "version": "0.93.2",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.93.1",
+  "version": "0.93.2",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.93.1",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.93.1",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.93.1",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.93.1",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.93.1"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.93.2",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.93.2",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.93.2",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.93.2",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.93.2"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.93.1",
+  "version": "0.93.2",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.93.1",
+  "version": "0.93.2",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.93.1",
+  "version": "0.93.2",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
## Fixes

- The `grafbase dev` web app now correctly injects the MCP server url into the chat page.