### PR TITLE
cli: validate schemas before composition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3830,6 +3830,7 @@ dependencies = [
  "graphql-federated-graph",
  "graphql-lint",
  "graphql-mocks",
+ "graphql-schema-validation",
  "http 1.3.1",
  "ignore",
  "indicatif",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -84,6 +84,7 @@ grafbase-workspace-hack.workspace = true
 graph-ref.workspace = true
 graphql-composition.workspace = true
 graphql-lint.workspace = true
+graphql-schema-validation.workspace = true
 runtime.workspace = true
 runtime-local.workspace = true
 semver.workspace = true

--- a/cli/changelog/unreleased.md
+++ b/cli/changelog/unreleased.md
@@ -1,3 +1,7 @@
+## Improvements
+
+- GraphQL schema validation is now run on every subgraph schema before composition in `grafbase dev` and `grafbase compose`. That makes for better error messages.
+
 ## Breaking changes
 
 - The CLI will now try to expand environment variables everywhere in the `grafbase.toml` configuration with the syntax `{{ env>VAR_NAME }}`.

--- a/cli/src/dev/subgraphs.rs
+++ b/cli/src/dev/subgraphs.rs
@@ -175,6 +175,22 @@ impl SubgraphCache {
                 async move {
                     let current_dir = current_dir;
 
+                    {
+                        let diagnostics = graphql_schema_validation::validate(&subgraph.sdl);
+
+                        if diagnostics.has_errors() {
+                            return Err(anyhow::anyhow!(
+                                "The schema of subgraph `{}` is invalid: {}",
+                                subgraph.name,
+                                diagnostics
+                                    .iter()
+                                    .map(|diagnostic| diagnostic.to_string())
+                                    .collect::<Vec<_>>()
+                                    .join("\n\n")
+                            ));
+                        }
+                    }
+
                     let parsed_schema = cynic_parser::parse_type_system_document(&subgraph.sdl).map_err(|err| {
                         anyhow::anyhow!("Failed to parse subgraph SDL for `{}`: {err}", subgraph.name)
                     })?;


### PR DESCRIPTION
In both `grafbase dev` and `grafbase compose`.

closes GB-8981