### PR TITLE
chore(engine): Decouple shape id from the subgraph response

### DIFF
--- a/crates/engine/src/execution/hooks/authorized.rs
+++ b/crates/engine/src/execution/hooks/authorized.rs
@@ -4,7 +4,7 @@ use schema::{FieldDefinition, SchemaInputValue, TypeDefinition};
 
 use crate::{
     prepare::PlanFieldArgumentsQueryView,
-    response::{GraphqlError, ResponseObjectsView},
+    response::{GraphqlError, ParentObjectsView},
 };
 
 impl<H: Hooks> super::RequestHooks<'_, H> {
@@ -35,7 +35,7 @@ impl<H: Hooks> super::RequestHooks<'_, H> {
     pub async fn authorize_parent_edge_post_execution(
         &self,
         definition: FieldDefinition<'_>,
-        parents: ResponseObjectsView<'_>,
+        parents: ParentObjectsView<'_>,
         metadata: Option<SchemaInputValue<'_>>,
     ) -> Result<Vec<Result<(), GraphqlError>>, GraphqlError> {
         self.hooks
@@ -59,7 +59,7 @@ impl<H: Hooks> super::RequestHooks<'_, H> {
     pub async fn authorize_edge_node_post_execution(
         &self,
         definition: FieldDefinition<'_>,
-        nodes: ResponseObjectsView<'_>,
+        nodes: ParentObjectsView<'_>,
         metadata: Option<SchemaInputValue<'_>>,
     ) -> Result<Vec<Result<(), GraphqlError>>, GraphqlError> {
         self.hooks

--- a/crates/engine/src/execution/operation/state.rs
+++ b/crates/engine/src/execution/operation/state.rs
@@ -6,7 +6,7 @@ use walker::Walk;
 use crate::{
     Runtime,
     prepare::{Executable, Plan, PlanId, ResponseModifierId, ResponseObjectSetDefinitionId},
-    response::{InputResponseObjectSet, ResponseBuilder, ResponseObjectSet},
+    response::{ParentObjects, ResponseBuilder, ResponseObjectSet},
 };
 
 use super::ExecutionContext;
@@ -90,7 +90,7 @@ impl<'ctx, R: Runtime> OperationExecutionState<'ctx, R> {
         self[set_id] = Some(Arc::new(response_object_refs));
     }
 
-    pub fn get_input(&mut self, response: &ResponseBuilder, plan: Plan<'_>) -> InputResponseObjectSet {
+    pub fn get_input(&mut self, response: &ResponseBuilder<'ctx>, plan: Plan<'_>) -> ParentObjects {
         // If there is no root, an error propagated up to it and data will be null. So there's
         // nothing to do anymore.
         let Some(root_ref) = response.root_response_object() else {
@@ -100,7 +100,7 @@ impl<'ctx, R: Runtime> OperationExecutionState<'ctx, R> {
         let input_id = plan.input_id();
         tracing::trace!("Get response objects for {input_id}");
 
-        let output = InputResponseObjectSet::default();
+        let output = ParentObjects::default();
         if let Some(refs) = &self[input_id] {
             output.with_filtered_response_objects(
                 self.ctx.schema(),

--- a/crates/engine/src/prepare/cached/extension/mod.rs
+++ b/crates/engine/src/prepare/cached/extension/mod.rs
@@ -7,7 +7,7 @@ pub(crate) use query::*;
 pub(crate) use response::*;
 use schema::{ExtensionDirective, ExtensionDirectiveArgumentsStaticView, InjectionStage, Schema};
 
-use crate::response::ResponseObjectsView;
+use crate::response::ParentObjectsView;
 
 use super::PlanFieldArguments;
 
@@ -38,7 +38,7 @@ pub(crate) fn create_extension_directive_response_view<'ctx, 'resp>(
     directive: ExtensionDirective<'ctx>,
     field_arguments: PlanFieldArguments<'ctx>,
     variables: &'ctx Variables,
-    response_objects_view: ResponseObjectsView<'resp>,
+    response_objects_view: ParentObjectsView<'resp>,
 ) -> ExtensionDirectiveArgumentsResponseObjectsView<'resp>
 where
     'ctx: 'resp,

--- a/crates/engine/src/prepare/cached/extension/response.rs
+++ b/crates/engine/src/prepare/cached/extension/response.rs
@@ -3,14 +3,14 @@ use std::borrow::Cow;
 use schema::{ExtensionInputValueRecord, InputValueSet};
 use walker::Walk;
 
-use crate::response::{ResponseObjectView, ResponseObjectsView};
+use crate::response::{ParentObjectsView, ResponseObjectView};
 
 use super::{ArgumentsContext, template::JsonContent};
 
 pub struct ExtensionDirectiveArgumentsResponseObjectsView<'a> {
     pub(super) ctx: ArgumentsContext<'a>,
     pub(super) arguments: Vec<(&'a str, &'a ExtensionInputValueRecord)>,
-    pub(super) response_objects_view: ResponseObjectsView<'a>,
+    pub(super) response_objects_view: ParentObjectsView<'a>,
 }
 
 impl ExtensionDirectiveArgumentsResponseObjectsView<'_> {

--- a/crates/engine/src/prepare/cached/query_plan/field/arguments.rs
+++ b/crates/engine/src/prepare/cached/query_plan/field/arguments.rs
@@ -5,7 +5,7 @@ use walker::Walk as _;
 
 use crate::{
     prepare::{CachedOperationContext, PartitionFieldArgument, PartitionFieldArgumentRecord},
-    response::{ResponseObjectView, ResponseObjectsView},
+    response::{ParentObjectsView, ResponseObjectView},
 };
 
 use super::PlanValueRecord;
@@ -57,7 +57,7 @@ impl<'ctx> PlanFieldArguments<'ctx> {
     pub(crate) fn batch_view<'v, 'r, 'view>(
         &self,
         variables: &'v Variables,
-        parent_objects: ResponseObjectsView<'r>,
+        parent_objects: ParentObjectsView<'r>,
     ) -> PlanFieldArgumentsBatchView<'view>
     where
         'ctx: 'view,
@@ -180,7 +180,7 @@ impl serde::Serialize for PlanFieldArgumentsQueryView<'_> {
 pub(crate) struct PlanFieldArgumentsBatchView<'a> {
     pub(in crate::prepare::cached::query_plan) ctx: CachedOperationContext<'a>,
     pub(in crate::prepare::cached::query_plan) variables: &'a Variables,
-    parent_objects: ResponseObjectsView<'a>,
+    parent_objects: ParentObjectsView<'a>,
     arguments: &'a [PartitionFieldArgumentRecord],
 }
 

--- a/crates/engine/src/resolver/extension/field/query_or_mutation.rs
+++ b/crates/engine/src/resolver/extension/field/query_or_mutation.rs
@@ -8,8 +8,11 @@ use walker::Walk;
 use crate::{
     Runtime,
     execution::{ExecutionContext, ExecutionResult},
-    prepare::{Plan, SubgraphField, create_extension_directive_query_view, create_extension_directive_response_view},
-    response::{GraphqlError, InputResponseObjectSet, ResponseObjectsView, SubgraphResponse},
+    prepare::{
+        ConcreteShapeId, Plan, SubgraphField, create_extension_directive_query_view,
+        create_extension_directive_response_view,
+    },
+    response::{GraphqlError, ParentObjects, ParentObjectsView, ResponsePart},
 };
 
 impl super::FieldResolverExtension {
@@ -17,8 +20,8 @@ impl super::FieldResolverExtension {
         &'ctx self,
         ctx: ExecutionContext<'ctx, R>,
         plan: Plan<'ctx>,
-        root_response_objects: ResponseObjectsView<'_>,
-        subgraph_response: SubgraphResponse,
+        root_response_objects: ParentObjectsView<'_>,
+        subgraph_response: ResponsePart<'ctx>,
     ) -> Executor<'ctx> {
         let directive = self.directive_id.walk(ctx.schema());
         let subgraph_headers = ctx.subgraph_headers_with_rules(directive.subgraph().header_rules());
@@ -59,11 +62,12 @@ impl super::FieldResolverExtension {
             })
             .unzip();
 
-        let input_object_refs = root_response_objects.into_input_object_refs();
+        let parent_objects = root_response_objects.into_parent_objects();
 
         Executor {
-            subgraph_response,
-            input_object_refs,
+            response_part: subgraph_response,
+            shape_id: plan.shape_id(),
+            parent_objects,
             fields,
             futures,
         }
@@ -71,18 +75,20 @@ impl super::FieldResolverExtension {
 }
 
 pub(in crate::resolver) struct Executor<'ctx> {
-    subgraph_response: SubgraphResponse,
-    input_object_refs: Arc<InputResponseObjectSet>,
+    shape_id: ConcreteShapeId,
+    response_part: ResponsePart<'ctx>,
+    parent_objects: Arc<ParentObjects>,
     fields: Vec<SubgraphField<'ctx>>,
     #[allow(clippy::type_complexity)] // should be better with resolver rework... hopefully.
     futures: Vec<BoxFuture<'ctx, Result<Vec<Result<Data, GraphqlError>>, GraphqlError>>>,
 }
 
 impl<'ctx> Executor<'ctx> {
-    pub async fn execute<R: Runtime>(self, ctx: ExecutionContext<'ctx, R>) -> ExecutionResult<SubgraphResponse> {
+    pub async fn execute(self) -> ExecutionResult<ResponsePart<'ctx>> {
         let Self {
-            mut subgraph_response,
-            input_object_refs,
+            shape_id,
+            response_part,
+            parent_objects,
             fields,
             futures,
         } = self;
@@ -98,30 +104,30 @@ impl<'ctx> Executor<'ctx> {
             .zip(results)
             .map(|(field, result)| match result {
                 Ok(result) => (*field, result.into_iter()),
-                Err(err) => (*field, vec![Err(err); input_object_refs.len()].into_iter()),
+                Err(err) => (*field, vec![Err(err); parent_objects.len()].into_iter()),
             })
             .collect::<Vec<_>>();
 
         let mut entity_fields = Vec::with_capacity(field_results.len());
-        let response = subgraph_response.as_shared_mut();
-        for input_object_id in input_object_refs.ids() {
+        let response_part = response_part.into_shared();
+        for parent_object_id in parent_objects.ids() {
             entity_fields.clear();
             for (field, results) in &mut field_results {
                 entity_fields.push((*field, results.next().unwrap()));
             }
 
-            response
-                .seed(&ctx, input_object_id)
+            response_part
+                .seed(shape_id, parent_object_id)
                 .deserialize_from_fields(&mut entity_fields)
                 .map_err(|err| {
                     tracing::error!("Failed to deserialize subgraph response: {}", err);
 
                     GraphqlError::invalid_subgraph_response()
                         .with_location(fields[0].location())
-                        .with_path(&input_object_refs[input_object_id].path)
+                        .with_path(&parent_objects[parent_object_id].path)
                 })?;
         }
 
-        Ok(subgraph_response)
+        Ok(response_part.unshare().unwrap())
     }
 }

--- a/crates/engine/src/resolver/graphql/cache.rs
+++ b/crates/engine/src/resolver/graphql/cache.rs
@@ -7,7 +7,7 @@ use runtime::entity_cache::EntityCache;
 use serde_json::value::RawValue;
 use std::time::Duration;
 
-use crate::{Runtime, response::InputObjectId};
+use crate::{Runtime, response::ParentObjectId};
 
 use super::{EntityToFetch, SubgraphContext};
 
@@ -125,19 +125,19 @@ pub(super) struct CacheFetchEntitiesOutcome {
 }
 
 pub(super) struct EntityCacheHit {
-    pub id: InputObjectId,
+    pub id: ParentObjectId,
     pub data: Vec<u8>,
 }
 
 pub(super) struct EntityCacheMiss {
-    pub id: InputObjectId,
+    pub id: ParentObjectId,
     pub key: String,
     pub representation: Box<RawValue>,
 }
 
 async fn fetch_entity(
     entity_cache: &dyn EntityCache,
-    id: InputObjectId,
+    id: ParentObjectId,
     key: String,
     representation: Box<RawValue>,
 ) -> Result<EntityCacheHit, EntityCacheMiss> {

--- a/crates/engine/src/resolver/graphql/context.rs
+++ b/crates/engine/src/resolver/graphql/context.rs
@@ -28,7 +28,7 @@ use crate::{
     Engine, Runtime,
     execution::{ExecutionContext, ExecutionError, ExecutionResult, RequestHooks},
     resolver::ResolverResult,
-    response::SubgraphResponse,
+    response::ResponsePart,
 };
 
 #[derive(Clone)]
@@ -106,8 +106,8 @@ impl<'ctx, R: Runtime> SubgraphContext<'ctx, R> {
 
     pub async fn finalize(
         self,
-        subgraph_result: ExecutionResult<SubgraphResponse>,
-    ) -> ResolverResult<<R::Hooks as Hooks>::OnSubgraphResponseOutput> {
+        subgraph_result: ExecutionResult<ResponsePart<'ctx>>,
+    ) -> ResolverResult<'ctx, <R::Hooks as Hooks>::OnSubgraphResponseOutput> {
         let duration = self.start.elapsed();
 
         if let Some(status) = self.status {

--- a/crates/engine/src/resolver/graphql/deserialize/errors.rs
+++ b/crates/engine/src/resolver/graphql/deserialize/errors.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use serde::{Deserializer, de::DeserializeSeed};
 
-use crate::response::{ErrorCode, ErrorPath, GraphqlError, SubgraphResponseRefMut};
+use crate::response::{ErrorCode, ErrorPath, GraphqlError, SharedResponsePart};
 
 pub(in crate::resolver::graphql) trait SubgraphToSupergraphErrorPathConverter {
     fn convert(&self, path: serde_json::Value) -> Option<ErrorPath>;
@@ -19,7 +19,7 @@ where
 
 /// Deserialize the `errors` field of a GraphQL response with the help of a ErrorPathConverter.
 pub(in crate::resolver::graphql) struct GraphqlErrorsSeed<'resp, ErrorPathConverter> {
-    pub response: SubgraphResponseRefMut<'resp>,
+    pub response_part: SharedResponsePart<'resp>,
     pub path_converter: ErrorPathConverter,
 }
 
@@ -27,9 +27,9 @@ impl<'resp, ErrorPathConverter> GraphqlErrorsSeed<'resp, ErrorPathConverter>
 where
     ErrorPathConverter: SubgraphToSupergraphErrorPathConverter,
 {
-    pub fn new(response: SubgraphResponseRefMut<'resp>, path_converter: ErrorPathConverter) -> Self {
+    pub fn new(response_part: SharedResponsePart<'resp>, path_converter: ErrorPathConverter) -> Self {
         Self {
-            response,
+            response_part,
             path_converter,
         }
     }
@@ -66,7 +66,7 @@ where
                 error
             })
             .collect();
-        self.response.borrow_mut().set_subgraph_errors(errors);
+        self.response_part.borrow_mut().set_subgraph_errors(errors);
         Ok(errors_count)
     }
 }

--- a/crates/engine/src/resolver/introspection/writer.rs
+++ b/crates/engine/src/resolver/introspection/writer.rs
@@ -12,9 +12,7 @@ use crate::{
     Runtime,
     execution::ExecutionContext,
     prepare::{ConcreteShapeId, FieldShapeRecord, Plan, Shapes},
-    response::{
-        InputObjectId, ObjectUpdate, ResponseObject, ResponseObjectField, ResponseValue, SubgraphResponseRefMut,
-    },
+    response::{ObjectUpdate, ParentObjectId, ResponseObject, ResponseObjectField, ResponseValue, SharedResponsePart},
 };
 
 pub(super) struct IntrospectionWriter<'ctx, R: Runtime> {
@@ -23,8 +21,8 @@ pub(super) struct IntrospectionWriter<'ctx, R: Runtime> {
     pub shapes: &'ctx Shapes,
     pub metadata: &'ctx IntrospectionSubgraph,
     pub plan: Plan<'ctx>,
-    pub input_object_id: InputObjectId,
-    pub response: SubgraphResponseRefMut<'ctx>,
+    pub parent_object_id: ParentObjectId,
+    pub response: SharedResponsePart<'ctx>,
 }
 
 impl<'ctx, R: Runtime> IntrospectionWriter<'ctx, R> {
@@ -69,7 +67,7 @@ impl<'ctx, R: Runtime> IntrospectionWriter<'ctx, R> {
         }
         self.response
             .borrow_mut()
-            .insert_update(self.input_object_id, ObjectUpdate::Fields(fields));
+            .insert_update(self.parent_object_id, ObjectUpdate::Fields(fields));
     }
 
     fn object<E: Copy, const N: usize>(

--- a/crates/engine/src/resolver/lookup.rs
+++ b/crates/engine/src/resolver/lookup.rs
@@ -6,7 +6,7 @@ use crate::{
     Runtime,
     execution::ExecutionContext,
     prepare::{Plan, PlanError, PlanQueryPartition, PlanResult, PrepareContext},
-    response::{ResponseObjectsView, SubgraphResponse},
+    response::{ParentObjectsView, ResponsePart},
 };
 
 use super::{ResolverResult, extension::SelectionSetResolverExtension, graphql::GraphqlResolver};
@@ -57,9 +57,9 @@ impl LookupResolver {
         &'ctx self,
         ctx: ExecutionContext<'ctx, R>,
         plan: Plan<'ctx>,
-        root_response_objects: ResponseObjectsView<'_>,
-        subgraph_response: SubgraphResponse,
-    ) -> BoxFuture<'f, ResolverResult<<R::Hooks as Hooks>::OnSubgraphResponseOutput>>
+        root_response_objects: ParentObjectsView<'_>,
+        subgraph_response: ResponsePart<'ctx>,
+    ) -> BoxFuture<'f, ResolverResult<'ctx, <R::Hooks as Hooks>::OnSubgraphResponseOutput>>
     where
         'ctx: 'f,
     {

--- a/crates/engine/src/response/read/mod.rs
+++ b/crates/engine/src/response/read/mod.rs
@@ -2,19 +2,19 @@ use std::sync::Arc;
 
 use crate::prepare::RequiredFieldSet;
 
-use super::{InputResponseObjectSet, ResponseBuilder};
+use super::{ParentObjects, ResponseBuilder};
 mod ser;
 mod view;
 
 pub(crate) use view::*;
 
-impl ResponseBuilder {
+impl ResponseBuilder<'_> {
     pub fn read<'a>(
         &'a self,
-        response_object_set: Arc<InputResponseObjectSet>,
+        response_object_set: Arc<ParentObjects>,
         selection_set: RequiredFieldSet<'a>,
-    ) -> ResponseObjectsView<'a> {
-        ResponseObjectsView {
+    ) -> ParentObjectsView<'a> {
+        ParentObjectsView {
             ctx: ViewContext { response: self },
             response_object_set,
             view: selection_set,

--- a/crates/engine/src/response/read/view/ser.rs
+++ b/crates/engine/src/response/read/view/ser.rs
@@ -4,10 +4,10 @@ use schema::{EntityDefinition, KeyValueInjectionRecord, ValueInjection};
 use serde::ser::{Error, SerializeMap};
 use walker::Walk as _;
 
-use super::{ForFieldSet, ForInjection, ResponseObjectView, ResponseObjectsView, ResponseValueView, WithExtraFields};
+use super::{ForFieldSet, ForInjection, ParentObjectsView, ResponseObjectView, ResponseValueView, WithExtraFields};
 use crate::{prepare::RequiredFieldSet, response::ResponseValue};
 
-impl<'a, View: Copy> serde::Serialize for ResponseObjectsView<'a, View>
+impl<'a, View: Copy> serde::Serialize for ParentObjectsView<'a, View>
 where
     ResponseObjectView<'a, View>: serde::Serialize,
 {

--- a/crates/engine/src/response/write/deserialize/ctx.rs
+++ b/crates/engine/src/response/write/deserialize/ctx.rs
@@ -2,7 +2,7 @@ use std::cell::{Cell, Ref, RefCell, RefMut};
 
 use crate::{
     prepare::{CachedOperationContext, OperationPlanContext, PreparedOperation},
-    response::{ResponseValueId, SubgraphResponseRefMut},
+    response::{ResponseValueId, SharedResponsePart},
 };
 use itertools::Itertools;
 use operation::ResponseKeys;
@@ -11,7 +11,7 @@ use schema::Schema;
 pub(super) struct SeedContext<'ctx> {
     pub schema: &'ctx Schema,
     pub prepared_operation: &'ctx PreparedOperation,
-    pub subgraph_response: SubgraphResponseRefMut<'ctx>,
+    pub response: SharedResponsePart<'ctx>,
     pub bubbling_up_serde_error: Cell<bool>,
     pub path: RefCell<Vec<ResponseValueId>>,
 }

--- a/crates/engine/src/response/write/deserialize/entity.rs
+++ b/crates/engine/src/response/write/deserialize/entity.rs
@@ -139,7 +139,7 @@ impl<'de> MapAccess<'de> for EntityFieldsMapAccess<'de, '_, '_> {
             },
             Err(err) => {
                 if field.query_position().is_some() {
-                    let mut resp = self.ctx.subgraph_response.borrow_mut();
+                    let mut resp = self.ctx.response.borrow_mut();
                     let path = self.ctx.path();
                     resp.propagate_null(&path);
                     // FIXME: remove Clone...

--- a/crates/engine/src/response/write/deserialize/enum.rs
+++ b/crates/engine/src/response/write/deserialize/enum.rs
@@ -38,7 +38,7 @@ impl<'de> DeserializeSeed<'de> for EnumValueSeed<'_, '_> {
         } = self;
         match deserializer.deserialize_any(self)? {
             Ok(string_value) => {
-                let mut resp = ctx.subgraph_response.borrow_mut();
+                let mut resp = ctx.response.borrow_mut();
                 let path = ctx.path();
                 match definition_id.walk(ctx.schema).find_value_by_name(string_value.as_ref()) {
                     // If inaccessible propagating an error without any message.
@@ -88,7 +88,7 @@ impl EnumValueSeed<'_, '_> {
         );
 
         if self.parent_field.key.query_position.is_some() {
-            let mut resp = self.ctx.subgraph_response.borrow_mut();
+            let mut resp = self.ctx.response.borrow_mut();
             let path = self.ctx.path();
             // If not required, we don't need to propagate as Unexpected is equivalent to
             // null for users.

--- a/crates/engine/src/response/write/deserialize/field.rs
+++ b/crates/engine/src/response/write/deserialize/field.rs
@@ -68,7 +68,7 @@ impl<'de> DeserializeSeed<'de> for FieldSeed<'_, '_> {
                     "Deserialization failure of subgraph response at path '{}': {err}",
                     self.ctx.display_path()
                 );
-                let mut resp = self.ctx.subgraph_response.borrow_mut();
+                let mut resp = self.ctx.response.borrow_mut();
                 resp.propagate_null(&self.ctx.path());
                 resp.push_error(
                     GraphqlError::invalid_subgraph_response()

--- a/crates/engine/src/response/write/deserialize/list.rs
+++ b/crates/engine/src/response/write/deserialize/list.rs
@@ -46,7 +46,7 @@ where
         );
 
         if self.parent_field.key.query_position.is_some() {
-            let mut resp = self.ctx.subgraph_response.borrow_mut();
+            let mut resp = self.ctx.response.borrow_mut();
             let path = self.ctx.path();
             // If not required, we don't need to propagate as Unexpected is equivalent to
             // null for users.
@@ -87,7 +87,7 @@ where
         } = self;
 
         let mut index: u32 = 0;
-        let list_id = ctx.subgraph_response.borrow_mut().data.reserve_list_id();
+        let list_id = ctx.response.borrow_mut().data.reserve_list_id();
         let mut list = Vec::new();
         if let Some(size_hint) = seq.size_hint() {
             list.reserve(size_hint);
@@ -116,7 +116,7 @@ where
                             "Deserialization failure of subgraph response at path '{}': {err}",
                             self.ctx.display_path()
                         );
-                        let mut resp = ctx.subgraph_response.borrow_mut();
+                        let mut resp = ctx.response.borrow_mut();
                         resp.propagate_null(&ctx.path());
                         resp.push_error(
                             GraphqlError::invalid_subgraph_response()
@@ -130,7 +130,7 @@ where
             }
         }
 
-        ctx.subgraph_response.borrow_mut().data.put_list(list_id, list);
+        ctx.response.borrow_mut().data.put_list(list_id, list);
         Ok(list_id.into())
     }
 

--- a/crates/engine/src/response/write/deserialize/object/concrete.rs
+++ b/crates/engine/src/response/write/deserialize/object/concrete.rs
@@ -66,7 +66,7 @@ impl<'de> DeserializeSeed<'de> for ConcreteShapeSeed<'_, '_> {
         D: serde::Deserializer<'de>,
     {
         let shape = self.shape_id.walk(self.ctx);
-        let object_id = self.ctx.subgraph_response.borrow_mut().data.reserve_object_id();
+        let object_id = self.ctx.response.borrow_mut().data.reserve_object_id();
 
         Ok(self.post_process_fields_seed_result(
             shape,
@@ -84,7 +84,7 @@ impl<'ctx> ConcreteShapeSeed<'ctx, '_> {
         A: MapAccess<'de>,
     {
         let shape = self.shape_id.walk(self.ctx);
-        let object_id = self.ctx.subgraph_response.borrow_mut().data.reserve_object_id();
+        let object_id = self.ctx.response.borrow_mut().data.reserve_object_id();
 
         Ok(self.post_process_fields_seed_result(
             shape,
@@ -101,7 +101,7 @@ impl<'ctx> ConcreteShapeSeed<'ctx, '_> {
     ) -> ResponseValue {
         match object {
             ObjectValue::Some { definition_id, fields } => {
-                let mut resp = self.ctx.subgraph_response.borrow_mut();
+                let mut resp = self.ctx.response.borrow_mut();
                 resp.data
                     .put_object(object_id, ResponseObject::new(definition_id, fields));
 
@@ -134,7 +134,7 @@ impl<'ctx> ConcreteShapeSeed<'ctx, '_> {
                         self.ctx.display_path()
                     );
                     if self.parent_field.key.query_position.is_some() {
-                        let mut resp = self.ctx.subgraph_response.borrow_mut();
+                        let mut resp = self.ctx.response.borrow_mut();
                         let path = self.ctx.path();
                         resp.propagate_null(&path);
                         resp.push_error(
@@ -150,7 +150,7 @@ impl<'ctx> ConcreteShapeSeed<'ctx, '_> {
             }
             ObjectValue::Error(error) => {
                 if self.parent_field.key.query_position.is_some() {
-                    let mut resp = self.ctx.subgraph_response.borrow_mut();
+                    let mut resp = self.ctx.response.borrow_mut();
                     let path = self.ctx.path();
                     // If not required, we don't need to propagate as Unexpected is equivalent to
                     // null for users.
@@ -418,7 +418,7 @@ impl<'ctx> ConcreteShapeFieldsSeed<'ctx, '_> {
     fn post_process(&self, response_fields: &mut Vec<ResponseObjectField>) {
         if self.has_error {
             let mut must_propagate_null = false;
-            let mut resp = self.ctx.subgraph_response.borrow_mut();
+            let mut resp = self.ctx.response.borrow_mut();
             for field_shape in self.field_shape_ids.walk(self.ctx) {
                 for error in field_shape.errors() {
                     resp.push_error(
@@ -470,7 +470,7 @@ impl<'ctx> ConcreteShapeFieldsSeed<'ctx, '_> {
                                     self.ctx.display_path()
                                 )
                             }
-                            let mut resp = self.ctx.subgraph_response.borrow_mut();
+                            let mut resp = self.ctx.response.borrow_mut();
                             let path = self.ctx.path();
                             resp.propagate_null(&path);
                             resp.push_error(

--- a/crates/engine/src/response/write/deserialize/object/polymorphic.rs
+++ b/crates/engine/src/response/write/deserialize/object/polymorphic.rs
@@ -61,7 +61,7 @@ impl PolymorphicShapeSeed<'_, '_> {
         );
 
         if self.parent_field.key.query_position.is_some() {
-            let mut resp = self.ctx.subgraph_response.borrow_mut();
+            let mut resp = self.ctx.response.borrow_mut();
             let path = self.ctx.path();
             // If not required, we don't need to propagate as Unexpected is equivalent to
             // null for users.
@@ -173,7 +173,7 @@ impl<'de> Visitor<'de> for PolymorphicShapeSeed<'_, '_> {
                     // Adding empty object instead
                     Ok(self
                         .ctx
-                        .subgraph_response
+                        .response
                         .borrow_mut()
                         .data
                         .push_object(ResponseObject::new(Some(object_definition_id), Vec::new()))
@@ -189,7 +189,7 @@ impl<'de> Visitor<'de> for PolymorphicShapeSeed<'_, '_> {
         while map.next_entry::<IgnoredAny, IgnoredAny>()?.is_some() {}
 
         if self.parent_field.key.query_position.is_some() {
-            let mut resp = self.ctx.subgraph_response.borrow_mut();
+            let mut resp = self.ctx.response.borrow_mut();
             let path = self.ctx.path();
             // If not required, we don't need to propagate as Unexpected is equivalent to
             // null for users.

--- a/crates/engine/src/response/write/deserialize/scalar.rs
+++ b/crates/engine/src/response/write/deserialize/scalar.rs
@@ -44,7 +44,7 @@ impl ScalarTypeSeed<'_, '_> {
         );
 
         if self.parent_field.key.query_position.is_some() {
-            let mut resp = self.ctx.subgraph_response.borrow_mut();
+            let mut resp = self.ctx.response.borrow_mut();
             let path = self.ctx.path();
             // If not required, we don't need to propagate as Unexpected is equivalent to
             // null for users.
@@ -339,7 +339,7 @@ impl<'de> Visitor<'de> for ScalarTypeSeed<'_, '_> {
                     list.push(value);
                 }
                 Ok(ResponseValue::List {
-                    id: self.ctx.subgraph_response.borrow_mut().data.push_list(list),
+                    id: self.ctx.response.borrow_mut().data.push_list(list),
                 })
             }
             _ => {
@@ -368,7 +368,7 @@ impl<'de> Visitor<'de> for ScalarTypeSeed<'_, '_> {
                     key_values.push((key, value));
                 }
                 Ok(ResponseValue::Map {
-                    id: self.ctx.subgraph_response.borrow_mut().data.push_map(key_values),
+                    id: self.ctx.response.borrow_mut().data.push_map(key_values),
                 })
             }
             _ => {

--- a/crates/engine/src/response/write/merge.rs
+++ b/crates/engine/src/response/write/merge.rs
@@ -4,7 +4,7 @@ use crate::response::{ResponseListId, ResponseObjectField, ResponseObjectId, Res
 
 use super::ResponseBuilder;
 
-impl ResponseBuilder {
+impl ResponseBuilder<'_> {
     pub(super) fn recursive_merge_with_default_object(
         &mut self,
         object_id: ResponseObjectId,


### PR DESCRIPTION
Today the `ResponsePart`, which as the name suggests is a part of the
response written by a resolver, is tied to a specific shape (computed
from the GraphQL query). This doesn't work well with `@lookup` as we add
a root "virtual" GraphQL field inside the plan, taken into account for the
shape computation. For some resolver like GraphQL we have to use the
complete shape. For others, like extensions, we have to ignore this
top field.

Decoupling both makes it possible to handle this more finely.

I've also renamed `InputObjectId` and other naming like this to
`ParentObjectId` which should be clearer. I'm also adding a reference to
`Schema` & `PreparedOperation` inside the `ResponsePart`.
