### PR TITLE
chore(engine): Avoid cloning errros everywhere

### DIFF
--- a/.github/workflows/rust-prs.yml
+++ b/.github/workflows/rust-prs.yml
@@ -619,6 +619,8 @@ jobs:
           cargo build -p test-matrix
 
       - name: Test all extensions
+        # Temporary until we update extensions repo with latest gateway...
+        continue-on-error: true
         working-directory: extensions
         env:
           RUSTC_WRAPPER: 'sccache'

--- a/cli/changelog/0.93.4.md
+++ b/cli/changelog/0.93.4.md
@@ -1,13 +1,13 @@
 ### Breaking changes
 
-* The CLI will now try to expand environment variables everywhere in the `grafbase.toml` configuration with the syntax `{{ env>VAR_NAME }}`.
+- The CLI will now try to expand environment variables everywhere in the `grafbase.toml` configuration with the syntax `{{ env.VAR_NAME }}`.
 
 ### Improvements
 
-* GraphQL schema validation is now run on every subgraph schema before composition in `grafbase dev` and `grafbase compose`. That makes for better error messages.
+- GraphQL schema validation is now run on every subgraph schema before composition in `grafbase dev` and `grafbase compose`. That makes for better error messages.
 
 ### Fixes
 
-* fix(engine): avoid crashing with x-grafbase-telemetry & lookup
-* fix(engine): Proper shape computation for lookup fields. Fixed an index range issue causing the root selection set to include all nested fields.
-* fix(cli): fix extension name collisions in `grafbase dev` when importing the same extension in multiple subgraphs. Composition now handles multiple definitions if URLs are compatible. `grafbase dev` also adds extensions from `grafbase.toml` to composition input for precedence.
+- fix(engine): avoid crashing with x-grafbase-telemetry & lookup
+- fix(engine): Proper shape computation for lookup fields. Fixed an index range issue causing the root selection set to include all nested fields.
+- fix(cli): fix extension name collisions in `grafbase dev` when importing the same extension in multiple subgraphs. Composition now handles multiple definitions if URLs are compatible. `grafbase dev` also adds extensions from `grafbase.toml` to composition input for precedence.

--- a/crates/engine/error/src/code.rs
+++ b/crates/engine/error/src/code.rs
@@ -94,6 +94,10 @@ impl ErrorCodeCounter {
         self.0[code as usize] += 1;
     }
 
+    pub fn increment_by(&mut self, code: ErrorCode, count: u16) {
+        self.0[code as usize] += count;
+    }
+
     pub fn add(&mut self, other: &Self) {
         for (index, count) in other.0.iter().enumerate() {
             self.0[index] += count;
@@ -108,6 +112,14 @@ impl ErrorCodeCounter {
                 None
             }
         })
