### PR TITLE
fix(engine): Proper shape computation for lookup fields

### DIFF
--- a/crates/engine/codegen/domain/query_plan.graphql
+++ b/crates/engine/codegen/domain/query_plan.graphql
@@ -36,7 +36,7 @@ type ResponseObjectSetDefinition @meta(module: "response_object_set") @indexed(i
 # - SelectionSet -
 # ----------------
 
-type PartitionSelectionSet @meta(module: "selection_set", derive: ["Default"]) @copy {
+type PartitionSelectionSet @meta(module: "selection_set", derive: ["Default"], debug: false) @copy {
   data_fields_ordered_by_parent_entity_then_key: [DataField!]!
     @field(record_field_name: "data_field_ids_ordered_by_parent_entity_then_key")
   typename_fields: [TypenameField!]!

--- a/crates/engine/codegen/domain/schema.graphql
+++ b/crates/engine/codegen/domain/schema.graphql
@@ -84,7 +84,7 @@ type InterfaceDefinition @meta(module: "interface", debug: false) @indexed(dedup
   is_interface_object_in: [Subgraph!]!
 }
 
-type FieldDefinition @meta(module: "field") @indexed(id_size: "u32") {
+type FieldDefinition @meta(module: "field", debug: false) @indexed(id_size: "u32") {
   name: String!
   description: String
   parent_entity: EntityDefinition!

--- a/crates/engine/schema/src/field.rs
+++ b/crates/engine/schema/src/field.rs
@@ -56,3 +56,14 @@ impl<'a> FieldDefinition<'a> {
         self.directives().find_map(|directive| directive.as_deprecated())
     }
 }
+
+impl std::fmt::Debug for FieldDefinition<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FieldDefinition")
+            .field("name", &self.name())
+            .field("parent_entity", &self.parent_entity().name())
+            .field("ty", &self.ty())
+            .field("arguments", &self.arguments())
+            .finish()
+    }
+}

--- a/crates/engine/schema/src/generated/field.rs
+++ b/crates/engine/schema/src/generated/field.rs
@@ -24,7 +24,7 @@ use walker::{Iter, Walk};
 /// Generated from:
 ///
 /// ```custom,{.language-graphql}
-/// type FieldDefinition @meta(module: "field") @indexed(id_size: "u32") {
+/// type FieldDefinition @meta(module: "field", debug: false) @indexed(id_size: "u32") {
 ///   name: String!
 ///   description: String
 ///   parent_entity: EntityDefinition!
@@ -130,23 +130,5 @@ impl<'a> Walk<&'a Schema> for FieldDefinitionId {
             schema: schema.into(),
             id: self,
         }
-    }
-}
-
-impl std::fmt::Debug for FieldDefinition<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("FieldDefinition")
-            .field("name", &self.name())
-            .field("description", &self.description())
-            .field("parent_entity", &self.parent_entity())
-            .field("ty", &self.ty())
-            .field("resolvers", &self.resolvers())
-            .field("exists_in_subgraphs", &self.exists_in_subgraphs())
-            .field("subgraph_types", &self.subgraph_types())
-            .field("requires", &self.requires())
-            .field("provides", &self.provides())
-            .field("arguments", &self.arguments())
-            .field("directives", &self.directives())
-            .finish()
     }
 }

--- a/crates/engine/src/prepare/cached/builder/mod.rs
+++ b/crates/engine/src/prepare/cached/builder/mod.rs
@@ -182,8 +182,13 @@ impl<'a> Solver<'a> {
                     selection_set_record,
                     query_partition_id,
                 };
-                let lookup_field_id = self.output.query_plan.lookup_fields.len().into();
-
+                let lookup_field_id: LookupFieldId = self.output.query_plan.lookup_fields.len().into();
+                for child_id in lookup_field
+                    .selection_set_record
+                    .data_field_ids_ordered_by_parent_entity_then_key
+                {
+                    self.output.query_plan[child_id].parent_field_id = Some(lookup_field_id.into());
+                }
                 // Confirm with authorization tests...
                 self.node_to_field[source_ix.index()] = Some(PartitionFieldId::Lookup(lookup_field_id));
 

