### PR TITLE
graphql-composition: test that directive definitions line up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4267,6 +4267,7 @@ dependencies = [
  "fixedbitset",
  "grafbase-workspace-hack",
  "graphql-federated-graph",
+ "graphql-schema-validation",
  "indexmap 2.9.0",
  "insta",
  "itertools 0.14.0",

--- a/crates/graphql-composition/CHANGELOG.md
+++ b/crates/graphql-composition/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Composition now allows federated graphs without a query root. That happens if none of the subgraphs define a query root type. The new, relaxed requirement is that at least one root field (query, mutation or subscription) is defined, so the federated schema is not empty. (https://github.com/grafbase/grafbase/pull/3111)
+- Fixed a few inaccurate directive definition locations in the federated SDL emitted by render_federated_sdl().
 
 ### Fixes
 

--- a/crates/graphql-composition/Cargo.toml
+++ b/crates/graphql-composition/Cargo.toml
@@ -27,6 +27,7 @@ url.workspace = true
 [dev-dependencies]
 anyhow.workspace = true
 grafbase-workspace-hack.workspace = true
+graphql-schema-validation.workspace = true
 insta.workspace = true
 pretty_assertions.workspace = true
 serde.workspace = true

--- a/crates/graphql-composition/src/emit_federated_graph/federation_builtins.rs
+++ b/crates/graphql-composition/src/emit_federated_graph/federation_builtins.rs
@@ -152,7 +152,7 @@ pub(super) fn emit_federation_builtins(ctx: &mut Context<'_>, join_graph_enum_id
     //     external: Boolean,
     //     override: String,
     //     overrideLabel: String
-    // ) on FIELD_DEFINITION
+    // ) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
     {
         let directive_name = ctx.insert_str("field");
         let requires_str = ctx.insert_str("requires");
@@ -161,7 +161,8 @@ pub(super) fn emit_federation_builtins(ctx: &mut Context<'_>, join_graph_enum_id
         let directive_definition_id = ctx.out.push_directive_definition(federated::DirectiveDefinitionRecord {
             namespace: join_namespace,
             name: directive_name,
-            locations: federated::DirectiveLocations::FIELD_DEFINITION,
+            locations: federated::DirectiveLocations::FIELD_DEFINITION
+                | federated::DirectiveLocations::INPUT_FIELD_DEFINITION,
             repeatable: false,
         });
 
@@ -277,7 +278,12 @@ pub(super) fn emit_federation_builtins(ctx: &mut Context<'_>, join_graph_enum_id
         let directive_definition_id = ctx.out.push_directive_definition(federated::DirectiveDefinitionRecord {
             namespace: join_namespace,
             name,
-            locations: federated::DirectiveLocations::OBJECT | federated::DirectiveLocations::INTERFACE,
+            locations: federated::DirectiveLocations::OBJECT
+                | federated::DirectiveLocations::INTERFACE
+                | federated::DirectiveLocations::UNION
+                | federated::DirectiveLocations::ENUM
+                | federated::DirectiveLocations::INPUT_OBJECT
+                | federated::DirectiveLocations::SCALAR,
             repeatable: false,
         });
 

--- a/crates/graphql-composition/tests/composition/authenticated_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/authenticated_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/authorized_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/authorized_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/authorized_with_composeDirective/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/authorized_with_composeDirective/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/composed_directives_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/composed_directives_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/composite_schema/api.graphql.snap
+++ b/crates/graphql-composition/tests/composition/composite_schema/api.graphql.snap
@@ -10,7 +10,7 @@ type User {
 
 type Account {
   id: ID!
-  name: String
+  name(case: String): String
 }
 
 type Query {

--- a/crates/graphql-composition/tests/composition/composite_schema/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/composite_schema/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 
@@ -34,7 +34,7 @@ type Account
   @join__type(graph: B, key: "id", resolvable: false)
 {
   id: ID!
-  name: String @composite__require(graph: B, field: "ploop")
+  name(case: String @composite__require(graph: B, field: "ploop")): String
 }
 
 type Query

--- a/crates/graphql-composition/tests/composition/composite_schema/subgraphs/b.graphql
+++ b/crates/graphql-composition/tests/composition/composite_schema/subgraphs/b.graphql
@@ -6,5 +6,5 @@ type Query {
 
 type Account @key(fields: "id") {
   id: ID!
-  name: String @require(field: "ploop")
+  name(case: String @require(field: "ploop")): String
 }

--- a/crates/graphql-composition/tests/composition/cost_basic/api.graphql.snap
+++ b/crates/graphql-composition/tests/composition/cost_basic/api.graphql.snap
@@ -9,12 +9,12 @@ enum Blah {
   BLAH
 }
 
-type Query {
+type Account {
   foo(name: String): String
   id: ID!
 }
 
-interface Account {
+type Query {
   foo(name: String): String
   id: ID!
 }

--- a/crates/graphql-composition/tests/composition/cost_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/cost_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 
@@ -22,19 +22,19 @@ scalar Foo
 
 scalar join__FieldSet
 
-type Query
-  @cost(weight: 1)
-{
-  foo(name: String @cost(weight: 100)): String @join__field(graph: A)
-  id: ID! @cost(weight: 2) @join__field(graph: A)
-}
-
-interface Account
+type Account
   @cost(weight: 3)
   @join__type(graph: A)
 {
   foo(name: String @cost(weight: 200)): String
   id: ID! @cost(weight: 4)
+}
+
+type Query
+  @cost(weight: 1)
+{
+  foo(name: String @cost(weight: 100)): String @join__field(graph: A)
+  id: ID! @cost(weight: 2) @join__field(graph: A)
 }
 
 enum Blah

--- a/crates/graphql-composition/tests/composition/cost_basic/subgraphs/a.graphql
+++ b/crates/graphql-composition/tests/composition/cost_basic/subgraphs/a.graphql
@@ -4,7 +4,7 @@ type Query @cost(weight: 1) {
   foo(name: String @cost(weight: 100)): String
 }
 
-interface Account @cost(weight: 3) {
+type Account @cost(weight: 3) {
   id: ID! @cost(weight: 4)
 
   foo(name: String @cost(weight: 200)): String

--- a/crates/graphql-composition/tests/composition/custom_query_root/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/custom_query_root/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/custom_query_root_as_non_root_in_other_subgraph/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/custom_query_root_as_non_root_in_other_subgraph/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/custom_scalars_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/custom_scalars_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/default_values/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/default_values/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/descriptions_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/descriptions_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/disjoint_keys/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/disjoint_keys/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/empty_query_type/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/empty_query_type/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/entity_composite_key_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_composite_key_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/entity_composite_key_nested/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_composite_key_nested/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/entity_interface_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_interface_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/entity_interfaces_multi_subgraph/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_interfaces_multi_subgraph/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/entity_interfaces_with_requires/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_interfaces_with_requires/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/entity_multiple_keys_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_multiple_keys_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/entity_staggered_composite_key/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_staggered_composite_key/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/entity_unresolvable_keys/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/entity_unresolvable_keys/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/enum_only_inputs/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/enum_only_inputs/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/enum_only_outputs/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/enum_only_outputs/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/enum_unused/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/enum_unused/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/extensions_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/extensions_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/extensions_directives_on_schema_definition/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/extensions_directives_on_schema_definition/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/extensions_same_extension_ingested_twice/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/extensions_same_extension_ingested_twice/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/field_type_composition/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/field_type_composition/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/inaccessible_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/inaccessible_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/inaccessible_in_one_subgraph_is_enough/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/inaccessible_in_one_subgraph_is_enough/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/input_object_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/input_object_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/interface_implementing_interface_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/interface_implementing_interface_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 
@@ -27,8 +27,9 @@ type Product implements Node
   price: Float!
 }
 
-type User implements Timestamped
+type User implements Node & Timestamped
   @join__type(graph: USER)
+  @join__implements(graph: USER, interface: "Node")
   @join__implements(graph: USER, interface: "Timestamped")
 {
   createdAt: String!

--- a/crates/graphql-composition/tests/composition/interface_implementing_interface_basic/subgraphs/user.graphql
+++ b/crates/graphql-composition/tests/composition/interface_implementing_interface_basic/subgraphs/user.graphql
@@ -8,7 +8,7 @@ interface Timestamped implements Node {
   updatedAt: String!
 }
 
-type User implements Timestamped {
+type User implements Timestamped & Node {
   id: ID!
   createdAt: String!
   updatedAt: String!

--- a/crates/graphql-composition/tests/composition/interfaces_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/interfaces_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/interfaces_single_subgraph/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/interfaces_single_subgraph/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/kebab_case_subgraph_names/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/kebab_case_subgraph_names/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/link_import_as_valid/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/link_import_as_valid/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/link_import_scoping/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/link_import_scoping/federated.graphql.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/graphql-composition/tests/composition_tests.rs
-expression: huh?
-input_file: crates/graphql-composition/tests/composition/repro/test.md
+expression: "Check that `@link` imports are only valid for the subgraph that define the import. The import for the composite schemas spec `@key` should lead to `resolvable: false` only in the subgraph where it is imported."
+input_file: crates/graphql-composition/tests/composition/link_import_scoping/test.md
 ---
 directive @join__unionMember(graph: join__Graph!, member: String!) on UNION
 
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/list_size/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/list_size/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/namespaced_directive_without_import_are_ignored/subgraphs/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/namespaced_directive_without_import_are_ignored/subgraphs/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/namespaced_directives_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/namespaced_directives_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/no_query_type/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/no_query_type/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/null_value/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/null_value/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/object_field_arguments_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/object_field_arguments_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/objects_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/objects_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/override_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/override_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/override_label/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/override_label/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/policy_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/policy_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/provides_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/provides_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/requiresScopes_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/requiresScopes_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/requires_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/requires_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/requires_with_arguments/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/requires_with_arguments/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/requires_with_nested_inline_fragment/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/requires_with_nested_inline_fragment/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/shareable_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/shareable_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/shareable_is_repeatable/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/shareable_is_repeatable/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/subgraph_query_fields_service_entities/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/subgraph_query_fields_service_entities/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/subscriptions_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/subscriptions_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/tag_directive_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/tag_directive_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-composition/tests/composition/unions_basic/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/unions_basic/federated.graphql.snap
@@ -9,9 +9,9 @@ directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT |
 
 directive @join__graph(name: String!, url: String) on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
-directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on OBJECT | INTERFACE
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
 
 directive @join__owner(graph: join__Graph!) on OBJECT
 

--- a/crates/graphql-schema-validation/CHANGELOG.md
+++ b/crates/graphql-schema-validation/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Whenever we had a graph of input objects with multiple cycles in graphql-schema-validation, we would go into an infinite loop and stack overflow. This is fixed in this release.
 - Do not consider schema extensions as schema definitions for the purpose of duplicate schema definition validation.
 - Validation of the types of arguments inside directive definitions worked only for types defined before the directive definition. That would lead to incorrect validation errors about scalar or input types not existing. Validation of argument types in directive definitions now properly takes all types into account.
+- Fixed validation of directive locations on enum values — they were mistakenly treated as input value definitions.
 
 ## [0.1.3] - 2024-02-06
 

--- a/crates/graphql-schema-validation/src/validate/enums.rs
+++ b/crates/graphql-schema-validation/src/validate/enums.rs
@@ -16,11 +16,7 @@ pub(crate) fn validate_enum_members<'a>(
         });
 
         for value in values {
-            validate_directives(
-                &value.node.directives,
-                ast::DirectiveLocation::InputFieldDefinition,
-                ctx,
-            );
+            validate_directives(&value.node.directives, ast::DirectiveLocation::EnumValue, ctx);
         }
     });
 }

--- a/crates/graphql-schema-validation/src/validate/interface_implementers.rs
+++ b/crates/graphql-schema-validation/src/validate/interface_implementers.rs
@@ -246,7 +246,7 @@ fn validate_implements_interface_transitively<'a>(
         {
             let implements = iface_implements.node.as_str();
             ctx.push_error(miette::miette!(
-                "`Type {parent_name}` must implement `{implements}` because it is implemented by `{iface_name}`"
+                "Type `{parent_name}` must implement `{implements}` because it is implemented by `{iface_name}`"
             ));
         }
     }

--- a/crates/graphql-schema-validation/tests/validation_errors/object_does_not_implement_transitively.errors.txt
+++ b/crates/graphql-schema-validation/tests/validation_errors/object_does_not_implement_transitively.errors.txt
@@ -1,7 +1,7 @@
-  × `Type Siamese` must implement `HasId` because it is implemented by `Cat`
+  × Type `Siamese` must implement `HasId` because it is implemented by `Cat`
 
 
-  × `Type MeowingCat` must implement `HasId` because it is implemented by `Cat`
+  × Type `MeowingCat` must implement `HasId` because it is implemented by `Cat`
 
 
   × Missing `id` field in `MeowingCat` (required by the `Cat` interface)


### PR DESCRIPTION
In graphql-composition tests, test that the federated graph is valid GraphQL with graphql-schema-validation. That revealed a few directive definitions that didn't line up with the usage, sometimes because the usage was wrong, sometimes because the directive definition was wrong.

Also revealed a bug and a bad error message in graphql-schema-validation.