### PR TITLE
cli: add third-party plugins support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,6 +1588,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
+name = "color-print"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aa954171903797d5623e047d9ab69d91b493657917bdfb8c2c80ecaf9cdb6f4"
+dependencies = [
+ "color-print-proc-macro",
+]
+
+[[package]]
+name = "color-print-proc-macro"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692186b5ebe54007e45a59aea47ece9eb4108e141326c304cdc91699a7118a22"
+dependencies = [
+ "nom",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3811,6 +3832,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "cli-table",
+ "color-print",
  "colored",
  "const_format",
  "convert_case 0.8.0",
@@ -3884,6 +3906,7 @@ dependencies = [
  "wasi-component-loader",
  "wasmparser 0.228.0",
  "webbrowser",
+ "which 7.0.3",
  "wiremock",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ clap = "4"
 clap_complete = "4.5"
 cli-table = { version = "0.5", default-features = false }
 clickhouse = "0.13"
+color-print = "0.3"
 colored = "3"
 const_format = "0.2"
 convert_case = "0.8"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,6 +18,7 @@ chrono.workspace = true
 clap = { workspace = true, features = ["cargo", "wrap_help", "derive", "env"] }
 clap_complete.workspace = true
 cli-table = { workspace = true, default-features = false }
+color-print.workspace = true
 colored.workspace = true
 const_format.workspace = true
 crossterm.workspace = true
@@ -66,6 +67,7 @@ url.workspace = true
 urlencoding.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 webbrowser.workspace = true
+which.workspace = true
 
 anyhow.workspace = true
 askama.workspace = true

--- a/cli/changelog/unreleased.md
+++ b/cli/changelog/unreleased.md
@@ -1,0 +1,5 @@
+## Features
+
+- Added support for CLI plugins (https://github.com/grafbase/grafbase/pull/3133).
+
+  Any binary in your `$PATH` that starts with `grafbase-` will be automatically detected and usable as a subcommand. For example, if you have the `grafbase-postgres` plugin installed, you can run it with `grafbase postgres`. Subsequent arguments are forwarded to the plugin. A new `grafbase list-plugins` command is also introduced. If you are familiar with these, this is similar to how cargo and git plugins work.

--- a/cli/src/cli_input.rs
+++ b/cli/src/cli_input.rs
@@ -49,8 +49,25 @@ fn split_header(header: &str) -> Option<(&str, &str)> {
     })
 }
 
+// We have to override the default help template to include a custom section for third party subcommands.
+const HELP_TEMPLATE: &str = color_print::cstr!(
+    "\
+{before-help}{about-with-newline}
+{usage-heading} {usage}
+
+<bold><underline>Commands:</underline></bold>
+{subcommands}
+{tab}<bold>...</bold>               Run `grafbase list-plugins` for a list of available plugins.
+
+<bold><underline>Options:</underline></bold>
+{options}
+
+{after-help}\
+"
+);
+
 #[derive(Debug, Parser)]
-#[command(name = "Grafbase CLI", version)]
+#[command(name = "Grafbase CLI", version, allow_external_subcommands = true, help_template = HELP_TEMPLATE)]
 /// The Grafbase command line interface
 pub struct Args {
     /// Set the tracing level

--- a/cli/src/cli_input/sub_command.rs
+++ b/cli/src/cli_input/sub_command.rs
@@ -10,12 +10,14 @@ use super::{
 
 #[derive(Debug, Parser, strum::AsRefStr, strum::Display)]
 #[strum(serialize_all = "lowercase")]
-pub enum SubCommand {
+pub(crate) enum SubCommand {
     /// Graph branch management
     Branch(BranchCommand),
     /// Output completions for the chosen shell to use, write the output to the
     /// appropriate location for your shell
     Completions(CompletionsCommand),
+    /// List all plugin subcommands. To list first-party subcommands, run `grafbase help`.
+    ListPlugins,
     /// Logs into your Grafbase account
     Login(LoginCommand),
     /// Logs out of your Grafbase account
@@ -46,6 +48,8 @@ pub enum SubCommand {
     Mcp(McpCommand),
     /// Develop gateway extensions
     Extension(ExtensionCommand),
+    #[clap(external_subcommand)]
+    Plugin(Vec<String>),
 }
 
 pub trait RequiresLogin {

--- a/cli/src/plugins.rs
+++ b/cli/src/plugins.rs
@@ -1,0 +1,105 @@
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+use std::{env, fs, path::Path, process};
+
+const PLUGIN_COMMANDS_PREFIX: &str = "grafbase-";
+const PLUGIN_COMMANDS_SUFFIX: &str = env::consts::EXE_SUFFIX;
+
+pub(crate) fn execute(args: &[String]) -> anyhow::Result<()> {
+    let Some(name) = args.first() else {
+        // it should be unreachable
+        return Err(anyhow::anyhow!("No command provided"));
+    };
+
+    if name == "gateway" {
+        anyhow::bail!(
+            "Running grafbase-gateway as a plugin CLI command is not supported. Please run `grafbase-gateway` directly instead of `grafbase gateway`."
+        )
+    }
+
+    let binary_name = format!("{PLUGIN_COMMANDS_PREFIX}{name}{PLUGIN_COMMANDS_SUFFIX}");
+
+    match which::which(&binary_name) {
+        Err(err) => {
+            anyhow::bail!(
+                "The binary '{binary_name}' is not installed ({err})\nRun `grafbase help` to list built-in commands or `grafbase list-plugins` to list available plugin commands."
+            )
+        }
+        #[cfg(unix)]
+        Ok(path) => Err(process::Command::new(path).args(&args[1..]).exec().into()),
+        #[cfg(not(unix))]
+        Ok(path) => process::Command::new(path)
+            .args(&args[1..])
+            .output()
+            .map(|_| ())
+            .map_err(From::from),
+    }
+}
+
+pub(crate) fn list() -> anyhow::Result<()> {
+    let path = path();
+
+    let mut external_commands = Vec::new();
+
+    // Logic inspired by https://github.com/rust-lang/cargo/blob/6cba807e2ce0b7b4bcdf3bdf0a07dcf83988c05a/src/bin/cargo/main.rs#L222
+    for dir in std::env::split_paths(&path) {
+        let Ok(entries) = fs::read_dir(dir) else { continue };
+
+        for entry in entries.filter_map(|e| e.ok()) {
+            let path = entry.path();
+            let Some(filename) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+
+            let Some(name) = filename
+                .strip_prefix(PLUGIN_COMMANDS_PREFIX)
+                .and_then(|s| s.strip_suffix(PLUGIN_COMMANDS_SUFFIX))
+            else {
+                continue;
+            };
+
+            if is_executable(entry.path()) && name != "gateway" {
+                external_commands.push(name.to_string());
+            }
+        }
+    }
+
+    if external_commands.is_empty() {
+        eprintln!("Found no plugin");
+    }
+
+    color_print::cprintln!("<bold><underline>Plugins:</underline></bold>");
+    let base_command_name = env::args()
+        .next()
+        .and_then(|string| {
+            Path::new(&string)
+                .file_name()
+                .and_then(|file_name| file_name.to_str())
+                .map(ToOwned::to_owned)
+        })
+        .unwrap_or_default();
+
+    for command in external_commands {
+        println!("  {base_command_name} {command}")
+    }
+
+    Ok(())
+}
+
+fn path() -> String {
+    env::var("PATH").unwrap_or_default()
+}
+
+#[cfg(unix)]
+fn is_executable<P: AsRef<Path>>(path: P) -> bool {
+    use std::os::unix::prelude::*;
+
+    fs::metadata(path)
+        .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(windows)]
+fn is_executable<P: AsRef<Path>>(path: P) -> bool {
+    path.as_ref().is_file()
+}


### PR DESCRIPTION
Like cargo and git.

For example, if you have a `grafbase-postgres` binary installed, you can call it with `grafbase postgres`.

This PR includes:

- Executing third-party plugins when available
- Advertising them in the help text
- A `grafbase list-third-plugins` command to list them
- Handling of bad arguments, unknown third party plugins, etc.

The gateway (`grafbase-gateway`) is given special treatment and excluded from plugins, since it is its own thing, and it would be confusing if `grafbase gateway` worked locally, but not in an environment where the CLI is not installed.

closes GB-8998