### PR TITLE
cli: fix extension name collisions in grafbase dev

### DIFF
--- a/cli/src/compose.rs
+++ b/cli/src/compose.rs
@@ -12,7 +12,7 @@ pub(crate) async fn compose(args: ComposeCommand) -> anyhow::Result<()> {
 
     let subgraph_cache = SubgraphCache::new(args.graph_ref.as_ref(), &config, warnings_sender).await?;
 
-    let result = subgraph_cache.compose().await?;
+    let result = subgraph_cache.compose(&config).await?;
 
     match result {
         Ok(schema) => {

--- a/cli/src/dev.rs
+++ b/cli/src/dev.rs
@@ -106,7 +106,7 @@ async fn start(args: DevCommand) -> anyhow::Result<()> {
     let subgraph_cache =
         Arc::new(SubgraphCache::new(args.graph_ref.as_ref(), &config, composition_warnings_sender).await?);
 
-    let composition_result = subgraph_cache.compose().await?;
+    let composition_result = subgraph_cache.compose(&config).await?;
 
     let federated_sdl = match composition_result {
         Ok(federated_schema) => federated_schema,

--- a/cli/src/dev/hot_reload.rs
+++ b/cli/src/dev/hot_reload.rs
@@ -142,7 +142,7 @@ async fn reload_subgraphs(
     cancellation_token: Option<CancellationToken>,
 ) -> Result<(), BackendError> {
     subgraph_cache.reload_local_subgraphs(&config).await?;
-    let composition_result = subgraph_cache.compose().await?;
+    let composition_result = subgraph_cache.compose(&config).await?;
 
     let federated_sdl = match composition_result {
         Ok(result) => result,

--- a/crates/graphql-composition/src/compose/context.rs
+++ b/crates/graphql-composition/src/compose/context.rs
@@ -295,3 +295,11 @@ impl<'a> Context<'a> {
         self.ir.used_extensions.put(usize::from(id));
     }
 }
+
+impl std::ops::Index<subgraphs::StringId> for Context<'_> {
+    type Output = str;
+
+    fn index(&self, index: subgraphs::StringId) -> &Self::Output {
+        &self.subgraphs[index]
+    }
+}

--- a/crates/graphql-composition/src/subgraphs.rs
+++ b/crates/graphql-composition/src/subgraphs.rs
@@ -125,6 +125,8 @@ impl Subgraphs {
     }
 
     /// Add Grafbase extension schemas to compose. The extensions are referenced in subgraphs through their `url` in an `@link` directive.
+    ///
+    /// It is safe to add the same extension (same name) multiple times. It will only be an error if the urls are not compatible. Different remote versions are compatible between each other, but different paths are not compatible, and local paths are not compatible with remote urls.
     #[cfg(feature = "grafbase-extensions")]
     pub fn ingest_loaded_extensions(&mut self, extensions: impl IntoIterator<Item = crate::LoadedExtension>) {
         self.extensions

--- a/crates/graphql-composition/src/validate/extension_names.rs
+++ b/crates/graphql-composition/src/validate/extension_names.rs
@@ -10,9 +10,34 @@ pub(crate) fn validate_extension_names(ctx: &mut ValidateContext<'_>) {
         let name = ctx.subgraphs.strings.resolve(extension.name);
 
         if !seen.insert(name.to_ascii_lowercase()) {
-            ctx.diagnostics.push_fatal(format!(
-                r#"Found two extensions named "{name}". Extension names are case insensitive."#
-            ));
+            if let Some(previous) = ctx
+                .subgraphs
+                .iter_extensions()
+                .find(|ext| ctx[ext.name].eq_ignore_ascii_case(&ctx[extension.name]))
+            {
+                if extension_urls_are_compatible(&ctx[previous.url], &ctx[extension.url]) {
+                    continue;
+                } else {
+                    ctx.diagnostics.push_fatal(format!(
+                        r#"Found two extensions named "{name}". The urls must match, but got "{}" and "{}"."#,
+                        &ctx[previous.url], &ctx[extension.url],
+                    ));
+                }
+            } else {
+                ctx.diagnostics.push_fatal(format!(
+                    r#"Found two extensions named "{name}". Extension names are case insensitive."#
+                ));
+            }
         }
     }
+}
+
+fn extension_urls_are_compatible(a: &str, b: &str) -> bool {
+    // If there is a path, it must be the same
+    if a.starts_with("file:") || b.starts_with("file:") {
+        return a == b;
+    }
+
+    // Otherwise, assume they're the same
+    true
 }

--- a/crates/graphql-composition/tests/composition/extensions_name_collision/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/extensions_name_collision/federated.graphql.snap
@@ -3,4 +3,4 @@ source: crates/graphql-composition/tests/composition_tests.rs
 expression: Tests that extension names are case insensitive and unique.
 input_file: crates/graphql-composition/tests/composition/extensions_name_collision/test.md
 ---
-# Found two extensions named "REST-CONNECTOR". Extension names are case insensitive.
+# Found two extensions named "REST-CONNECTOR". The urls must match, but got "https://extensions.grafbase.com/rest" and "file://my/home/rest-connector-dev".

--- a/crates/graphql-composition/tests/composition/extensions_same_extension_ingested_twice/api.graphql.snap
+++ b/crates/graphql-composition/tests/composition/extensions_same_extension_ingested_twice/api.graphql.snap
@@ -1,0 +1,8 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: actual_api_sdl
+input_file: crates/graphql-composition/tests/composition/extensions_same_extension_ingested_twice/test.md
+---
+type Query {
+  hiMark: String
+}

--- a/crates/graphql-composition/tests/composition/extensions_same_extension_ingested_twice/extensions.toml
+++ b/crates/graphql-composition/tests/composition/extensions_same_extension_ingested_twice/extensions.toml
@@ -1,0 +1,7 @@
+[[extensions]]
+url = "https://extensions.grafbase.com/rest"
+name = "rest-connector"
+
+[[extensions]]
+url = "https://extensions.grafbase.com/rest"
+name = "REST-CONNECTOR"

--- a/crates/graphql-composition/tests/composition/extensions_same_extension_ingested_twice/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/extensions_same_extension_ingested_twice/federated.graphql.snap
@@ -1,0 +1,28 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: "Tests that extension names are case insensitive and unique. But if the same extension is ingested twice, as long as the url is compatible, we're fine."
+input_file: crates/graphql-composition/tests/composition/extensions_same_extension_ingested_twice/test.md
+---
+directive @join__unionMember(graph: join__Graph!, member: String!) on UNION
+
+directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT | INTERFACE
+
+directive @join__graph(name: String!, url: String) on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+
+directive @join__owner(graph: join__Graph!) on OBJECT
+
+scalar join__FieldSet
+
+type Query
+{
+  hiMark: String @join__field(graph: IRRELEVANT)
+}
+
+enum join__Graph
+{
+  IRRELEVANT @join__graph(name: "irrelevant", url: "http://example.com/irrelevant")
+}

--- a/crates/graphql-composition/tests/composition/extensions_same_extension_ingested_twice/subgraphs/irrelevant.graphql
+++ b/crates/graphql-composition/tests/composition/extensions_same_extension_ingested_twice/subgraphs/irrelevant.graphql
@@ -1,0 +1,3 @@
+type Query {
+  hiMark: String
+}

--- a/crates/graphql-composition/tests/composition/extensions_same_extension_ingested_twice/test.md
+++ b/crates/graphql-composition/tests/composition/extensions_same_extension_ingested_twice/test.md
@@ -1,0 +1,1 @@
+Tests that extension names are case insensitive and unique. But if the same extension is ingested twice, as long as the url is compatible, we're fine.


### PR DESCRIPTION
Until this commit, if you imported the same extension in multiple subgraphs, grafbase dev would ingest it twice and that would trigger a name collision error at the composition stage.

Composition now accepts multiple loaded extension definitions, as long as their urls are compatible (see explanation in the diff).

In addition, grafbase dev also adds extensions from grafbase.toml to the composition input compose now, just so configuration takes precedence for names over auto-detected extensions.

closes GB-8977