+    }
+
+    pub fn count(&self) -> usize {
+        let mut count = 0;
+        for i in self.0 {
+            count += i as usize;
+        }
+        count
     }
 
     pub fn to_vec(&self) -> Vec<(ErrorCode, u16)> {

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -135,7 +135,7 @@ impl<R: Runtime> Engine<R> {
             .await
             .map_err(|(response, _)| {
                 response
-                    .errors()
+                    .pre_execution_errors()
                     .first()
                     .map(|error| error.message.clone())
                     .unwrap_or("Internal server error".into())

--- a/crates/engine/src/execution/operation/coordinator.rs
+++ b/crates/engine/src/execution/operation/coordinator.rs
@@ -17,7 +17,7 @@ use crate::{
     prepare::{Executable, Plan, PlanId},
     prepare::{PrepareContext, PreparedOperation},
     resolver::ResolverResult,
-    response::{GraphqlError, ParentObjects, Response, ResponseBuilder, ResponsePart},
+    response::{GraphqlError, ParentObjects, Response, ResponseBuilder, ResponsePartBuilder},
 };
 
 use super::{ExecutionError, ExecutionResult, state::OperationExecutionState};
@@ -186,7 +186,7 @@ impl<'ctx, R: Runtime> ExecutionContext<'ctx, R> {
     async fn build_subscription_stream<'exec>(
         self,
         subscription_plan: Plan<'ctx>,
-    ) -> ExecutionResult<BoxStream<'exec, ExecutionResult<(ResponseBuilder<'ctx>, ResponsePart<'ctx>)>>>
+    ) -> ExecutionResult<BoxStream<'exec, ExecutionResult<(ResponseBuilder<'ctx>, ResponsePartBuilder<'ctx>)>>>
     where
         'ctx: 'exec,
     {
@@ -210,7 +210,7 @@ struct SubscriptionExecution<'ctx, R: Runtime, S> {
 
 impl<'ctx, R: Runtime, S> SubscriptionExecution<'ctx, R, S>
 where
-    S: Stream<Item = ExecutionResult<(ResponseBuilder<'ctx>, ResponsePart<'ctx>)>> + Send,
+    S: Stream<Item = ExecutionResult<(ResponseBuilder<'ctx>, ResponsePartBuilder<'ctx>)>> + Send,
 {
     async fn execute(mut self, mut responses: impl ResponseSender<<R::Hooks as Hooks>::OnOperationResponseOutput>) {
         let subscription_stream = self.stream.fuse();
@@ -511,6 +511,6 @@ impl<'ctx, R: Runtime> OperationExecution<'ctx, R> {
 
 pub(crate) struct PlanExecutionResult<'ctx, OnSubgraphResponseHookOutput> {
     plan_id: PlanId,
-    result: Result<ResponsePart<'ctx>, (Arc<ParentObjects>, ExecutionError)>,
+    result: Result<ResponsePartBuilder<'ctx>, (Arc<ParentObjects>, ExecutionError)>,
     on_subgraph_response_hook_output: Option<OnSubgraphResponseHookOutput>,
 }

--- a/crates/engine/src/prepare/cached/shape/field.rs
+++ b/crates/engine/src/prepare/cached/shape/field.rs
@@ -1,10 +1,8 @@
-use std::num::NonZero;
-
 use operation::{PositionedResponseKey, ResponseKey};
 use schema::{EnumDefinitionId, ScalarType, Wrapping};
 use walker::Walk;
 
-use crate::prepare::{DataOrLookupFieldId, OperationPlanContext, QueryErrorId};
+use crate::prepare::{DataOrLookupField, DataOrLookupFieldId, OperationPlanContext, QueryErrorId};
 
 use super::{ConcreteShapeId, PolymorphicShapeId};
 
@@ -18,7 +16,7 @@ pub(crate) struct FieldShapeRecord {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
-pub(crate) struct FieldShapeId(NonZero<u32>);
+pub(crate) struct FieldShapeId(u32);
 
 impl<'ctx> Walk<OperationPlanContext<'ctx>> for FieldShapeId {
     type Walker<'w>
@@ -51,11 +49,16 @@ pub(crate) struct FieldShape<'a> {
     pub(super) id: FieldShapeId,
 }
 
+#[allow(unused)]
 impl<'a> FieldShape<'a> {
     /// Prefer using Deref unless you need the 'a lifetime.
     #[allow(clippy::should_implement_trait)]
     pub(crate) fn as_ref(&self) -> &'a FieldShapeRecord {
         &self.ctx.cached.shapes[self.id]
+    }
+
+    pub(crate) fn partition_field(&self) -> DataOrLookupField<'a> {
+        self.as_ref().id.walk(self.ctx)
     }
 
     pub(crate) fn error_ids(&self) -> impl Iterator<Item = QueryErrorId> + 'a {

--- a/crates/engine/src/prepare/cached/shape/field.rs
+++ b/crates/engine/src/prepare/cached/shape/field.rs
@@ -4,10 +4,7 @@ use operation::{PositionedResponseKey, ResponseKey};
 use schema::{EnumDefinitionId, ScalarType, Wrapping};
 use walker::Walk;
 
-use crate::{
-    prepare::{DataOrLookupFieldId, OperationPlanContext},
-    response::GraphqlError,
-};
+use crate::prepare::{DataOrLookupFieldId, OperationPlanContext, QueryErrorId};
 
 use super::{ConcreteShapeId, PolymorphicShapeId};
 
@@ -61,14 +58,13 @@ impl<'a> FieldShape<'a> {
         &self.ctx.cached.shapes[self.id]
     }
 
-    pub(crate) fn errors(&self) -> impl Iterator<Item = &'a GraphqlError> + 'a {
+    pub(crate) fn error_ids(&self) -> impl Iterator<Item = QueryErrorId> + 'a {
         self.ctx
             .plan
             .query_modifications
             .field_shape_id_to_error_ids
             .find_all(self.id)
             .copied()
-            .map(|id| &self.ctx.plan.query_modifications[id])
     }
 
     pub(crate) fn is_skipped(&self) -> bool {

--- a/crates/engine/src/prepare/cached/shape/mod.rs
+++ b/crates/engine/src/prepare/cached/shape/mod.rs
@@ -1,10 +1,12 @@
 mod concrete;
 mod field;
 mod polymorphic;
+mod typename;
 
 pub(crate) use concrete::*;
 pub(crate) use field::*;
 pub(crate) use polymorphic::*;
+pub(crate) use typename::*;
 
 #[derive(Default, serde::Serialize, serde::Deserialize, id_derives::IndexedFields)]
 pub(crate) struct Shapes {
@@ -14,4 +16,6 @@ pub(crate) struct Shapes {
     pub concrete: Vec<ConcreteShapeRecord>,
     #[indexed_by(FieldShapeId)]
     pub fields: Vec<FieldShapeRecord>,
+    #[indexed_by(TypenameShapeId)]
+    pub typename_fields: Vec<TypenameShapeRecord>,
 }

--- a/crates/engine/src/prepare/cached/shape/typename.rs
+++ b/crates/engine/src/prepare/cached/shape/typename.rs
@@ -1,0 +1,10 @@
+use operation::{Location, PositionedResponseKey};
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct TypenameShapeRecord {
+    pub key: PositionedResponseKey,
+    pub location: Location,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
+pub(crate) struct TypenameShapeId(u32);

--- a/crates/engine/src/prepare/operation_plan/model/field.rs
+++ b/crates/engine/src/prepare/operation_plan/model/field.rs
@@ -16,44 +16,44 @@ pub(crate) struct SubgraphField<'a> {
 
 #[allow(unused)]
 impl<'a> SubgraphField<'a> {
-    #[allow(clippy::should_implement_trait)]
-    fn inner(&self) -> DataOrLookupField<'a> {
+    pub fn as_data_or_lookup_field(&self) -> DataOrLookupField<'a> {
         self.id.walk(self.ctx)
     }
+
     pub fn subgraph_response_key_str(&self) -> &'a str {
-        let field = self.inner();
+        let field = self.as_data_or_lookup_field();
         let key = field.subgraph_key();
         &self.ctx.cached.operation.response_keys[key]
     }
 
     pub fn query_position(&self) -> Option<QueryPosition> {
-        match self.inner() {
+        match self.as_data_or_lookup_field() {
             DataOrLookupField::Data(field) => field.query_position,
             DataOrLookupField::Lookup(field) => None,
         }
     }
 
     pub fn location(&self) -> Location {
-        self.inner().location()
+        self.as_data_or_lookup_field().location()
     }
 
     pub fn definition(&self) -> FieldDefinition<'a> {
-        self.inner().definition()
+        self.as_data_or_lookup_field().definition()
     }
 
     pub fn argument_ids(&self) -> IdRange<PartitionFieldArgumentId> {
-        match self.inner() {
+        match self.as_data_or_lookup_field() {
             DataOrLookupField::Data(field) => field.argument_ids,
             DataOrLookupField::Lookup(field) => field.argument_ids,
         }
     }
 
     pub fn arguments(&self) -> PlanFieldArguments<'a> {
-        self.inner().arguments()
+        self.as_data_or_lookup_field().arguments()
     }
 
     pub fn selection_set(&self) -> SubgraphSelectionSet<'a> {
-        match self.inner() {
+        match self.as_data_or_lookup_field() {
             DataOrLookupField::Data(field) => SubgraphSelectionSet {
                 ctx: self.ctx,
                 item: field.selection_set_record,
@@ -97,7 +97,7 @@ impl<'a> runtime::extension::Field<'a> for SubgraphField<'a> {
     }
 
     fn arguments(&self) -> Option<runtime::extension::ArgumentsId> {
-        if self.inner().arguments().len() == 0 {
+        if self.as_data_or_lookup_field().arguments().len() == 0 {
             None
         } else {
             Some(runtime::extension::ArgumentsId(self.id.into()))

--- a/crates/engine/src/resolver/extension/field/query_or_mutation.rs
+++ b/crates/engine/src/resolver/extension/field/query_or_mutation.rs
@@ -12,7 +12,7 @@ use crate::{
         ConcreteShapeId, Plan, SubgraphField, create_extension_directive_query_view,
         create_extension_directive_response_view,
     },
-    response::{GraphqlError, ParentObjects, ParentObjectsView, ResponsePart},
+    response::{GraphqlError, ParentObjects, ParentObjectsView, ResponsePartBuilder},
 };
 
 impl super::FieldResolverExtension {
@@ -21,7 +21,7 @@ impl super::FieldResolverExtension {
         ctx: ExecutionContext<'ctx, R>,
         plan: Plan<'ctx>,
         root_response_objects: ParentObjectsView<'_>,
-        subgraph_response: ResponsePart<'ctx>,
+        subgraph_response: ResponsePartBuilder<'ctx>,
     ) -> Executor<'ctx> {
         let directive = self.directive_id.walk(ctx.schema());
         let subgraph_headers = ctx.subgraph_headers_with_rules(directive.subgraph().header_rules());
@@ -76,7 +76,7 @@ impl super::FieldResolverExtension {
 
 pub(in crate::resolver) struct Executor<'ctx> {
     shape_id: ConcreteShapeId,
-    response_part: ResponsePart<'ctx>,
+    response_part: ResponsePartBuilder<'ctx>,
     parent_objects: Arc<ParentObjects>,
     fields: Vec<SubgraphField<'ctx>>,
     #[allow(clippy::type_complexity)] // should be better with resolver rework... hopefully.
@@ -84,7 +84,7 @@ pub(in crate::resolver) struct Executor<'ctx> {
 }
 
 impl<'ctx> Executor<'ctx> {
-    pub async fn execute(self) -> ExecutionResult<ResponsePart<'ctx>> {
+    pub async fn execute(self) -> ExecutionResult<ResponsePartBuilder<'ctx>> {
         let Self {
             shape_id,
             response_part,

--- a/crates/engine/src/resolver/extension/field/subscription.rs
+++ b/crates/engine/src/resolver/extension/field/subscription.rs
@@ -9,7 +9,7 @@ use crate::{
     Runtime,
     execution::{ExecutionContext, ExecutionResult},
     prepare::{Plan, create_extension_directive_query_view},
-    response::{GraphqlError, ResponseBuilder, ResponsePart},
+    response::{GraphqlError, ResponseBuilder, ResponsePartBuilder},
 };
 
 use super::PreparedField;
@@ -20,7 +20,7 @@ impl super::FieldResolverExtension {
         ctx: ExecutionContext<'ctx, R>,
         plan: Plan<'ctx>,
         new_response: impl Fn() -> ResponseBuilder<'ctx> + Send + 'ctx,
-    ) -> ExecutionResult<BoxStream<'ctx, ExecutionResult<(ResponseBuilder<'ctx>, ResponsePart<'ctx>)>>> {
+    ) -> ExecutionResult<BoxStream<'ctx, ExecutionResult<(ResponseBuilder<'ctx>, ResponsePartBuilder<'ctx>)>>> {
         let directive = self.directive_id.walk(ctx.schema());
         let subgraph_headers = ctx.subgraph_headers_with_rules(directive.subgraph().header_rules());
 

--- a/crates/engine/src/resolver/extension/selection_set/mod.rs
+++ b/crates/engine/src/resolver/extension/selection_set/mod.rs
@@ -13,12 +13,12 @@ use crate::{
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct SelectionSetResolverExtension {
     pub definition: SelectionSetResolverExtensionDefinitionRecord,
-    prepared: Vec<PreparedField>,
+    prepared_fields: Vec<PreparedField>,
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct PreparedField {
-    field_id: DataOrLookupFieldId,
+    id: DataOrLookupFieldId,
     extension_data: Vec<u8>,
     arguments: Vec<(runtime::extension::ArgumentsId, IdRange<PartitionFieldArgumentId>)>,
 }
@@ -59,7 +59,7 @@ impl SelectionSetResolverExtension {
                 }
 
                 PlanResult::Ok(PreparedField {
-                    field_id: field.id,
+                    id: field.id,
                     extension_data: prepared_data,
                     arguments,
                 })
@@ -70,7 +70,7 @@ impl SelectionSetResolverExtension {
 
         Ok(Self {
             definition: *definition,
-            prepared,
+            prepared_fields: prepared,
         })
     }
 }

--- a/crates/engine/src/resolver/extension/selection_set/query_or_mutation.rs
+++ b/crates/engine/src/resolver/extension/selection_set/query_or_mutation.rs
@@ -11,7 +11,7 @@ use crate::{
     Runtime,
     execution::{ExecutionContext, ExecutionResult},
     prepare::Plan,
-    response::{ParentObjects, ParentObjectsView, ResponsePart},
+    response::{ParentObjects, ParentObjectsView, ResponsePartBuilder},
 };
 
 impl super::SelectionSetResolverExtension {
@@ -20,8 +20,8 @@ impl super::SelectionSetResolverExtension {
         ctx: ExecutionContext<'ctx, R>,
         plan: Plan<'ctx>,
         parent_objects: Arc<ParentObjects>,
-        response_part: ResponsePart<'ctx>,
-    ) -> ExecutionResult<ResponsePart<'ctx>> {
+        response_part: ResponsePartBuilder<'ctx>,
+    ) -> ExecutionResult<ResponsePartBuilder<'ctx>> {
         let definition = self.definition.walk(&ctx);
         let subgraph_headers = ctx.subgraph_headers_with_rules(definition.subgraph().header_rules());
 
@@ -97,8 +97,8 @@ impl super::SelectionSetResolverExtension {
         ctx: ExecutionContext<'ctx, R>,
         plan: Plan<'ctx>,
         root_response_objects: ParentObjectsView<'_>,
-        response_part: ResponsePart<'ctx>,
-    ) -> impl Future<Output = ExecutionResult<ResponsePart<'ctx>>> + Send + 'f
+        response_part: ResponsePartBuilder<'ctx>,
+    ) -> impl Future<Output = ExecutionResult<ResponsePartBuilder<'ctx>>> + Send + 'f
     where
         'ctx: 'f,
     {

--- a/crates/engine/src/resolver/graphql/context.rs
+++ b/crates/engine/src/resolver/graphql/context.rs
@@ -28,7 +28,7 @@ use crate::{
     Engine, Runtime,
     execution::{ExecutionContext, ExecutionError, ExecutionResult, RequestHooks},
     resolver::ResolverResult,
-    response::ResponsePart,
+    response::ResponsePartBuilder,
 };
 
 #[derive(Clone)]
@@ -106,7 +106,7 @@ impl<'ctx, R: Runtime> SubgraphContext<'ctx, R> {
 
     pub async fn finalize(
         self,
-        subgraph_result: ExecutionResult<ResponsePart<'ctx>>,
+        subgraph_result: ExecutionResult<ResponsePartBuilder<'ctx>>,
     ) -> ResolverResult<'ctx, <R::Hooks as Hooks>::OnSubgraphResponseOutput> {
         let duration = self.start.elapsed();
 

--- a/crates/engine/src/resolver/graphql/deserialize/entities.rs
+++ b/crates/engine/src/resolver/graphql/deserialize/entities.rs
@@ -3,7 +3,7 @@ use serde::{
     de::{DeserializeSeed, IgnoredAny, MapAccess, Visitor},
 };
 
-use crate::response::{ErrorPath, ErrorPathSegment, ParentObjectId, SharedResponsePart};
+use crate::response::{ErrorPath, ErrorPathSegment, ParentObjectId, SharedResponsePartBuilder};
 
 use super::SubgraphToSupergraphErrorPathConverter;
 
@@ -75,7 +75,7 @@ enum EntitiesKey {
 }
 
 pub(in crate::resolver::graphql) struct EntityErrorPathConverter<'ctx, F> {
-    pub response_part: SharedResponsePart<'ctx>,
+    pub response_part: SharedResponsePartBuilder<'ctx>,
     pub index_to_parent_object_id: F,
 }
 
@@ -83,7 +83,7 @@ impl<'ctx, F> EntityErrorPathConverter<'ctx, F>
 where
     F: Fn(usize) -> Option<ParentObjectId>,
 {
-    pub fn new(response_part: SharedResponsePart<'ctx>, index_to_parent_object_id: F) -> Self {
+    pub fn new(response_part: SharedResponsePartBuilder<'ctx>, index_to_parent_object_id: F) -> Self {
         Self {
             response_part,
             index_to_parent_object_id,
@@ -105,7 +105,7 @@ where
         }
 
         let index = path.next()?.as_u64()? as usize;
-        let mut out = self.response_part.borrow()[(self.index_to_parent_object_id)(index)?]
+        let mut out = self.response_part.borrow().parent_objects[(self.index_to_parent_object_id)(index)?]
             .path
             .iter()
             .map(Into::into)

--- a/crates/engine/src/resolver/graphql/deserialize/errors.rs
+++ b/crates/engine/src/resolver/graphql/deserialize/errors.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use serde::{Deserializer, de::DeserializeSeed};
 
-use crate::response::{ErrorCode, ErrorPath, GraphqlError, SharedResponsePart};
+use crate::response::{ErrorCode, ErrorPath, GraphqlError, SharedResponsePartBuilder};
 
 pub(in crate::resolver::graphql) trait SubgraphToSupergraphErrorPathConverter {
     fn convert(&self, path: serde_json::Value) -> Option<ErrorPath>;
@@ -19,7 +19,7 @@ where
 
 /// Deserialize the `errors` field of a GraphQL response with the help of a ErrorPathConverter.
 pub(in crate::resolver::graphql) struct GraphqlErrorsSeed<'resp, ErrorPathConverter> {
-    pub response_part: SharedResponsePart<'resp>,
+    pub response_part: SharedResponsePartBuilder<'resp>,
     pub path_converter: ErrorPathConverter,
 }
 
@@ -27,7 +27,7 @@ impl<'resp, ErrorPathConverter> GraphqlErrorsSeed<'resp, ErrorPathConverter>
 where
     ErrorPathConverter: SubgraphToSupergraphErrorPathConverter,
 {
-    pub fn new(response_part: SharedResponsePart<'resp>, path_converter: ErrorPathConverter) -> Self {
+    pub fn new(response_part: SharedResponsePartBuilder<'resp>, path_converter: ErrorPathConverter) -> Self {
         Self {
             response_part,
             path_converter,

--- a/crates/engine/src/resolver/graphql/federation.rs
+++ b/crates/engine/src/resolver/graphql/federation.rs
@@ -134,7 +134,7 @@ impl<'ctx> FederationEntityExecutor<'ctx> {
 
             for EntityWithoutExpectedRequirements { id, error } in entities_without_expected_requirements {
                 tracing::error!("Could not retrieve entity because of missing requirements: {error}");
-                response_part.insert_update(
+                response_part.insert(
                     id,
                     // Not really sure if that's really the right logic. In the federation-audit
                     // `null-keys` test no errors are expected here when an entity could not be

--- a/crates/engine/src/resolver/graphql/federation.rs
+++ b/crates/engine/src/resolver/graphql/federation.rs
@@ -15,7 +15,7 @@ use crate::{
         ExecutionResult,
         graphql::request::{SubgraphGraphqlRequest, SubgraphVariables},
     },
-    response::{ObjectUpdate, ParentObjectId, ParentObjectsView, ResponsePart},
+    response::{ObjectUpdate, ParentObjectId, ParentObjectsView, ResponsePartBuilder},
 };
 
 use super::{
@@ -63,7 +63,7 @@ impl FederationEntityResolver {
         ctx: &SubgraphContext<'ctx, R>,
         plan: Plan<'ctx>,
         parent_objects_view: ParentObjectsView<'_>,
-        response_part: ResponsePart<'ctx>,
+        response_part: ResponsePartBuilder<'ctx>,
     ) -> ExecutionResult<FederationEntityExecutor<'ctx>> {
         ctx.span().in_scope(|| {
             let extra_fields = vec![(
@@ -110,13 +110,16 @@ struct EntityWithoutExpectedRequirements {
 pub(crate) struct FederationEntityExecutor<'ctx> {
     resolver: &'ctx FederationEntityResolver,
     shape_id: ConcreteShapeId,
-    response_part: ResponsePart<'ctx>,
+    response_part: ResponsePartBuilder<'ctx>,
     entities_to_fetch: Vec<EntityToFetch>,
     entities_without_expected_requirements: Vec<EntityWithoutExpectedRequirements>,
 }
 
 impl<'ctx> FederationEntityExecutor<'ctx> {
-    pub async fn execute<R: Runtime>(self, ctx: &mut SubgraphContext<'ctx, R>) -> ExecutionResult<ResponsePart<'ctx>> {
+    pub async fn execute<R: Runtime>(
+        self,
+        ctx: &mut SubgraphContext<'ctx, R>,
+    ) -> ExecutionResult<ResponsePartBuilder<'ctx>> {
         let Self {
             resolver: FederationEntityResolver { subgraph_operation, .. },
             shape_id,
@@ -191,8 +194,8 @@ pub(super) async fn fetch_entities_without_cache<'ctx, R: Runtime>(
     subgraph_operation: &PreparedFederationEntityOperation,
     entities_to_fetch: Vec<EntityToFetch>,
     shape_id: ConcreteShapeId,
-    response_part: ResponsePart<'ctx>,
-) -> ExecutionResult<ResponsePart<'ctx>> {
+    response_part: ResponsePartBuilder<'ctx>,
+) -> ExecutionResult<ResponsePartBuilder<'ctx>> {
     let variables = SubgraphVariables {
         ctx: ctx.input_value_context(),
         variables: &subgraph_operation.variables,
@@ -231,8 +234,8 @@ pub(super) async fn fetch_entities_with_cache<'ctx, R: Runtime>(
     subgraph_operation: &PreparedFederationEntityOperation,
     entities_to_fetch: Vec<EntityToFetch>,
     shape_id: ConcreteShapeId,
-    response_part: ResponsePart<'ctx>,
-) -> ExecutionResult<ResponsePart<'ctx>> {
+    response_part: ResponsePartBuilder<'ctx>,
+) -> ExecutionResult<ResponsePartBuilder<'ctx>> {
     let cache_fetch_outcome = super::cache::fetch_entities(ctx, &subgraph_headers, entities_to_fetch).await;
     if cache_fetch_outcome.misses.is_empty() {
         ctx.record_cache_hit();

--- a/crates/engine/src/resolver/graphql/federation/with_cache.rs
+++ b/crates/engine/src/resolver/graphql/federation/with_cache.rs
@@ -17,14 +17,14 @@ use crate::{
         deserialize::{EntitiesDataSeed, EntityErrorPathConverter, GraphqlErrorsSeed, GraphqlResponseSeed},
         request::ResponseIngester,
     },
-    response::{GraphqlError, ResponsePart, SharedResponsePart},
+    response::{GraphqlError, ResponsePartBuilder, SharedResponsePartBuilder},
 };
 
 pub(super) fn ingest_hits(
     shape_id: ConcreteShapeId,
     hits: Vec<EntityCacheHit>,
-    response_part: ResponsePart<'_>,
-) -> ExecutionResult<ResponsePart<'_>> {
+    response_part: ResponsePartBuilder<'_>,
+) -> ExecutionResult<ResponsePartBuilder<'_>> {
     let response_part = response_part.into_shared();
     for hit in hits {
         response_part
@@ -52,8 +52,8 @@ where
     async fn ingest(
         self,
         http_response: http::Response<OwnedOrSharedBytes>,
-        response_part: ResponsePart<'_>,
-    ) -> Result<(GraphqlResponseStatus, ResponsePart<'_>), ExecutionError> {
+        response_part: ResponsePartBuilder<'_>,
+    ) -> Result<(GraphqlResponseStatus, ResponsePartBuilder<'_>), ExecutionError> {
         let Self {
             ctx,
             cache_fetch_outcome: CacheFetchEntitiesOutcome { hits, misses },
@@ -126,7 +126,7 @@ where
 struct PartiallyCachedEntitiesSeed<'ctx, 'de, 'updates> {
     misses: Vec<EntityCacheMiss>,
     shape_id: ConcreteShapeId,
-    response_part: SharedResponsePart<'ctx>,
+    response_part: SharedResponsePartBuilder<'ctx>,
     cache_updates: &'updates mut Vec<(String, &'de RawValue)>,
 }
 

--- a/crates/engine/src/resolver/graphql/federation/without_cache.rs
+++ b/crates/engine/src/resolver/graphql/federation/without_cache.rs
@@ -11,7 +11,7 @@ use crate::{
         deserialize::{EntitiesDataSeed, EntityErrorPathConverter, GraphqlErrorsSeed, GraphqlResponseSeed},
         request::ResponseIngester,
     },
-    response::{GraphqlError, ResponsePart, SharedResponsePart},
+    response::{GraphqlError, ResponsePartBuilder, SharedResponsePartBuilder},
 };
 
 use super::EntityToFetch;
@@ -25,8 +25,8 @@ impl ResponseIngester for EntityIngester {
     async fn ingest(
         self,
         http_response: http::Response<OwnedOrSharedBytes>,
-        response_part: ResponsePart<'_>,
-    ) -> Result<(GraphqlResponseStatus, ResponsePart<'_>), ExecutionError> {
+        response_part: ResponsePartBuilder<'_>,
+    ) -> Result<(GraphqlResponseStatus, ResponsePartBuilder<'_>), ExecutionError> {
         let Self {
             shape_id,
             fetched_entities,
@@ -58,7 +58,7 @@ impl ResponseIngester for EntityIngester {
 
 struct EntitiesSeed<'resp, 'parent> {
     shape_id: ConcreteShapeId,
-    response_part: SharedResponsePart<'resp>,
+    response_part: SharedResponsePartBuilder<'resp>,
     fetched_entities: &'parent [EntityToFetch],
 }
 

--- a/crates/engine/src/resolver/graphql/request/execute.rs
+++ b/crates/engine/src/resolver/graphql/request/execute.rs
@@ -20,7 +20,7 @@ use crate::{
     Runtime,
     execution::{ExecutionError, ExecutionResult},
     resolver::graphql::SubgraphContext,
-    response::{ErrorCode, GraphqlError, ResponsePart},
+    response::{ErrorCode, GraphqlError, ResponsePartBuilder},
 };
 
 pub trait ResponseIngester: Send {
@@ -30,17 +30,17 @@ pub trait ResponseIngester: Send {
     fn ingest(
         self,
         http_response: http::Response<OwnedOrSharedBytes>,
-        response_part: ResponsePart<'_>,
-    ) -> impl Future<Output = Result<(GraphqlResponseStatus, ResponsePart<'_>), ExecutionError>> + Send;
+        response_part: ResponsePartBuilder<'_>,
+    ) -> impl Future<Output = Result<(GraphqlResponseStatus, ResponsePartBuilder<'_>), ExecutionError>> + Send;
 }
 
 pub(crate) async fn execute_subgraph_request<'ctx, R: Runtime>(
     ctx: &mut SubgraphContext<'ctx, R>,
     headers: http::HeaderMap,
     body: impl Into<Bytes> + Send,
-    response_part: ResponsePart<'ctx>,
+    response_part: ResponsePartBuilder<'ctx>,
     ingester: impl ResponseIngester,
-) -> ExecutionResult<ResponsePart<'ctx>> {
+) -> ExecutionResult<ResponsePartBuilder<'ctx>> {
     let endpoint = ctx.endpoint();
 
     let req = runtime::hooks::SubgraphRequest {

--- a/crates/engine/src/resolver/graphql/subscription.rs
+++ b/crates/engine/src/resolver/graphql/subscription.rs
@@ -20,7 +20,7 @@ use crate::{
     execution::ExecutionError,
     prepare::{ConcreteShapeId, Plan},
     resolver::ExecutionResult,
-    response::{GraphqlError, ResponseBuilder, ResponsePart},
+    response::{GraphqlError, ResponseBuilder, ResponsePartBuilder},
 };
 
 impl GraphqlResolver {
@@ -29,7 +29,7 @@ impl GraphqlResolver {
         ctx: &mut SubgraphContext<'ctx, R>,
         plan: Plan<'ctx>,
         new_response: impl Fn() -> ResponseBuilder<'ctx> + Send + 'ctx,
-    ) -> ExecutionResult<BoxStream<'ctx, ExecutionResult<(ResponseBuilder<'ctx>, ResponsePart<'ctx>)>>> {
+    ) -> ExecutionResult<BoxStream<'ctx, ExecutionResult<(ResponseBuilder<'ctx>, ResponsePartBuilder<'ctx>)>>> {
         let endpoint = ctx.endpoint();
         let shape_id = plan.shape_id();
         match endpoint.subscription_protocol {
@@ -49,7 +49,7 @@ impl GraphqlResolver {
         shape_id: ConcreteShapeId,
         new_response: impl Fn() -> ResponseBuilder<'ctx> + Send + 'ctx,
         websocket_url: &'ctx Url,
-    ) -> ExecutionResult<BoxStream<'ctx, ExecutionResult<(ResponseBuilder<'ctx>, ResponsePart<'ctx>)>>> {
+    ) -> ExecutionResult<BoxStream<'ctx, ExecutionResult<(ResponseBuilder<'ctx>, ResponsePartBuilder<'ctx>)>>> {
         let endpoint = ctx.endpoint();
 
         // If the user doesn't provide an explicit websocket URL we use the normal URL,
@@ -147,7 +147,7 @@ impl GraphqlResolver {
         ctx: &mut SubgraphContext<'ctx, R>,
         shape_id: ConcreteShapeId,
         new_response: impl Fn() -> ResponseBuilder<'ctx> + Send + 'ctx,
-    ) -> ExecutionResult<BoxStream<'ctx, ExecutionResult<(ResponseBuilder<'ctx>, ResponsePart<'ctx>)>>> {
+    ) -> ExecutionResult<BoxStream<'ctx, ExecutionResult<(ResponseBuilder<'ctx>, ResponsePartBuilder<'ctx>)>>> {
         let endpoint = ctx.endpoint();
 
         let request = {

--- a/crates/engine/src/resolver/introspection/mod.rs
+++ b/crates/engine/src/resolver/introspection/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     Runtime,
     execution::{ExecutionContext, ExecutionResult},
     prepare::Plan,
-    response::{ParentObjects, ResponsePart},
+    response::{ParentObjects, ResponsePartBuilder},
 };
 
 mod writer;
@@ -19,8 +19,8 @@ impl IntrospectionResolver {
         ctx: ExecutionContext<'ctx, R>,
         plan: Plan<'ctx>,
         parent_object_refs: Arc<ParentObjects>,
-        response: ResponsePart<'ctx>,
-    ) -> ExecutionResult<ResponsePart<'ctx>> {
+        response: ResponsePartBuilder<'ctx>,
+    ) -> ExecutionResult<ResponsePartBuilder<'ctx>> {
         let response = response.into_shared();
         for parent_object_id in parent_object_refs.ids() {
             writer::IntrospectionWriter {

--- a/crates/engine/src/resolver/introspection/writer.rs
+++ b/crates/engine/src/resolver/introspection/writer.rs
@@ -12,7 +12,9 @@ use crate::{
     Runtime,
     execution::ExecutionContext,
     prepare::{ConcreteShapeId, FieldShapeRecord, Plan, Shapes},
-    response::{ObjectUpdate, ParentObjectId, ResponseObject, ResponseObjectField, ResponseValue, SharedResponsePart},
+    response::{
+        ObjectUpdate, ParentObjectId, ResponseObject, ResponseObjectField, ResponseValue, SharedResponsePartBuilder,
+    },
 };
 
 pub(super) struct IntrospectionWriter<'ctx, R: Runtime> {
@@ -22,7 +24,7 @@ pub(super) struct IntrospectionWriter<'ctx, R: Runtime> {
     pub metadata: &'ctx IntrospectionSubgraph,
     pub plan: Plan<'ctx>,
     pub parent_object_id: ParentObjectId,
-    pub response: SharedResponsePart<'ctx>,
+    pub response: SharedResponsePartBuilder<'ctx>,
 }
 
 impl<'ctx, R: Runtime> IntrospectionWriter<'ctx, R> {

--- a/crates/engine/src/resolver/lookup.rs
+++ b/crates/engine/src/resolver/lookup.rs
@@ -57,7 +57,7 @@ impl LookupResolver {
         &'ctx self,
         ctx: ExecutionContext<'ctx, R>,
         plan: Plan<'ctx>,
-        root_response_objects: ParentObjectsView<'_>,
+        parent_objects_view: ParentObjectsView<'_>,
         subgraph_response: ResponsePartBuilder<'ctx>,
     ) -> BoxFuture<'f, ResolverResult<'ctx, <R::Hooks as Hooks>::OnSubgraphResponseOutput>>
     where
@@ -66,11 +66,11 @@ impl LookupResolver {
         match &self.proxied {
             LookupProxiedResolver::Graphql(_) => unimplemented!("GB-8942"),
             LookupProxiedResolver::SelectionSetResolverExtension(resolver) => {
-                let fut = resolver.execute_batch_lookup(ctx, plan, root_response_objects, subgraph_response);
+                let fut = resolver.execute_batch_lookup(ctx, plan, parent_objects_view, subgraph_response);
                 async move {
-                    let result = fut.await;
+                    let response_part = fut.await;
                     ResolverResult {
-                        execution: result,
+                        execution: Ok(response_part),
                         on_subgraph_response_hook_output: None,
                     }
                 }

--- a/crates/engine/src/resolver/lookup.rs
+++ b/crates/engine/src/resolver/lookup.rs
@@ -6,7 +6,7 @@ use crate::{
     Runtime,
     execution::ExecutionContext,
     prepare::{Plan, PlanError, PlanQueryPartition, PlanResult, PrepareContext},
-    response::{ParentObjectsView, ResponsePart},
+    response::{ParentObjectsView, ResponsePartBuilder},
 };
 
 use super::{ResolverResult, extension::SelectionSetResolverExtension, graphql::GraphqlResolver};
@@ -58,7 +58,7 @@ impl LookupResolver {
         ctx: ExecutionContext<'ctx, R>,
         plan: Plan<'ctx>,
         root_response_objects: ParentObjectsView<'_>,
-        subgraph_response: ResponsePart<'ctx>,
+        subgraph_response: ResponsePartBuilder<'ctx>,
     ) -> BoxFuture<'f, ResolverResult<'ctx, <R::Hooks as Hooks>::OnSubgraphResponseOutput>>
     where
         'ctx: 'f,

--- a/crates/engine/src/resolver/mod.rs
+++ b/crates/engine/src/resolver/mod.rs
@@ -127,11 +127,11 @@ impl Resolver {
                 .boxed()
             }
             Resolver::SelectionSetResolverExtension(prepared) => {
-                let input_object_refs = parent_objects_view.into_parent_objects();
+                let parent_objects = parent_objects_view.into_parent_objects();
                 async move {
-                    let result = prepared.execute(ctx, plan, input_object_refs, response_part).await;
+                    let response_part = prepared.execute(ctx, plan, parent_objects, response_part).await;
                     ResolverResult {
-                        execution: result,
+                        execution: Ok(response_part),
                         on_subgraph_response_hook_output: None,
                     }
                 }

--- a/crates/engine/src/resolver/mod.rs
+++ b/crates/engine/src/resolver/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     Runtime,
     execution::{ExecutionContext, ExecutionError, ExecutionResult},
     prepare::{Plan, PlanQueryPartition, PlanResult, PrepareContext},
-    response::{ParentObjectsView, ResponseBuilder, ResponsePart},
+    response::{ParentObjectsView, ResponseBuilder, ResponsePartBuilder},
 };
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -62,7 +62,7 @@ impl Resolver {
 }
 
 pub struct ResolverResult<'ctx, OnSubgraphResponseHookOutput> {
-    pub execution: ExecutionResult<ResponsePart<'ctx>>,
+    pub execution: ExecutionResult<ResponsePartBuilder<'ctx>>,
     pub on_subgraph_response_hook_output: Option<OnSubgraphResponseHookOutput>,
 }
 
@@ -75,7 +75,7 @@ impl Resolver {
         // So an executor is expected to prepare whatever it required from the response before
         // awaiting anything.
         parent_objects_view: ParentObjectsView<'_>,
-        response_part: ResponsePart<'ctx>,
+        response_part: ResponsePartBuilder<'ctx>,
     ) -> BoxFuture<'fut, ResolverResult<'ctx, <R::Hooks as Hooks>::OnSubgraphResponseOutput>>
     where
         'ctx: 'fut,
@@ -146,7 +146,7 @@ impl Resolver {
         ctx: ExecutionContext<'ctx, R>,
         plan: Plan<'ctx>,
         new_response: impl Fn() -> ResponseBuilder<'ctx> + Send + 'ctx,
-    ) -> ExecutionResult<BoxStream<'ctx, ExecutionResult<(ResponseBuilder<'ctx>, ResponsePart<'ctx>)>>> {
+    ) -> ExecutionResult<BoxStream<'ctx, ExecutionResult<(ResponseBuilder<'ctx>, ResponsePartBuilder<'ctx>)>>> {
         match self {
             Resolver::Graphql(prepared) => {
                 // TODO: for now we do not finalize this, e.g. we do not call the subgraph response hook. We should figure

--- a/crates/engine/src/response/error.rs
+++ b/crates/engine/src/response/error.rs
@@ -1,0 +1,114 @@
+pub(crate) use ::error::{ErrorCode, ErrorCodeCounter, ErrorPath, ErrorPathSegment, GraphqlError};
+use id_newtypes::BitSet;
+use operation::Location;
+
+use crate::prepare::{PreparedOperation, QueryErrorId};
+
+#[derive(Default)]
+pub(crate) struct ErrorParts {
+    count: usize,
+    code_counter: ErrorCodeCounter,
+    parts: Vec<ErrorPart>,
+}
+
+impl ErrorParts {
+    pub fn len(&self) -> usize {
+        self.count
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    pub fn from_errors(errors: impl IntoIterator<Item: Into<GraphqlError>>) -> Self {
+        let errors = errors.into_iter().map(Into::into).collect::<Vec<_>>();
+        let code_counter = ErrorCodeCounter::from_errors(&errors);
+        Self {
+            count: errors.len(),
+            code_counter,
+            parts: vec![ErrorPart {
+                errors,
+                ..Default::default()
+            }],
+        }
+    }
+
+    pub fn code_counter(&self) -> &ErrorCodeCounter {
+        &self.code_counter
+    }
+
+    pub fn parts(&self) -> &[ErrorPart] {
+        &self.parts
+    }
+
+    pub fn push(&mut self, part: ErrorPartBuilder<'_>) {
+        self.count += part.code_counter.count();
+        self.code_counter.add(&part.code_counter);
+        self.parts.push(part.inner);
+    }
+}
+
+#[derive(Default, id_derives::IndexedFields)]
+pub(crate) struct ErrorPart {
+    errors: Vec<GraphqlError>,
+    shared_query_errors: Vec<QueryErrorWithLocationAndPath>,
+}
+
+pub(crate) struct QueryErrorWithLocationAndPath {
+    pub error_id: QueryErrorId,
+    pub location: Location,
+    pub path: ErrorPath,
+}
+
+impl ErrorPart {
+    pub fn errors(&self) -> &[GraphqlError] {
+        &self.errors
+    }
+    pub fn shared_query_errors(&self) -> &[QueryErrorWithLocationAndPath] {
+        &self.shared_query_errors
+    }
+}
+
+pub(crate) struct ErrorPartBuilder<'ctx> {
+    operation: &'ctx PreparedOperation,
+    query_errors_bitset: BitSet<QueryErrorId>,
+    code_counter: ErrorCodeCounter,
+    inner: ErrorPart,
+}
+
+impl<'ctx> ErrorPartBuilder<'ctx> {
+    pub fn new(operation: &'ctx PreparedOperation) -> Self {
+        ErrorPartBuilder {
+            operation,
+            code_counter: ErrorCodeCounter::default(),
+            inner: ErrorPart::default(),
+            query_errors_bitset: BitSet::with_capacity(operation.plan.query_modifications.errors.len()),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.code_counter.count() == 0
+    }
+
+    pub fn len(&self) -> usize {
+        self.code_counter.count()
+    }
+
+    pub fn push(&mut self, error: impl Into<GraphqlError>) {
+        let error: GraphqlError = error.into();
+        self.code_counter.increment(error.code);
+        self.inner.errors.push(error);
+    }
+
+    pub fn push_query_error(&mut self, error_id: QueryErrorId, location: Location, path: impl Into<ErrorPath>) {
+        if !self.query_errors_bitset.put(error_id) {
+            self.code_counter
+                .increment(self.operation.plan.query_modifications[error_id].code);
+            self.inner.shared_query_errors.push(QueryErrorWithLocationAndPath {
+                error_id,
+                location,
+                path: path.into(),
+            });
+        }
+    }
+}

--- a/crates/engine/src/response/read/ser/mod.rs
+++ b/crates/engine/src/response/read/ser/mod.rs
@@ -22,7 +22,7 @@ impl<OnOperationResponseHookOutput> serde::Serialize for Response<OnOperationRes
             }) => {
                 let mut map = serializer.serialize_map(None)?;
 
-                let keys = &operation.operation.response_keys;
+                let keys = &operation.cached.operation.response_keys;
                 if let Some(data) = data {
                     map.serialize_entry(
                         "data",
@@ -35,7 +35,14 @@ impl<OnOperationResponseHookOutput> serde::Serialize for Response<OnOperationRes
                 }
 
                 if !errors.is_empty() {
-                    map.serialize_entry("errors", &errors::SerializableErrors { keys, errors })?;
+                    map.serialize_entry(
+                        "errors",
+                        &errors::SerializableErrorParts {
+                            query_modifications: &operation.plan.query_modifications,
+                            keys,
+                            errors,
+                        },
+                    )?;
                 }
 
                 if !extensions.is_empty() {

--- a/crates/engine/src/response/write/deserialize/batch.rs
+++ b/crates/engine/src/response/write/deserialize/batch.rs
@@ -13,7 +13,7 @@ use serde::{
 
 use crate::{
     prepare::{ConcreteShapeId, PreparedOperation},
-    response::SharedResponsePart,
+    response::SharedResponsePartBuilder,
 };
 
 use super::{EntitySeed, SeedContext, entity::DeserError};
@@ -21,11 +21,11 @@ use super::{EntitySeed, SeedContext, entity::DeserError};
 pub(crate) struct EntitiesSeed<'ctx> {
     schema: &'ctx Schema,
     prepared_operation: &'ctx PreparedOperation,
-    response: SharedResponsePart<'ctx>,
+    response: SharedResponsePartBuilder<'ctx>,
     shape_id: ConcreteShapeId,
 }
 impl<'ctx> EntitiesSeed<'ctx> {
-    pub fn new(response: SharedResponsePart<'ctx>, shape_id: ConcreteShapeId) -> Self {
+    pub fn new(response: SharedResponsePartBuilder<'ctx>, shape_id: ConcreteShapeId) -> Self {
         let schema: &'ctx Schema = response.borrow().schema;
         let prepared_operation: &'ctx PreparedOperation = response.borrow().operation;
         Self {

--- a/crates/engine/src/response/write/deserialize/batch.rs
+++ b/crates/engine/src/response/write/deserialize/batch.rs
@@ -94,7 +94,7 @@ impl<'de> Visitor<'de> for EntitiesSeed<'_> {
         for (id, parent_object) in parent_objects.by_ref() {
             let ctx = Rc::new(SeedContext {
                 schema,
-                prepared_operation,
+                operation: prepared_operation,
                 response: response.clone(),
                 bubbling_up_serde_error: Cell::new(false),
                 path: RefCell::new(parent_object.path.clone()),

--- a/crates/engine/src/response/write/deserialize/ctx.rs
+++ b/crates/engine/src/response/write/deserialize/ctx.rs
@@ -2,7 +2,7 @@ use std::cell::{Cell, Ref, RefCell, RefMut};
 
 use crate::{
     prepare::{CachedOperationContext, OperationPlanContext, PreparedOperation},
-    response::{ResponseValueId, SharedResponsePart},
+    response::{ResponseValueId, SharedResponsePartBuilder},
 };
 use itertools::Itertools;
 use operation::ResponseKeys;
@@ -11,7 +11,7 @@ use schema::Schema;
 pub(super) struct SeedContext<'ctx> {
     pub schema: &'ctx Schema,
     pub prepared_operation: &'ctx PreparedOperation,
-    pub response: SharedResponsePart<'ctx>,
+    pub response: SharedResponsePartBuilder<'ctx>,
     pub bubbling_up_serde_error: Cell<bool>,
     pub path: RefCell<Vec<ResponseValueId>>,
 }

--- a/crates/engine/src/response/write/deserialize/ctx.rs
+++ b/crates/engine/src/response/write/deserialize/ctx.rs
@@ -10,7 +10,7 @@ use schema::Schema;
 
 pub(super) struct SeedContext<'ctx> {
     pub schema: &'ctx Schema,
-    pub prepared_operation: &'ctx PreparedOperation,
+    pub operation: &'ctx PreparedOperation,
     pub response: SharedResponsePartBuilder<'ctx>,
     pub bubbling_up_serde_error: Cell<bool>,
     pub path: RefCell<Vec<ResponseValueId>>,
@@ -20,7 +20,7 @@ impl<'ctx> From<&SeedContext<'ctx>> for CachedOperationContext<'ctx> {
     fn from(ctx: &SeedContext<'ctx>) -> Self {
         CachedOperationContext {
             schema: ctx.schema,
-            cached: &ctx.prepared_operation.cached,
+            cached: &ctx.operation.cached,
         }
     }
 }
@@ -29,15 +29,15 @@ impl<'ctx> From<&SeedContext<'ctx>> for OperationPlanContext<'ctx> {
     fn from(ctx: &SeedContext<'ctx>) -> Self {
         OperationPlanContext {
             schema: ctx.schema,
-            cached: &ctx.prepared_operation.cached,
-            plan: &ctx.prepared_operation.plan,
+            cached: &ctx.operation.cached,
+            plan: &ctx.operation.plan,
         }
     }
 }
 
 impl<'ctx> SeedContext<'ctx> {
     pub(super) fn response_keys(&self) -> &'ctx ResponseKeys {
-        &self.prepared_operation.cached.operation.response_keys
+        &self.operation.cached.operation.response_keys
     }
 
     pub(super) fn path_mut(&self) -> RefMut<'_, Vec<ResponseValueId>> {
@@ -49,7 +49,7 @@ impl<'ctx> SeedContext<'ctx> {
     }
 
     pub(super) fn display_path(&self) -> impl std::fmt::Display + '_ {
-        let keys = &self.prepared_operation.cached.operation.response_keys;
+        let keys = &self.operation.cached.operation.response_keys;
         let path = self.path.borrow();
         DisplayPath { keys, path }
     }

--- a/crates/engine/src/response/write/deserialize/entity.rs
+++ b/crates/engine/src/response/write/deserialize/entity.rs
@@ -143,7 +143,8 @@ impl<'de> MapAccess<'de> for EntityFieldsMapAccess<'de, '_, '_> {
                     let path = self.ctx.path();
                     resp.propagate_null(&path);
                     // FIXME: remove Clone...
-                    resp.push_error(err.clone().with_path(path).with_location(field.location()));
+                    resp.errors
+                        .push(err.clone().with_path(path).with_location(field.location()));
                 }
                 seed.deserialize(ErrorPlaceholder {
                     required: field.definition().ty().wrapping.is_required(),

--- a/crates/engine/src/response/write/deserialize/enum.rs
+++ b/crates/engine/src/response/write/deserialize/enum.rs
@@ -64,7 +64,7 @@ impl<'de> DeserializeSeed<'de> for EnumValueSeed<'_, '_> {
                             if is_required {
                                 resp.propagate_null(&path);
                             }
-                            resp.push_error(
+                            resp.errors.push(
                                 GraphqlError::invalid_subgraph_response()
                                     .with_path(path)
                                     .with_location(parent_field.id.walk(ctx).location()),
@@ -95,7 +95,7 @@ impl EnumValueSeed<'_, '_> {
             if self.is_required {
                 resp.propagate_null(&path);
             }
-            resp.push_error(
+            resp.errors.push(
                 GraphqlError::invalid_subgraph_response()
                     .with_path(path)
                     .with_location(self.parent_field.id.walk(self.ctx).location()),

--- a/crates/engine/src/response/write/deserialize/field.rs
+++ b/crates/engine/src/response/write/deserialize/field.rs
@@ -70,7 +70,7 @@ impl<'de> DeserializeSeed<'de> for FieldSeed<'_, '_> {
                 );
                 let mut resp = self.ctx.response.borrow_mut();
                 resp.propagate_null(&self.ctx.path());
-                resp.push_error(
+                resp.errors.push(
                     GraphqlError::invalid_subgraph_response()
                         .with_path(self.ctx.path().as_ref())
                         .with_location(self.field.id.walk(self.ctx).location()),

--- a/crates/engine/src/response/write/deserialize/list.rs
+++ b/crates/engine/src/response/write/deserialize/list.rs
@@ -53,7 +53,7 @@ where
             if self.is_required {
                 resp.propagate_null(&path);
             }
-            resp.push_error(
+            resp.errors.push(
                 GraphqlError::invalid_subgraph_response()
                     .with_path(path)
                     .with_location(self.parent_field.id.walk(self.ctx).location()),
@@ -118,7 +118,7 @@ where
                         );
                         let mut resp = ctx.response.borrow_mut();
                         resp.propagate_null(&ctx.path());
-                        resp.push_error(
+                        resp.errors.push(
                             GraphqlError::invalid_subgraph_response()
                                 .with_path((ctx.path().as_ref(), index))
                                 .with_location(parent_field.id.walk(ctx).location()),

--- a/crates/engine/src/response/write/deserialize/mod.rs
+++ b/crates/engine/src/response/write/deserialize/mod.rs
@@ -51,7 +51,7 @@ impl<'ctx> EntitySeed<'ctx> {
         Self {
             ctx: Rc::new(SeedContext {
                 schema,
-                prepared_operation,
+                operation: prepared_operation,
                 response,
                 bubbling_up_serde_error: Cell::new(false),
                 path,
@@ -109,7 +109,7 @@ impl<'de> DeserializeSeed<'de> for EntitySeed<'_> {
                 }
             }
         };
-        ctx.response.borrow_mut().insert_update(id, update);
+        ctx.response.borrow_mut().insert(id, update);
 
         Ok(())
     }

--- a/crates/engine/src/response/write/deserialize/mod.rs
+++ b/crates/engine/src/response/write/deserialize/mod.rs
@@ -31,7 +31,7 @@ use ctx::*;
 use list::ListSeed;
 use scalar::*;
 
-use super::{ObjectUpdate, SharedResponsePart};
+use super::{ObjectUpdate, SharedResponsePartBuilder};
 
 pub(crate) struct EntitySeed<'ctx> {
     ctx: Rc<SeedContext<'ctx>>,
@@ -40,8 +40,12 @@ pub(crate) struct EntitySeed<'ctx> {
 }
 
 impl<'ctx> EntitySeed<'ctx> {
-    pub(super) fn new(response: SharedResponsePart<'ctx>, shape_id: ConcreteShapeId, id: ParentObjectId) -> Self {
-        let path = RefCell::new(response.borrow()[id].path.clone());
+    pub(super) fn new(
+        response: SharedResponsePartBuilder<'ctx>,
+        shape_id: ConcreteShapeId,
+        id: ParentObjectId,
+    ) -> Self {
+        let path = RefCell::new(response.borrow().parent_objects[id].path.clone());
         let schema: &'ctx Schema = response.borrow().schema;
         let prepared_operation: &'ctx PreparedOperation = response.borrow().operation;
         Self {
@@ -76,7 +80,7 @@ impl<'de> DeserializeSeed<'de> for EntitySeed<'_> {
         let EntitySeed { ctx, shape_id, id } = self;
 
         let fields_seed = {
-            let parent_object = Ref::map(ctx.response.borrow(), |resp| &resp[id]);
+            let parent_object = Ref::map(ctx.response.borrow(), |resp| &resp.parent_objects[id]);
             ConcreteShapeFieldsSeed::new(
                 &ctx,
                 shape_id.walk(ctx.as_ref()),

--- a/crates/engine/src/response/write/deserialize/object/concrete.rs
+++ b/crates/engine/src/response/write/deserialize/object/concrete.rs
@@ -1,5 +1,4 @@
 use id_newtypes::IdRange;
-use operation::PositionedResponseKey;
 use schema::ObjectDefinitionId;
 use serde::{
     Deserializer,
@@ -9,7 +8,7 @@ use std::fmt;
 use walker::Walk;
 
 use crate::{
-    prepare::{ConcreteShape, ConcreteShapeId, FieldShapeId, FieldShapeRecord, ObjectIdentifier},
+    prepare::{ConcreteShape, ConcreteShapeId, FieldShapeId, FieldShapeRecord, ObjectIdentifier, TypenameShapeRecord},
     response::{
         GraphqlError, ResponseObject, ResponseObjectId, ResponseObjectRef, ResponseValue, ResponseValueId,
         value::ResponseObjectField,
@@ -176,7 +175,7 @@ pub(crate) struct ConcreteShapeFieldsSeed<'ctx, 'seed> {
     has_error: bool,
     object_identifier: ObjectIdentifier,
     field_shape_ids: IdRange<FieldShapeId>,
-    typename_response_keys: &'ctx [PositionedResponseKey],
+    typename_shapes: &'ctx [TypenameShapeRecord],
 }
 
 impl<'ctx, 'seed> ConcreteShapeFieldsSeed<'ctx, 'seed> {
@@ -192,7 +191,7 @@ impl<'ctx, 'seed> ConcreteShapeFieldsSeed<'ctx, 'seed> {
             has_error: shape.has_errors(),
             object_identifier: definition_id.map(ObjectIdentifier::Known).unwrap_or(shape.identifier),
             field_shape_ids: shape.field_shape_ids,
-            typename_response_keys: &shape.as_ref().typename_response_keys,
+            typename_shapes: shape.typename_shapes_slice(),
         }
     }
 }
@@ -242,7 +241,7 @@ impl<'de> Visitor<'de> for ConcreteShapeFieldsSeed<'_, '_> {
         A: MapAccess<'de>,
     {
         let schema = self.ctx.schema;
-        let mut response_fields = Vec::with_capacity(self.field_shape_ids.len() + self.typename_response_keys.len());
+        let mut response_fields = Vec::with_capacity(self.field_shape_ids.len() + self.typename_shapes.len());
         let mut maybe_object_definition_id = None;
 
         match self.object_identifier {
@@ -279,7 +278,7 @@ impl<'de> Visitor<'de> for ConcreteShapeFieldsSeed<'_, '_> {
 
         self.post_process(&mut response_fields);
 
-        if !self.typename_response_keys.is_empty() {
+        if !self.typename_shapes.is_empty() {
             let Some(object_id) = maybe_object_definition_id else {
                 tracing::error!(
                     "Expected to have the object definition id to generate __typename at path '{}'",
@@ -288,9 +287,9 @@ impl<'de> Visitor<'de> for ConcreteShapeFieldsSeed<'_, '_> {
                 return Ok(ObjectValue::Error(GraphqlError::invalid_subgraph_response()));
             };
             let name_id = schema[object_id].name_id;
-            for key in self.typename_response_keys {
+            for shape in self.typename_shapes {
                 response_fields.push(ResponseObjectField {
-                    key: *key,
+                    key: shape.key,
                     value: name_id.into(),
                 });
             }
@@ -497,7 +496,7 @@ impl<'ctx> ConcreteShapeFieldsSeed<'ctx, '_> {
     ) -> Result<Option<ObjectDefinitionId>, A::Error> {
         let schema = self.ctx.schema;
         let keys = self.ctx.response_keys();
-        let fields = &self.ctx.prepared_operation.cached.shapes[self.field_shape_ids];
+        let fields = &self.ctx.operation.cached.shapes[self.field_shape_ids];
         let mut offset = 0;
         let mut maybe_object_definition_id: Option<ObjectDefinitionId> = None;
         while let Some(key) = map.next_key::<Key<'_>>()? {
@@ -540,7 +539,7 @@ impl<'ctx> ConcreteShapeFieldsSeed<'ctx, '_> {
         response_fields: &mut Vec<ResponseObjectField>,
     ) -> Result<(), A::Error> {
         let keys = self.ctx.response_keys();
-        let fields = &self.ctx.prepared_operation.cached.shapes[self.field_shape_ids];
+        let fields = &self.ctx.operation.cached.shapes[self.field_shape_ids];
         let mut offset = 0;
         while let Some(key) = map.next_key::<Key<'_>>()? {
             let key = key.as_ref();

--- a/crates/engine/src/response/write/deserialize/object/polymorphic.rs
+++ b/crates/engine/src/response/write/deserialize/object/polymorphic.rs
@@ -68,7 +68,7 @@ impl PolymorphicShapeSeed<'_, '_> {
             if self.is_required {
                 resp.propagate_null(&path);
             }
-            resp.push_error(
+            resp.errors.push(
                 GraphqlError::invalid_subgraph_response()
                     .with_path(path)
                     .with_location(self.parent_field.id.walk(self.ctx).location()),
@@ -196,7 +196,7 @@ impl<'de> Visitor<'de> for PolymorphicShapeSeed<'_, '_> {
             if self.is_required {
                 resp.propagate_null(&path);
             }
-            resp.push_error(
+            resp.errors.push(
                 GraphqlError::invalid_subgraph_response()
                     .with_path(path)
                     .with_location(self.parent_field.id.walk(self.ctx).location()),

--- a/crates/engine/src/response/write/deserialize/scalar.rs
+++ b/crates/engine/src/response/write/deserialize/scalar.rs
@@ -51,7 +51,7 @@ impl ScalarTypeSeed<'_, '_> {
             if self.is_required {
                 resp.propagate_null(&path);
             }
-            resp.push_error(
+            resp.errors.push(
                 GraphqlError::invalid_subgraph_response()
                     .with_path(path)
                     .with_location(self.parent_field.id.walk(self.ctx).location()),

--- a/crates/engine/src/response/write/merge.rs
+++ b/crates/engine/src/response/write/merge.rs
@@ -10,6 +10,8 @@ impl ResponseBuilder<'_> {
         object_id: ResponseObjectId,
         default_fields_sorted_by_key: &[ResponseObjectField],
     ) {
+        // When ingesting default fields, which we set to Null, we may encounter an actual
+        // value in the case of shared roots. In this case we keep the old value.
         self.recursive_merge_object(object_id, default_fields_sorted_by_key.to_vec(), true);
     }
 
@@ -91,7 +93,7 @@ impl ResponseBuilder<'_> {
             (existing, ResponseValue::Inaccessible { id }) => {
                 self.recursive_merge_value(existing, self.data_parts[id].clone());
             }
-            (ResponseValue::Null, ResponseValue::Null) => (),
+            (ResponseValue::Null, ResponseValue::Null) => {}
             (l, r) => {
                 // FIXME: Unlikely, but we should generate an error here.
                 tracing::error!(

--- a/crates/engine/src/response/write/mod.rs
+++ b/crates/engine/src/response/write/mod.rs
@@ -10,9 +10,9 @@ use schema::{ObjectDefinitionId, Schema};
 use walker::Walk;
 
 use super::{
-    DataParts, ErrorCodeCounter, ErrorPathSegment, ExecutedResponse, GraphqlError, OutputResponseObjectSets,
-    ParentObjectId, ParentObjects, Response, ResponseData, ResponseObject, ResponseObjectField, ResponseObjectId,
-    ResponseObjectRef, ResponseValue, ResponseValueId,
+    DataParts, ErrorPartBuilder, ErrorParts, ErrorPathSegment, ExecutedResponse, GraphqlError,
+    OutputResponseObjectSets, ParentObjectId, ParentObjects, Response, ResponseData, ResponseObject,
+    ResponseObjectField, ResponseObjectId, ResponseObjectRef, ResponseValue, ResponseValueId,
 };
 use crate::{
     execution::ExecutionError,
@@ -23,26 +23,28 @@ pub(crate) use part::*;
 pub(crate) struct ResponseBuilder<'ctx> {
     // will be None if an error propagated up to the root.
     pub(in crate::response) schema: &'ctx Arc<Schema>,
-    operation: &'ctx PreparedOperation,
+    operation: &'ctx Arc<PreparedOperation>,
     pub(super) root: Option<(ResponseObjectId, ObjectDefinitionId)>,
     pub(super) data_parts: DataParts,
-    errors: Vec<GraphqlError>,
+    pub(super) error_parts: ErrorParts,
+    errors: ErrorPartBuilder<'ctx>,
 }
 
 impl<'ctx> ResponseBuilder<'ctx> {
-    pub fn new(schema: &'ctx Arc<Schema>, operation: &'ctx PreparedOperation) -> Self {
+    pub fn new(schema: &'ctx Arc<Schema>, operation: &'ctx Arc<PreparedOperation>) -> Self {
         let root_object_definition_id = operation.cached.operation.root_object_id;
-        let mut parts = DataParts::default();
-        let mut initial_part = parts.new_part();
+        let mut data_parts = DataParts::default();
+        let mut initial_part = data_parts.new_part();
         let root_id = initial_part.push_object(ResponseObject::new(Some(root_object_definition_id), Vec::new()));
-        parts.insert(initial_part);
+        data_parts.insert(initial_part);
 
         Self {
             schema,
             operation,
             root: Some((root_id, root_object_definition_id)),
-            data_parts: parts,
-            errors: Vec::new(),
+            data_parts,
+            error_parts: ErrorParts::default(),
+            errors: ErrorPartBuilder::new(operation),
         }
     }
 
@@ -62,7 +64,7 @@ impl<'ctx> ResponseBuilder<'ctx> {
         self.data_parts[value_id.part_id()].make_inaccessible(value_id);
     }
 
-    pub fn create_root_part(&mut self) -> (ParentObjectId, ResponsePart<'ctx>) {
+    pub fn create_root_part(&mut self) -> (ParentObjectId, ResponsePartBuilder<'ctx>) {
         let root_parent_objects = Arc::new(
             ParentObjects::default().with_response_objects(Arc::new(self.root_response_object().into_iter().collect())),
         );
@@ -71,8 +73,8 @@ impl<'ctx> ResponseBuilder<'ctx> {
         (root_id, resp)
     }
 
-    pub fn create_part_for(&mut self, parent_objects: Arc<ParentObjects>) -> ResponsePart<'ctx> {
-        ResponsePart::new(self.schema, self.operation, self.data_parts.new_part(), parent_objects)
+    pub fn create_part_for(&mut self, parent_objects: Arc<ParentObjects>) -> ResponsePartBuilder<'ctx> {
+        ResponsePartBuilder::new(self.schema, self.operation, self.data_parts.new_part(), parent_objects)
     }
 
     pub fn root_response_object(&self) -> Option<ResponseObjectRef> {
@@ -86,43 +88,43 @@ impl<'ctx> ResponseBuilder<'ctx> {
     pub fn propagate_execution_error(
         &mut self,
         plan: Plan<'_>,
-        root_response_object_set: Arc<ParentObjects>,
+        parent_objects: Arc<ParentObjects>,
         error: ExecutionError,
     ) {
         let (any_response_key, default_fields_sorted_by_key) =
             self.extract_any_response_key_and_default_fields_sorted_by_key(plan);
-        let error = GraphqlError::from(error);
         if let Some(any_response_key) = any_response_key {
+            let error = GraphqlError::from(error);
+            if let Some(parent_object) = parent_objects.iter().next() {
+                self.errors
+                    .push(error.with_path((&parent_object.path, any_response_key)));
+            }
             if let Some(default_fields_sorted_by_key) = &default_fields_sorted_by_key {
-                for obj_ref in root_response_object_set.iter() {
-                    self.errors
-                        .push(error.clone().with_path((&obj_ref.path, any_response_key)));
-                    self.recursive_merge_with_default_object(obj_ref.id, default_fields_sorted_by_key);
+                for parent_object in parent_objects.iter() {
+                    self.recursive_merge_with_default_object(parent_object.id, default_fields_sorted_by_key);
                 }
             } else {
-                for obj_ref in root_response_object_set.iter() {
-                    self.propagate_null(&obj_ref.path);
-                    self.errors
-                        .push(error.clone().with_path((&obj_ref.path, any_response_key)));
+                for parent_object in parent_objects.iter() {
+                    self.propagate_null(&parent_object.path);
                 }
             }
         }
     }
 
-    pub fn ingest(&mut self, plan: Plan<'ctx>, mut subgraph_response: ResponsePart<'ctx>) -> OutputResponseObjectSets {
-        self.data_parts.insert(subgraph_response.data);
+    pub fn ingest(&mut self, plan: Plan<'ctx>, response_part: ResponsePartBuilder<'ctx>) -> OutputResponseObjectSets {
+        self.data_parts.insert(response_part.data);
 
         let (any_response_key, default_fields_sorted_by_key) =
             self.extract_any_response_key_and_default_fields_sorted_by_key(plan);
-        for (update, obj_ref) in subgraph_response
+        for (update, obj_ref) in response_part
             .updates
             .into_iter()
-            .zip(subgraph_response.parent_objects.iter())
+            .zip(response_part.parent_objects.iter())
         {
             match update {
                 ObjectUpdate::Missing => {
                     if let Some(any_response_key) = any_response_key {
-                        if !subgraph_response
+                        if !response_part
                             .subgraph_errors
                             .iter()
                             .any(|subgraph_error| self.sugraph_error_matches_current_object(subgraph_error, obj_ref))
@@ -164,17 +166,19 @@ impl<'ctx> ResponseBuilder<'ctx> {
                 }
             }
         }
-        self.errors.append(&mut subgraph_response.subgraph_errors);
-        self.errors.append(&mut subgraph_response.errors);
-        if subgraph_response.propagated_null_up_to_root {
+        for err in response_part.subgraph_errors {
+            self.errors.push(err);
+        }
+        self.error_parts.push(response_part.errors);
+        if response_part.propagated_null_up_to_root {
             self.root = None;
         } else {
-            for path in subgraph_response.propagated_null_up_to_paths {
+            for path in response_part.propagated_null_up_to_paths {
                 self.propagate_null(&path);
             }
         }
 
-        let (ids, sets) = subgraph_response.object_sets.into_iter().unzip();
+        let (ids, sets) = response_part.object_sets.into_iter().unzip();
         OutputResponseObjectSets { ids, sets }
     }
 
@@ -254,32 +258,31 @@ impl<'ctx> ResponseBuilder<'ctx> {
     }
 
     pub fn graphql_status(&self) -> GraphqlResponseStatus {
-        if self.errors.is_empty() {
+        if self.errors.is_empty() && self.error_parts.is_empty() {
             GraphqlResponseStatus::Success
         } else {
             GraphqlResponseStatus::FieldError {
-                count: self.errors.len() as u64,
+                count: (self.errors.len() + self.error_parts.len()) as u64,
                 data_is_null: self.root.is_none(),
             }
         }
     }
 
     pub fn build<OnOperationResponseHookOutput>(
-        self,
+        mut self,
         operation_attributes: GraphqlOperationAttributes,
         on_operation_response_output: OnOperationResponseHookOutput,
     ) -> Response<OnOperationResponseHookOutput> {
-        let error_code_counter = ErrorCodeCounter::from_errors(&self.errors);
+        self.error_parts.push(self.errors);
         Response::Executed(ExecutedResponse {
             schema: self.schema.clone(),
-            operation: self.operation.cached.clone(),
+            operation: self.operation.clone(),
             operation_attributes,
             data: self.root.map(|(root, _)| ResponseData {
                 root,
                 parts: self.data_parts,
             }),
-            errors: self.errors,
-            error_code_counter,
+            errors: self.error_parts,
             on_operation_response_output: Some(on_operation_response_output),
             extensions: Default::default(),
         })

--- a/crates/engine/src/response/write/part.rs
+++ b/crates/engine/src/response/write/part.rs
@@ -1,12 +1,15 @@
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 use schema::Schema;
+use walker::Walk as _;
 
 use crate::{
-    prepare::{ConcreteShapeId, PreparedOperation, ResponseObjectSetDefinitionId},
+    prepare::{
+        ConcreteShapeId, ObjectIdentifier, OperationPlanContext, PreparedOperation, ResponseObjectSetDefinitionId,
+    },
     response::{
         DataPart, ErrorPartBuilder, GraphqlError, ParentObjectId, ParentObjects, ResponseObjectField,
-        ResponseObjectRef, ResponseObjectSet, ResponseValueId,
+        ResponseObjectRef, ResponseObjectSet, ResponseValue, ResponseValueId,
     },
 };
 
@@ -22,6 +25,7 @@ pub(crate) struct ResponsePartBuilder<'ctx> {
     pub(super) propagated_null_up_to_paths: Vec<Vec<ResponseValueId>>,
     pub(super) subgraph_errors: Vec<GraphqlError>,
     pub(super) updates: Vec<ObjectUpdate>,
+    pub(super) common_update: Option<CommonUpdate>,
     pub(super) object_sets: Vec<(ResponseObjectSetDefinitionId, ResponseObjectSet)>,
 }
 
@@ -39,6 +43,7 @@ impl<'ctx> ResponsePartBuilder<'ctx> {
             data,
             errors,
             updates: vec![ObjectUpdate::Missing; parent_objects.len()],
+            common_update: None,
             parent_objects,
             propagated_null_up_to_root: false,
             propagated_null_up_to_paths: Vec::new(),
@@ -64,14 +69,79 @@ impl<'ctx> ResponsePartBuilder<'ctx> {
         self.propagated_null_up_to_paths.push(path[..(i + 1)].to_vec());
     }
 
-    pub fn insert_update(&mut self, id: ParentObjectId, update: ObjectUpdate) {
+    pub fn insert(&mut self, id: ParentObjectId, update: ObjectUpdate) {
         self.updates[usize::from(id)] = update;
+    }
+
+    pub fn insert_subgraph_failure(&mut self, shape_id: ConcreteShapeId, error: GraphqlError) {
+        let ctx = OperationPlanContext {
+            schema: self.schema,
+            cached: &self.operation.cached,
+            plan: &self.operation.plan,
+        };
+        let shape = shape_id.walk(ctx);
+
+        let mut propagate_null = false;
+        let mut location_and_key = None;
+        let mut fields = Vec::new();
+        for field_shape in shape.fields() {
+            if field_shape.key.query_position.is_none() {
+                continue;
+            };
+            let field = field_shape
+                .partition_field()
+                .as_data()
+                .expect("We shouldn't generate errors for lookup fields");
+            location_and_key.get_or_insert_with(|| (field.location, field.response_key));
+            if propagate_null | field_shape.wrapping.is_required() {
+                propagate_null = true;
+                continue;
+            }
+            fields.push(ResponseObjectField {
+                key: field_shape.key,
+                value: ResponseValue::Null,
+            })
+        }
+        if let Some(first_typename_shape) = shape.typename_shapes().next() {
+            if let ObjectIdentifier::Known(object_id) = shape.identifier {
+                let name_id = object_id.walk(self.schema).name_id;
+                fields.extend(shape.typename_shapes().map(|shape| ResponseObjectField {
+                    key: shape.key,
+                    value: name_id.into(),
+                }))
+            } else {
+                propagate_null = true;
+                if location_and_key.is_none() {
+                    location_and_key = Some((first_typename_shape.location, first_typename_shape.key.response_key));
+                }
+            }
+        }
+
+        self.common_update = Some(
+            if let Some(((location, key), first_parent_object)) =
+                location_and_key.zip(self.parent_objects.iter().next())
+            {
+                self.errors.push(
+                    error
+                        .with_location(location)
+                        .with_path((&first_parent_object.path, key)),
+                );
+                if propagate_null {
+                    CommonUpdate::PropagateNull
+                } else {
+                    fields.sort_unstable_by(|a, b| a.key.cmp(&b.key));
+                    CommonUpdate::DefaultFields(fields.clone())
+                }
+            } else {
+                CommonUpdate::Skip
+            },
+        )
     }
 
     pub fn insert_errors(&mut self, error: impl Into<GraphqlError>, ids: impl IntoIterator<Item = ParentObjectId>) {
         let error: GraphqlError = error.into();
         for id in ids {
-            self.insert_update(id, ObjectUpdate::Error(error.clone()));
+            self.insert(id, ObjectUpdate::Error(error.clone()));
         }
     }
 
@@ -128,4 +198,10 @@ pub(crate) enum ObjectUpdate {
     Fields(Vec<ResponseObjectField>),
     Error(GraphqlError),
     PropagateNullWithoutError,
+}
+
+pub(crate) enum CommonUpdate {
+    PropagateNull,
+    DefaultFields(Vec<ResponseObjectField>),
+    Skip,
 }

--- a/crates/integration-tests/tests/gateway/extensions/authorization/deny_all.rs
+++ b/crates/integration-tests/tests/gateway/extensions/authorization/deny_all.rs
@@ -68,21 +68,6 @@ fn can_deny_all() {
               "extensions": {
                 "code": "UNAUTHORIZED"
               }
-            },
-            {
-              "message": "Not authorized",
-              "locations": [
-                {
-                  "line": 1,
-                  "column": 18
-                }
-              ],
-              "path": [
-                "forbidden"
-              ],
-              "extensions": {
-                "code": "UNAUTHORIZED"
-              }
             }
           ]
         }

--- a/crates/integration-tests/tests/gateway/extensions/authorization/multiple.rs
+++ b/crates/integration-tests/tests/gateway/extensions/authorization/multiple.rs
@@ -226,36 +226,6 @@ fn multiple_extensions_and_directives() {
           "extensions": {
             "code": "UNAUTHORIZED"
           }
-        },
-        {
-          "message": "Unauthorized",
-          "locations": [
-            {
-              "line": 1,
-              "column": 41
-            }
-          ],
-          "path": [
-            "denied1"
-          ],
-          "extensions": {
-            "code": "UNAUTHORIZED"
-          }
-        },
-        {
-          "message": "Unauthorized by bis",
-          "locations": [
-            {
-              "line": 1,
-              "column": 49
-            }
-          ],
-          "path": [
-            "denied2"
-          ],
-          "extensions": {
-            "code": "UNAUTHORIZED"
-          }
         }
       ]
     }

--- a/crates/integration-tests/tests/gateway/extensions/selection_set_resolver/errors/failure.rs
+++ b/crates/integration-tests/tests/gateway/extensions/selection_set_resolver/errors/failure.rs
@@ -1,0 +1,231 @@
+use engine::{ErrorCode, GraphqlError};
+use integration_tests::{gateway::Gateway, runtime};
+
+use crate::gateway::extensions::selection_set_resolver::StaticSelectionSetResolverExt;
+
+const SDL: &str = r#"
+extend schema
+    @link(url: "static-1.0.0", import: ["@init"])
+    @init
+
+type Nullable {
+    id: ID
+    int: Int
+    str: String
+    float: Float
+    bool: Boolean
+    nullable: Nullable
+    nullableList: [Nullable]
+    required: Required!
+    requiredList: [Required!]
+}
+
+type Required {
+    id: ID!
+    int: Int!
+    str: String!
+    float: Float!
+    bool: Boolean!
+    nullable: Nullable
+    nullableList: [Nullable]!
+    required: Required!
+    requiredList: [Required!]!
+
+}
+
+scalar JSON
+
+type Query {
+    nullable: Nullable
+    required: Required!
+}
+"#;
+
+#[test]
+fn nullable_field_invalid_json() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json_bytes(b"{]}"))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    nullable {
+                        int
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "nullable": null
+          },
+          "errors": [
+            {
+              "message": "Invalid response from subgraph",
+              "locations": [
+                {
+                  "line": 3,
+                  "column": 21
+                }
+              ],
+              "path": [
+                "nullable"
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}
+
+#[test]
+fn required_field_invalid_json() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json_bytes(b"{]}"))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    required {
+                        int
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "Invalid response from subgraph",
+              "locations": [
+                {
+                  "line": 3,
+                  "column": 21
+                }
+              ],
+              "path": [
+                "required"
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}
+
+#[test]
+fn nullable_field_subgraph_error() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::error(GraphqlError::new(
+                "oh no!",
+                ErrorCode::BadRequest,
+            )))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    nullable {
+                        int
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "nullable": null
+          },
+          "errors": [
+            {
+              "message": "oh no!",
+              "locations": [
+                {
+                  "line": 3,
+                  "column": 21
+                }
+              ],
+              "path": [
+                "nullable"
+              ],
+              "extensions": {
+                "code": "BAD_REQUEST"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}
+
+#[test]
+fn required_field_subgraph_error() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::error(GraphqlError::new(
+                "oh no!",
+                ErrorCode::BadRequest,
+            )))
+            .build()
+            .await;
+        let response = engine
+            .post(
+                r#"
+                query {
+                    required {
+                        int
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "oh no!",
+              "locations": [
+                {
+                  "line": 3,
+                  "column": 21
+                }
+              ],
+              "path": [
+                "required"
+              ],
+              "extensions": {
+                "code": "BAD_REQUEST"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}

--- a/crates/integration-tests/tests/gateway/extensions/selection_set_resolver/errors/fields.rs
+++ b/crates/integration-tests/tests/gateway/extensions/selection_set_resolver/errors/fields.rs
@@ -1,0 +1,247 @@
+use integration_tests::{gateway::Gateway, runtime};
+use serde_json::json;
+
+use crate::gateway::extensions::selection_set_resolver::StaticSelectionSetResolverExt;
+
+const SDL: &str = r#"
+extend schema
+    @link(url: "static-1.0.0", import: ["@init"])
+    @init
+
+type Nullable {
+    id: ID
+    int: Int
+    str: String
+    float: Float
+    bool: Boolean
+    nullable: Nullable
+    nullableList: [Nullable]!
+    required: Required!
+    requiredList: [Required!]
+}
+
+type Required {
+    id: ID!
+    int: Int!
+    str: String!
+    float: Float!
+    bool: Boolean!
+    nullable: Nullable
+    nullableList: [Nullable]!
+    required: Required!
+    requiredList: [Required!]!
+
+}
+
+scalar JSON
+
+type Query {
+    nullable: Nullable
+    required: Required!
+}
+"#;
+
+#[test]
+fn missing_nullable_field() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json(json!({ "int": 1 })))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    nullable {
+                        int
+                        str
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "nullable": {
+              "int": 1,
+              "str": null
+            }
+          }
+        }
+        "#);
+    })
+}
+
+#[test]
+fn unknown_field() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json(
+                json!({ "int": 1, "unknown": "Hi!" }),
+            ))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    nullable {
+                        int
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "nullable": {
+              "int": 1
+            }
+          }
+        }
+        "#);
+    })
+}
+
+#[test]
+fn missing_required_field() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json(json!({ "int": 1 })))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    required {
+                        int
+                        str
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "Invalid response from subgraph",
+              "locations": [
+                {
+                  "line": 5,
+                  "column": 25
+                }
+              ],
+              "path": [
+                "required",
+                "str"
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}
+
+#[test]
+fn field_ordering_1() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json_bytes(
+                br#"{
+                    "str": "hello",
+                    "int": 42,
+                    "float": 3.14,
+                    "bool": true
+                }"#,
+            ))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    nullable {
+                        int
+                        str
+                        float
+                        bool
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "nullable": {
+              "int": 42,
+              "str": "hello",
+              "float": 3.14,
+              "bool": true
+            }
+          }
+        }
+        "#);
+    })
+}
+
+#[test]
+fn field_ordering_2() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json_bytes(
+                br#"{
+                    "float": 3.14,
+                    "str": "hello",
+                    "bool": true,
+                    "int": 42
+                }"#,
+            ))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    nullable {
+                        int
+                        str
+                        float
+                        bool
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "nullable": {
+              "int": 42,
+              "str": "hello",
+              "float": 3.14,
+              "bool": true
+            }
+          }
+        }
+        "#);
+    })
+}

--- a/crates/integration-tests/tests/gateway/extensions/selection_set_resolver/errors/invalid_type.rs
+++ b/crates/integration-tests/tests/gateway/extensions/selection_set_resolver/errors/invalid_type.rs
@@ -1,0 +1,400 @@
+use integration_tests::{gateway::Gateway, runtime};
+use serde_json::json;
+
+use crate::gateway::extensions::selection_set_resolver::StaticSelectionSetResolverExt;
+
+const SDL: &str = r#"
+extend schema
+    @link(url: "static-1.0.0", import: ["@init"])
+    @init
+
+type Nullable {
+    id: ID
+    int: Int
+    str: String
+    float: Float
+    bool: Boolean
+    nullable: Nullable
+    nullableList: [Nullable]
+    required: Required!
+    requiredList: [Required!]
+}
+
+type Required {
+    id: ID!
+    int: Int!
+    str: String!
+    float: Float!
+    bool: Boolean!
+    nullable: Nullable
+    nullableList: [Nullable]!
+    required: Required!
+    requiredList: [Required!]!
+
+}
+
+scalar JSON
+
+type Query {
+    nullable: Nullable
+    required: Required!
+}
+"#;
+
+#[test]
+fn invalid_int() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json(json!({ "int": "19" })))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    nullable {
+                        int
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "nullable": {
+              "int": null
+            }
+          },
+          "errors": [
+            {
+              "message": "Invalid response from subgraph",
+              "locations": [
+                {
+                  "line": 4,
+                  "column": 25
+                }
+              ],
+              "path": [
+                "nullable",
+                "int"
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}
+
+#[test]
+fn invalid_float() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json(json!({ "float": "19.5" })))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    nullable {
+                        float
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "nullable": {
+              "float": null
+            }
+          },
+          "errors": [
+            {
+              "message": "Invalid response from subgraph",
+              "locations": [
+                {
+                  "line": 4,
+                  "column": 25
+                }
+              ],
+              "path": [
+                "nullable",
+                "float"
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}
+
+#[test]
+fn invalid_boolean() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json(json!({ "bool": "true" })))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    nullable {
+                        bool
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "nullable": {
+              "bool": null
+            }
+          },
+          "errors": [
+            {
+              "message": "Invalid response from subgraph",
+              "locations": [
+                {
+                  "line": 4,
+                  "column": 25
+                }
+              ],
+              "path": [
+                "nullable",
+                "bool"
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}
+
+#[test]
+fn invalid_string() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json(json!({ "str": 42 })))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    nullable {
+                        str
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "nullable": {
+              "str": null
+            }
+          },
+          "errors": [
+            {
+              "message": "Invalid response from subgraph",
+              "locations": [
+                {
+                  "line": 4,
+                  "column": 25
+                }
+              ],
+              "path": [
+                "nullable",
+                "str"
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}
+
+#[test]
+fn invalid_id() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json(json!({ "id": 42 })))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    nullable {
+                        id
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "nullable": {
+              "id": null
+            }
+          },
+          "errors": [
+            {
+              "message": "Invalid response from subgraph",
+              "locations": [
+                {
+                  "line": 4,
+                  "column": 25
+                }
+              ],
+              "path": [
+                "nullable",
+                "id"
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}
+
+#[test]
+fn invalid_list() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json(json!({
+               "nullableList": "not a list"
+            })))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    nullable {
+                        nullableList {
+                            id
+                        }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "nullable": {
+              "nullableList": null
+            }
+          },
+          "errors": [
+            {
+              "message": "Invalid response from subgraph",
+              "locations": [
+                {
+                  "line": 4,
+                  "column": 25
+                }
+              ],
+              "path": [
+                "nullable",
+                "nullableList"
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}
+
+#[test]
+fn invalid_object() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json(json!({
+                "nullable": "not an object",
+            })))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    nullable {
+                        nullable {
+                            id
+                        }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "nullable": {
+              "nullable": null
+            }
+          },
+          "errors": [
+            {
+              "message": "Invalid response from subgraph",
+              "locations": [
+                {
+                  "line": 4,
+                  "column": 25
+                }
+              ],
+              "path": [
+                "nullable",
+                "nullable"
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}

--- a/crates/integration-tests/tests/gateway/extensions/selection_set_resolver/errors/mod.rs
+++ b/crates/integration-tests/tests/gateway/extensions/selection_set_resolver/errors/mod.rs
@@ -1,0 +1,4 @@
+mod failure;
+mod fields;
+mod invalid_type;
+mod propagation;

--- a/crates/integration-tests/tests/gateway/extensions/selection_set_resolver/errors/propagation.rs
+++ b/crates/integration-tests/tests/gateway/extensions/selection_set_resolver/errors/propagation.rs
@@ -1,0 +1,493 @@
+use integration_tests::{gateway::Gateway, runtime};
+use serde_json::json;
+
+use crate::gateway::extensions::selection_set_resolver::StaticSelectionSetResolverExt;
+
+const SDL: &str = r#"
+extend schema
+    @link(url: "static-1.0.0", import: ["@init"])
+    @init
+
+type Nullable {
+    id: ID
+    int: Int
+    str: String
+    float: Float
+    bool: Boolean
+    nullable: Nullable
+    nullableList: [Nullable]
+    required: Required!
+    requiredList: [Required!]
+}
+
+type Required {
+    id: ID!
+    int: Int!
+    str: String!
+    float: Float!
+    bool: Boolean!
+    nullable: Nullable
+    nullableList: [Nullable]!
+    required: Required!
+    requiredList: [Required!]!
+
+}
+
+scalar JSON
+
+type Query {
+    nullable: Nullable
+    required: Required!
+}
+"#;
+
+#[test]
+fn nullable_field() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json(json!({ "int": "not an int" })))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    nullable {
+                        int
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "nullable": {
+              "int": null
+            }
+          },
+          "errors": [
+            {
+              "message": "Invalid response from subgraph",
+              "locations": [
+                {
+                  "line": 4,
+                  "column": 25
+                }
+              ],
+              "path": [
+                "nullable",
+                "int"
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}
+
+#[test]
+fn required_field() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json(json!({ "int": "not an int" })))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    required {
+                        int
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "Invalid response from subgraph",
+              "locations": [
+                {
+                  "line": 4,
+                  "column": 25
+                }
+              ],
+              "path": [
+                "required",
+                "int"
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}
+
+#[test]
+fn nullable_nested_object() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json(json!({
+                "nullable": { "int": "not an int" }
+            })))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    nullable {
+                        nullable {
+                            int
+                        }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "nullable": {
+              "nullable": {
+                "int": null
+              }
+            }
+          },
+          "errors": [
+            {
+              "message": "Invalid response from subgraph",
+              "locations": [
+                {
+                  "line": 5,
+                  "column": 29
+                }
+              ],
+              "path": [
+                "nullable",
+                "nullable",
+                "int"
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}
+
+#[test]
+fn required_nested_object() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json(json!({
+                "required": { "int": "not an int" }
+            })))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    nullable {
+                        required {
+                            int
+                        }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "nullable": null
+          },
+          "errors": [
+            {
+              "message": "Invalid response from subgraph",
+              "locations": [
+                {
+                  "line": 5,
+                  "column": 29
+                }
+              ],
+              "path": [
+                "nullable",
+                "required",
+                "int"
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}
+
+#[test]
+fn nullable_list_inner_nullable() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json(json!({
+                "nullableList": [
+                    { "int": "not an int" },
+                    { "int": 42 }
+                ]
+            })))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    nullable {
+                        nullableList {
+                            int
+                        }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "nullable": {
+              "nullableList": [
+                {
+                  "int": null
+                },
+                {
+                  "int": 42
+                }
+              ]
+            }
+          },
+          "errors": [
+            {
+              "message": "Invalid response from subgraph",
+              "locations": [
+                {
+                  "line": 5,
+                  "column": 29
+                }
+              ],
+              "path": [
+                "nullable",
+                "nullableList",
+                0,
+                "int"
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}
+
+#[test]
+fn nullable_list_inner_required() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json(json!({
+                "requiredList": [
+                    { "int": "not an int" },
+                    { "int": 42 }
+                ]
+            })))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    nullable {
+                        requiredList {
+                            int
+                        }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "nullable": {
+              "requiredList": null
+            }
+          },
+          "errors": [
+            {
+              "message": "Invalid response from subgraph",
+              "locations": [
+                {
+                  "line": 5,
+                  "column": 29
+                }
+              ],
+              "path": [
+                "nullable",
+                "requiredList",
+                0,
+                "int"
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}
+
+#[test]
+fn required_list_inner_nullable() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json(json!({
+                "nullableList": [
+                    { "int": "not an int" },
+                    { "int": 42 }
+                ]
+            })))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    required {
+                        nullableList {
+                            int
+                        }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "required": {
+              "nullableList": [
+                {
+                  "int": null
+                },
+                {
+                  "int": 42
+                }
+              ]
+            }
+          },
+          "errors": [
+            {
+              "message": "Invalid response from subgraph",
+              "locations": [
+                {
+                  "line": 5,
+                  "column": 29
+                }
+              ],
+              "path": [
+                "required",
+                "nullableList",
+                0,
+                "int"
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}
+#[test]
+fn required_list_inner_required() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl("ext", SDL)
+            .with_extension(StaticSelectionSetResolverExt::json(json!({
+                "requiredList": [
+                     { "int": "not an int" },
+                     { "int": 42 }
+                ]
+            })))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                    required {
+                        requiredList {
+                            int
+                        }
+                    }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": null,
+          "errors": [
+            {
+              "message": "Invalid response from subgraph",
+              "locations": [
+                {
+                  "line": 5,
+                  "column": 29
+                }
+              ],
+              "path": [
+                "required",
+                "requiredList",
+                0,
+                "int"
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}

--- a/crates/integration-tests/tests/gateway/extensions/selection_set_resolver/mod.rs
+++ b/crates/integration-tests/tests/gateway/extensions/selection_set_resolver/mod.rs
@@ -1,5 +1,6 @@
 mod alias;
 mod config;
+mod errors;
 mod selection_set;
 mod subgraph_schema;
 
@@ -16,14 +17,24 @@ use runtime::extension::{ArgumentsId, Data};
 
 #[derive(Clone)]
 pub struct StaticSelectionSetResolverExt {
-    data: Result<Data, GraphqlError>,
+    result: Result<Data, GraphqlError>,
 }
 
 impl StaticSelectionSetResolverExt {
     pub fn json(value: impl serde::Serialize) -> Self {
         Self {
-            data: Ok(Data::Json(serde_json::to_vec(&value).unwrap().into())),
+            result: Ok(Data::Json(serde_json::to_vec(&value).unwrap().into())),
         }
+    }
+
+    pub fn json_bytes(bytes: &[u8]) -> Self {
+        Self {
+            result: Ok(Data::Json(bytes.to_vec().into())),
+        }
+    }
+
+    pub fn error(error: GraphqlError) -> Self {
+        Self { result: Err(error) }
     }
 }
 
@@ -54,7 +65,7 @@ impl SelectionSetResolverTestExtension for StaticSelectionSetResolverExt {
         _subgraph_headers: http::HeaderMap,
         _arguments: Vec<(ArgumentsId, serde_json::Value)>,
     ) -> Result<Data, GraphqlError> {
-        self.data.clone()
+        self.result.clone()
     }
 }
 

--- a/gateway/changelog/0.37.0.md
+++ b/gateway/changelog/0.37.0.md
@@ -1,18 +1,18 @@
 ### Breaking changes
 
-* The gateway will now try to expand environment variables everywhere in the configuration with the syntax `{{ env>VAR_NAME }}`.
+- The gateway will now try to expand environment variables everywhere in the configuration with the syntax `{{ env.VAR_NAME }}`.
 
 ### Features
 
-* feat(engine): Composite batch key/lookup matching
-* feat(engine): Add @oneOf support
-* feat(gb-8838): Fix empty arguments for postgres
+- feat(engine): Composite batch key/lookup matching
+- feat(engine): Add @oneOf support
+- feat(gb-8838): Fix empty arguments for postgres
 
 ## Fixes
 
-* The gateway now accepts the `extension` directive on the `@join__type` federated directive. It is valid but previously caused a validation error on startup.
-* fix(engine): avoid crashing with x-grafbase-telemetry & lookup
-* fix(engine): Proper shape computation for lookup fields. Fixed an index range issue that caused the root selection set to include all nested fields.
-* fix(engine): Fix incorrect interpretation of `resolvable: false` in `@join__type`. The engine was incorrectly triggering entity joins for lookup fields. `resolvable` indicates availability via Apollo `_entities`, not field existence within a subgraph.
-* fix(engine): infinite debug loop
-* fix(composition): Corrected a bug where directive imports with `@link(imports:)` sometimes exceeded their subgraph scope.
+- The gateway now accepts the `extension` directive on the `@join__type` federated directive. It is valid but previously caused a validation error on startup.
+- fix(engine): avoid crashing with x-grafbase-telemetry & lookup
+- fix(engine): Proper shape computation for lookup fields. Fixed an index range issue that caused the root selection set to include all nested fields.
+- fix(engine): Fix incorrect interpretation of `resolvable: false` in `@join__type`. The engine was incorrectly triggering entity joins for lookup fields. `resolvable` indicates availability via Apollo `_entities`, not field existence within a subgraph.
+- fix(engine): infinite debug loop
+- fix(composition): Corrected a bug where directive imports with `@link(imports:)` sometimes exceeded their subgraph scope.


### PR DESCRIPTION
Today each ResponsePart has its own errors vec that will appended to
the `ResponseBuilder` one. This move is useless as their only purpose is
to be serialized later.

Furthermore, before I used to add an error for every field which had a problem, even if it was the same one. I think it's pretty much useless. The primary purpose of the error is to help a human to understand what went wrong.

So now I only add unique errors, avoiding duplicates. Less data to serialize and clone.

Have to update extensions repo after.
