### PR TITLE
 graphql-federated-graph: simplify FederatedGraph::default() 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4283,7 +4283,6 @@ dependencies = [
  "bitflags 2.9.0",
  "cynic-parser",
  "cynic-parser-deser",
- "expect-test",
  "grafbase-workspace-hack",
  "graphql-wrapping-types",
  "indexmap 2.9.0",

--- a/crates/graphql-federated-graph/Cargo.toml
+++ b/crates/graphql-federated-graph/Cargo.toml
@@ -24,7 +24,6 @@ indexmap = { optional = true, workspace = true }
 itertools.workspace = true
 
 [dev-dependencies]
-expect-test.workspace = true
 insta.workspace = true
 pretty_assertions.workspace = true
 serde_json.workspace = true

--- a/crates/graphql-federated-graph/src/federated_graph.rs
+++ b/crates/graphql-federated-graph/src/federated_graph.rs
@@ -34,7 +34,7 @@ use enum_definitions::EnumDefinition;
 use scalar_definitions::ScalarDefinition;
 use std::ops::Range;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct FederatedGraph {
     pub subgraphs: Vec<Subgraph>,
     pub extensions: Vec<Extension>,
@@ -280,70 +280,6 @@ pub struct Key {
     pub is_interface_object: bool,
 
     pub resolvable: bool,
-}
-
-impl Default for FederatedGraph {
-    fn default() -> Self {
-        FederatedGraph {
-            directive_definitions: Vec::new(),
-            directive_definition_arguments: Vec::new(),
-            enum_definitions: Vec::new(),
-            subgraphs: Vec::new(),
-            extensions: Vec::new(),
-            interfaces: Vec::new(),
-            unions: Vec::new(),
-            input_objects: Vec::new(),
-            enum_values: Vec::new(),
-            input_value_definitions: Vec::new(),
-
-            scalar_definitions: vec![ScalarDefinitionRecord {
-                namespace: None,
-                name: StringId::from(3),
-                description: None,
-                directives: Vec::new(),
-            }],
-            root_operation_types: RootOperationTypes {
-                query: Some(ObjectId::from(0)),
-                mutation: None,
-                subscription: None,
-            },
-            objects: vec![Object {
-                name: StringId::from(0),
-                description: None,
-                directives: Vec::new(),
-                implements_interfaces: Vec::new(),
-                fields: FieldId::from(0)..FieldId::from(2),
-            }],
-            fields: vec![
-                Field {
-                    name: StringId::from(1),
-                    r#type: Type {
-                        wrapping: Default::default(),
-                        definition: Definition::Scalar(0usize.into()),
-                    },
-                    parent_entity_id: EntityDefinitionId::Object(ObjectId::from(0)),
-                    arguments: NO_INPUT_VALUE_DEFINITION,
-                    description: None,
-                    directives: Vec::new(),
-                },
-                Field {
-                    name: StringId::from(2),
-                    r#type: Type {
-                        wrapping: Default::default(),
-                        definition: Definition::Scalar(0usize.into()),
-                    },
-                    parent_entity_id: EntityDefinitionId::Object(ObjectId::from(0)),
-                    arguments: NO_INPUT_VALUE_DEFINITION,
-                    description: None,
-                    directives: Vec::new(),
-                },
-            ],
-            strings: ["Query", "__type", "__schema", "String"]
-                .into_iter()
-                .map(|string| string.to_owned())
-                .collect(),
-        }
-    }
 }
 
 impl std::ops::Index<InputValueDefinitions> for FederatedGraph {

--- a/crates/graphql-federated-graph/src/federated_graph/root_operation_types.rs
+++ b/crates/graphql-federated-graph/src/federated_graph/root_operation_types.rs
@@ -1,6 +1,6 @@
 use crate::ObjectId;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct RootOperationTypes {
     pub query: Option<ObjectId>,
     pub mutation: Option<ObjectId>,

--- a/crates/graphql-federated-graph/src/render_sdl/render_federated_sdl.rs
+++ b/crates/graphql-federated-graph/src/render_sdl/render_federated_sdl.rs
@@ -507,8 +507,6 @@ mod tests {
 
     #[test]
     fn escape_strings() {
-        use expect_test::expect;
-
         let empty = FederatedGraph::from_sdl(
             r###"
             directive @dummy(test: String!) on FIELD
@@ -521,22 +519,18 @@ mod tests {
         .unwrap();
 
         let actual = render_federated_sdl(&empty).expect("valid");
-        let expected = expect![[r#"
+        insta::assert_snapshot!(actual, @r#"
             directive @dummy(test: String!) on FIELD
 
             type Query
             {
               field: String @deprecated(reason: "This is a \"deprecated\" reason") @dummy(test: "a \"test\"")
             }
-        "#]];
-
-        expected.assert_eq(&actual);
+        "#);
     }
 
     #[test]
     fn multiline_strings() {
-        use expect_test::expect;
-
         let empty = FederatedGraph::from_sdl(
             r###"
             directive @dummy(test: String!) on FIELD
@@ -555,16 +549,14 @@ mod tests {
         .unwrap();
 
         let actual = render_federated_sdl(&empty).expect("valid");
-        let expected = expect![[r#"
+        insta::assert_snapshot!(actual, @r#"
             directive @dummy(test: String!) on FIELD
 
             type Query
             {
               field: String @deprecated(reason: "This is a \"deprecated\" reason\n\non multiple lines.\n\nyes, way") @dummy(test: "a \"test\"")
             }
-        "#]];
-
-        expected.assert_eq(&actual);
+        "#);
     }
 
     #[test]


### PR DESCRIPTION
We don't need to do anything fancy anymore because the engine schema is instantiated from SDL now.