--- a/crates/engine/src/prepare/cached/query_plan/field/data.rs
+++ b/crates/engine/src/prepare/cached/query_plan/field/data.rs
@@ -98,9 +98,8 @@ impl<'a> DataField<'a> {
 
 impl std::fmt::Debug for DataField<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DataPlanField")
-            .field("key", &self.response_key)
-            .field("location", &self.location)
+        f.debug_struct("DataField")
+            .field("key", &&self.ctx.cached.operation.response_keys[self.response_key])
             .field("definition", &self.definition())
             .field("selection_set", &self.selection_set())
             .finish()

--- a/crates/engine/src/prepare/cached/query_plan/field/lookup.rs
+++ b/crates/engine/src/prepare/cached/query_plan/field/lookup.rs
@@ -73,8 +73,7 @@ impl<'a> LookupField<'a> {
 impl std::fmt::Debug for LookupField<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DataPlanField")
-            .field("key", &self.subgraph_key)
-            .field("location", &self.location)
+            .field("key", &&self.ctx.cached.operation.response_keys[self.subgraph_key])
             .field("definition", &self.definition())
             .field("selection_set", &self.selection_set())
             .finish()

--- a/crates/engine/src/prepare/cached/query_plan/generated/selection_set.rs
+++ b/crates/engine/src/prepare/cached/query_plan/generated/selection_set.rs
@@ -75,16 +75,3 @@ impl<'a> Walk<CachedOperationContext<'a>> for PartitionSelectionSetRecord {
         }
     }
 }
-
-impl std::fmt::Debug for PartitionSelectionSet<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PartitionSelectionSet")
-            .field(
-                "data_fields_ordered_by_parent_entity_then_key",
-                &self.data_fields_ordered_by_parent_entity_then_key(),
-            )
-            .field("typename_fields", &self.typename_fields())
-            .field("lookup_fields", &self.lookup_fields())
-            .finish()
-    }
-}

--- a/crates/engine/src/prepare/cached/query_plan/selection_set.rs
+++ b/crates/engine/src/prepare/cached/query_plan/selection_set.rs
@@ -7,3 +7,32 @@ impl<'a> PartitionSelectionSet<'a> {
         self.data_fields_ordered_by_parent_entity_then_key()
     }
 }
+
+impl std::fmt::Debug for PartitionSelectionSet<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let keys = &self.ctx.cached.operation.response_keys;
+        f.debug_struct("PartitionSelectionSet")
+            .field(
+                "data_fields",
+                &self
+                    .data_fields_ordered_by_parent_entity_then_key()
+                    .map(|field| &keys[field.response_key])
+                    .collect::<Vec<_>>(),
+            )
+            .field(
+                "typename_fields",
+                &self
+                    .typename_fields()
+                    .map(|field| &keys[field.response_key])
+                    .collect::<Vec<_>>(),
+            )
+            .field(
+                "lookup_fields",
+                &self
+                    .lookup_fields()
+                    .map(|field| &keys[field.subgraph_key])
+                    .collect::<Vec<_>>(),
+            )
+            .finish()
+    }
+}

--- a/crates/engine/src/response/write/deserialize/ctx.rs
+++ b/crates/engine/src/response/write/deserialize/ctx.rs
@@ -40,8 +40,12 @@ impl<'ctx> SeedContext<'ctx> {
         &self.prepared_operation.cached.operation.response_keys
     }
 
-    pub(super) fn path(&self) -> RefMut<'_, Vec<ResponseValueId>> {
+    pub(super) fn path_mut(&self) -> RefMut<'_, Vec<ResponseValueId>> {
         self.path.borrow_mut()
+    }
+
+    pub(super) fn path(&self) -> Ref<'_, Vec<ResponseValueId>> {
+        self.path.borrow()
     }
 
     pub(super) fn display_path(&self) -> impl std::fmt::Display + '_ {

--- a/crates/engine/src/response/write/deserialize/list.rs
+++ b/crates/engine/src/response/write/deserialize/list.rs
@@ -94,13 +94,13 @@ where
         }
 
         loop {
-            ctx.path().push(ResponseValueId::Index {
+            ctx.path_mut().push(ResponseValueId::Index {
                 list_id,
                 index,
                 nullable: element_is_nullable,
             });
             let result = seq.next_element_seed(seed.clone());
-            ctx.path().pop();
+            ctx.path_mut().pop();
             match result {
                 Ok(Some(value)) => {
                     list.push(value);

--- a/crates/engine/src/response/write/deserialize/object/concrete.rs
+++ b/crates/engine/src/response/write/deserialize/object/concrete.rs
@@ -576,7 +576,7 @@ impl<'ctx> ConcreteShapeFieldsSeed<'ctx, '_> {
         field: &'ctx FieldShapeRecord,
         response_fields: &mut Vec<ResponseObjectField>,
     ) -> Result<(), A::Error> {
-        self.ctx.path().push(ResponseValueId::Field {
+        self.ctx.path_mut().push(ResponseValueId::Field {
             object_id: self.object_id,
             key: field.key,
             nullable: field.wrapping.is_nullable(),
@@ -586,7 +586,7 @@ impl<'ctx> ConcreteShapeFieldsSeed<'ctx, '_> {
             field,
             wrapping: field.wrapping.to_mutable(),
         });
-        self.ctx.path().pop();
+        self.ctx.path_mut().pop();
         let value = result?;
 
         response_fields.push(ResponseObjectField { key: field.key, value });

--- a/crates/integration-tests/tests/gateway/composite/lookup/mod.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/mod.rs
@@ -1,4 +1,5 @@
 mod key;
+mod shape;
 
 use graphql_mocks::dynamic::DynamicSchema;
 use integration_tests::{gateway::Gateway, runtime};

--- a/crates/integration-tests/tests/gateway/composite/lookup/shape.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/shape.rs
@@ -1,0 +1,155 @@
+use graphql_mocks::dynamic::DynamicSchema;
+use integration_tests::{gateway::Gateway, runtime};
+use serde_json::json;
+
+use crate::gateway::extensions::selection_set_resolver::StaticSelectionSetResolverExt;
+
+#[test]
+fn generate_the_correct_lookup_field_shape() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph(
+                DynamicSchema::builder(
+                    r#"
+                    type Query {
+                        users: [User!]!
+                    }
+
+                    type User @key(fields: "id") {
+                        id: Int!
+                        age: Int
+                    }
+                    "#,
+                )
+                .with_resolver("Query", "users", json!([{"id":3,"age":13},{"id":1,"age":12}]))
+                .into_subgraph("gql"),
+            )
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "static-1.0.0", import: ["@init"])
+                    @link(url: "https://specs.grafbase.com/composite-schema/v1", import: ["@lookup", "@key"])
+                    @init
+
+                type Query {
+                    userLookup(ids: [Int!]!): [User!]! @lookup
+                }
+
+                type User @key(fields: "id") {
+                    id: Int!
+                    name: String!
+                    blogs: BlogConnection
+                }
+
+                type BlogConnection
+                {
+                    edges: [BlogEdge!]!
+                }
+
+                type BlogEdge
+                {
+                    node: Blog!
+                }
+
+                type Blog
+                {
+                    id: Int!
+                }
+                "#,
+            )
+            .with_extension(StaticSelectionSetResolverExt::json(json!([
+               {
+                  "id":3,
+                  "name":"Pentti",
+                  "blogs":{
+                     "edges":[],
+                     "pageInfo":{
+                        "endCursor":"todo",
+                        "hasNextPage":false,
+                        "startCursor":"todo",
+                        "hasPreviousPage":false
+                     }
+                  }
+               },
+               {
+                  "id":1,
+                  "name":"Musti",
+                  "blogs":{
+                     "edges":[
+                        {
+                           "node":{
+                              "id":1
+                           },
+                           "cursor":"todo"
+                        },
+                        {
+                           "node":{
+                              "id":2
+                           },
+                           "cursor":"todo"
+                        }
+                     ],
+                     "pageInfo":{
+                        "endCursor":"todo",
+                        "hasNextPage":false,
+                        "startCursor":"todo",
+                        "hasPreviousPage":false
+                     }
+                  }
+               }
+            ])))
+            .build()
+            .await;
+
+        let response = engine
+            .post(
+                r#"
+                query {
+                  users {
+                    id
+                    name
+                    age
+                    blogs { edges { node { id } } }
+                  }
+                }
+                "#,
+            )
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "users": [
+              {
+                "id": 3,
+                "name": "Pentti",
+                "age": 13,
+                "blogs": {
+                  "edges": []
+                }
+              },
+              {
+                "id": 1,
+                "name": "Musti",
+                "age": 12,
+                "blogs": {
+                  "edges": [
+                    {
+                      "node": {
+                        "id": 1
+                      }
+                    },
+                    {
+                      "node": {
+                        "id": 2
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+        "#);
+    })
+}


### PR DESCRIPTION
A classic problem with an index range, taking the start index before
processing sub-fields and the end after. So we ended up with a root
selection set with all nested fields.

Fixed/Improved a few other things also, the problem was here: https://github.com/grafbase/grafbase/pull/3109/files#diff-90b9bc3a66d5fa7490c5eaee0eab69e1cd092e1dbee66fc3218e7177b7908342