### PR TITLE
feat(engine): @is binding & initial validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2866,6 +2866,7 @@ dependencies = [
  "grafbase-workspace-hack",
  "insta",
  "itertools 0.14.0",
+ "pretty_assertions",
  "winnow",
 ]
 
@@ -2954,6 +2955,7 @@ dependencies = [
  "blake3",
  "cynic-parser",
  "cynic-parser-deser",
+ "engine-field-selection-map",
  "engine-id-derives",
  "engine-id-newtypes",
  "engine-walker",

--- a/crates/engine/field-selection-map/Cargo.toml
+++ b/crates/engine/field-selection-map/Cargo.toml
@@ -12,5 +12,6 @@ winnow.workspace = true
 
 [dev-dependencies]
 insta.workspace = true
+pretty_assertions.workspace = true
 # Not sure how to make it work with Hakari, it'll add debug feature everywhere with this...
 # winnow = { workspace = true, features = ["debug"] }

--- a/crates/engine/field-selection-map/src/model.rs
+++ b/crates/engine/field-selection-map/src/model.rs
@@ -76,14 +76,20 @@ impl fmt::Display for PathSegment<'_> {
 
 /// Represents a path to a field, possibly nested.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Path<'a>(pub Vec<PathSegment<'a>>);
+pub struct Path<'a> {
+    pub ty: Option<&'a str>,
+    pub segments: Vec<PathSegment<'a>>,
+}
 
 impl fmt::Display for Path<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(ty) = &self.ty {
+            write!(f, "<{}>.", ty)?
+        };
         write!(
             f,
             "{}",
-            self.0
+            self.segments
                 .iter()
                 .format_with(".", |segment, f| f(&format_args!("{}", segment)))
         )

--- a/crates/engine/schema/Cargo.toml
+++ b/crates/engine/schema/Cargo.toml
@@ -19,6 +19,7 @@ cynic-parser.workspace = true
 cynic-parser-deser.workspace = true
 extension-catalog.workspace = true
 federated-graph.workspace = true
+field-selection-map = { path = "../field-selection-map", package = "engine-field-selection-map" }
 fxhash.workspace = true
 gateway-config.workspace = true
 grafbase-workspace-hack.workspace = true

--- a/crates/engine/schema/src/builder/coerce/field_selection_map/bind.rs
+++ b/crates/engine/schema/src/builder/coerce/field_selection_map/bind.rs
@@ -1,0 +1,37 @@
+use crate::FieldDefinitionId;
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct BoundSelectedValue<Id> {
+    pub alternatives: Vec<BoundSelectedValueEntry<Id>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum BoundSelectedValueEntry<Id> {
+    Path(BoundPath),
+    ObjectWithPath {
+        path: BoundPath,
+        object: BoundSelectedObjectValue<Id>,
+    },
+    ListWithPath {
+        path: BoundPath,
+        list: BoundSelectedListValue<Id>,
+    },
+    Object(BoundSelectedObjectValue<Id>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct BoundPath(pub Vec<FieldDefinitionId>);
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct BoundSelectedObjectValue<Id> {
+    pub fields: Vec<BoundSelectedObjectField<Id>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct BoundSelectedObjectField<Id> {
+    pub field: Id,
+    pub value: Option<BoundSelectedValue<Id>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct BoundSelectedListValue<Id>(pub BoundSelectedValue<Id>);

--- a/crates/engine/schema/src/builder/coerce/field_selection_map/mod.rs
+++ b/crates/engine/schema/src/builder/coerce/field_selection_map/mod.rs
@@ -1,0 +1,353 @@
+mod bind;
+mod target;
+
+pub(crate) use bind::*;
+use std::collections::VecDeque;
+use target::*;
+
+use ::field_selection_map::*;
+use wrapping::Wrapping;
+
+use crate::{
+    CompositeTypeId, EntityDefinitionId, FieldDefinitionId, InputValueDefinitionId, TypeDefinitionId, TypeRecord,
+    builder::GraphBuilder,
+};
+
+use super::field_set::is_disjoint;
+
+impl GraphBuilder<'_> {
+    pub(crate) fn parse_field_selection_map_for_argument(
+        &mut self,
+        output: EntityDefinitionId,
+        field_id: FieldDefinitionId,
+        argument_id: InputValueDefinitionId,
+        field_selection_map: &str,
+    ) -> Result<BoundSelectedValue<InputValueDefinitionId>, String> {
+        let selected_value = SelectedValue::try_from(field_selection_map)?;
+        let wrapping = self.graph[argument_id].ty_record.wrapping;
+        bind_selected_value(
+            self,
+            (output.into(), Wrapping::required()),
+            (Input::Argument { field_id, argument_id }, wrapping),
+            selected_value,
+        )
+    }
+
+    pub(crate) fn parse_field_selection_map_for_field(
+        &mut self,
+        output: EntityDefinitionId,
+        target: FieldDefinitionId,
+        field_selection_map: &str,
+    ) -> Result<BoundSelectedValue<FieldDefinitionId>, String> {
+        let selected_value = SelectedValue::try_from(field_selection_map)?;
+        let wrapping = self.graph[target].ty_record.wrapping;
+        bind_selected_value(
+            self,
+            (output.into(), Wrapping::required()),
+            (target, wrapping),
+            selected_value,
+        )
+    }
+}
+
+fn bind_selected_value<T: Target>(
+    ctx: &mut GraphBuilder<'_>,
+    output: (CompositeTypeId, Wrapping),
+    target: (T, Wrapping),
+    selected_value: SelectedValue<'_>,
+) -> Result<BoundSelectedValue<T::Id>, String> {
+    let alternatives = selected_value
+        .alternatives
+        .into_iter()
+        .map(|entry| bind_selected_value_entry(ctx, output, target, entry))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(BoundSelectedValue { alternatives })
+}
+
+fn bind_selected_value_entry<T: Target>(
+    ctx: &mut GraphBuilder<'_>,
+    output: (CompositeTypeId, Wrapping),
+    target: (T, Wrapping),
+    selected_value: SelectedValueEntry<'_>,
+) -> Result<BoundSelectedValueEntry<T::Id>, String> {
+    match selected_value {
+        SelectedValueEntry::Path(path) => {
+            let (path, _) = bind_path(ctx, output, path)?;
+            let last = *path.0.last().unwrap();
+            ensure_type_compatibility(ctx, target, last)?;
+            Ok(BoundSelectedValueEntry::Path(path))
+        }
+        SelectedValueEntry::ObjectWithPath { path, object } => {
+            let (path, (output, output_wrapping)) = bind_path(ctx, output, path)?;
+            let output = output
+                .as_composite_type()
+                .ok_or_else(|| format!("Type {} does not have any fields", ctx[ctx.definition_name_id(output)]))?;
+            let object = bind_selected_object_value(ctx, (output, output_wrapping), target, object)?;
+            Ok(BoundSelectedValueEntry::ObjectWithPath { path, object })
+        }
+        SelectedValueEntry::ListWithPath { path, list } => {
+            let (path, (output, output_wrapping)) = bind_path(ctx, output, path)?;
+            let output = output
+                .as_composite_type()
+                .ok_or_else(|| format!("Type {} does not have any fields", ctx[ctx.definition_name_id(output)]))?;
+            let list = bind_selected_list_value(ctx, (output, output_wrapping), target, list)?;
+            Ok(BoundSelectedValueEntry::ListWithPath { path, list })
+        }
+        SelectedValueEntry::Object(object) => {
+            let object = bind_selected_object_value(ctx, output, target, object)?;
+            Ok(BoundSelectedValueEntry::Object(object))
+        }
+    }
+}
+
+fn bind_path(
+    ctx: &mut GraphBuilder<'_>,
+    (output, mut output_wrapping): (CompositeTypeId, Wrapping),
+    path: Path<'_>,
+) -> Result<(BoundPath, (TypeDefinitionId, Wrapping)), String> {
+    if output_wrapping.is_list() {
+        return Err(format!(
+            "Cannot select a field from {}, it's a list",
+            ctx.type_name(TypeRecord {
+                definition_id: output.into(),
+                wrapping: output_wrapping
+            })
+        ));
+    }
+    let mut output: TypeDefinitionId = if let Some(ty) = path.ty {
+        bind_type_condition(ctx, output, ty)?.into()
+    } else {
+        output.into()
+    };
+
+    let mut out = Vec::new();
+    let mut segments = VecDeque::from(path.segments);
+    while let Some(segment) = segments.pop_front() {
+        let field_ids = match output {
+            TypeDefinitionId::Interface(id) => ctx.graph[id].field_ids,
+            TypeDefinitionId::Object(id) => ctx.graph[id].field_ids,
+            _ => {
+                return Err(format!(
+                    "Type {} does not have any fields",
+                    ctx[ctx.definition_name_id(output)]
+                ));
+            }
+        };
+        let field_id = field_ids
+            .into_iter()
+            .find(|id| ctx[ctx.graph[*id].name_id] == segment.field)
+            .ok_or_else(|| {
+                format!(
+                    "Type {} does not have a field named '{}'",
+                    ctx[ctx.definition_name_id(output)],
+                    segment.field
+                )
+            })?;
+        out.push(field_id);
+        output = ctx.graph[field_id].ty_record.definition_id;
+        let parent_output_is_nullable = output_wrapping.is_nullable();
+        output_wrapping = ctx.graph[field_id].ty_record.wrapping;
+        if parent_output_is_nullable {
+            output_wrapping = output_wrapping.without_non_null();
+        }
+
+        if let Some(ty) = segment.ty {
+            if let Some(id) = output.as_composite_type() {
+                output = bind_type_condition(ctx, id, ty)?.into();
+            } else {
+                return Err(format!(
+                    "Field '{}' doesn't return an object, interface or union and thus cannot have type condition '{}'",
+                    ctx[ctx.graph[field_id].name_id], ty
+                ));
+            }
+        }
+    }
+
+    Ok((BoundPath(out), (output, output_wrapping)))
+}
+
+fn bind_type_condition(
+    ctx: &mut GraphBuilder<'_>,
+    parent: CompositeTypeId,
+    ty: &str,
+) -> Result<EntityDefinitionId, String> {
+    let Ok(ty_id) = ctx
+        .graph
+        .type_definitions_ordered_by_name
+        .binary_search_by(|probe| ctx[ctx.definition_name_id(*probe)].as_str().cmp(ty))
+        .map(|ix| ctx.graph.type_definitions_ordered_by_name[ix])
+    else {
+        return Err(format!("Type {} does not exist", ty));
+    };
+    let Some(ty_id) = ty_id.as_entity() else {
+        return Err(format!("Type {} is not an object or an interface", ty));
+    };
+    if is_disjoint(ctx, parent, ty_id.into()) {
+        return Err(format!(
+            "Type mismatch: Cannot use type condition {} on {}",
+            ty,
+            ctx[ctx.definition_name_id(parent.into())]
+        ));
+    }
+    Ok(ty_id)
+}
+
+fn bind_selected_object_value<T: Target>(
+    ctx: &mut GraphBuilder<'_>,
+    (output, output_wrapping): (CompositeTypeId, Wrapping),
+    (target, target_wrapping): (T, Wrapping),
+    object: SelectedObjectValue<'_>,
+) -> Result<BoundSelectedObjectValue<T::Id>, String> {
+    if output_wrapping.is_list() {
+        return Err(format!(
+            "Cannot select object fomr {}, it's a list",
+            ctx.type_name(TypeRecord {
+                definition_id: output.into(),
+                wrapping: output_wrapping
+            })
+        ));
+    }
+    if target_wrapping.is_list() {
+        return Err(format!("Cannot map object into {}, it's a list", target.display(ctx)));
+    }
+    if target_wrapping.is_required() && output_wrapping.is_nullable() {
+        return Err(format!(
+            "Cannot map nullable object {} into required one {}",
+            ctx.type_name(TypeRecord {
+                definition_id: output.into(),
+                wrapping: output_wrapping
+            }),
+            target.display(ctx),
+        ));
+    }
+    let fields = object
+        .fields
+        .into_iter()
+        .map(|field| bind_selected_object_field(ctx, output, target, field))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(BoundSelectedObjectValue { fields })
+}
+
+fn bind_selected_object_field<T: Target>(
+    ctx: &mut GraphBuilder<'_>,
+    output: CompositeTypeId,
+    parent_target: T,
+    field: SelectedObjectField<'_>,
+) -> Result<BoundSelectedObjectField<T::Id>, String> {
+    let Some(target) = parent_target.field(ctx, field.key) else {
+        return Err(format!(
+            "Field '{}' does not exist on {}",
+            field.key,
+            parent_target.display(ctx)
+        ));
+    };
+    let value = if let Some(value) = field.value {
+        // The parent wrapping doesn't matter anymore, it was already handled.
+        Some(bind_selected_value(ctx, (output, Wrapping::required()), target, value)?)
+    } else {
+        let field_ids = match output {
+            CompositeTypeId::Interface(id) => ctx.graph[id].field_ids,
+            CompositeTypeId::Object(id) => ctx.graph[id].field_ids,
+            CompositeTypeId::Union(id) => {
+                return Err(format!(
+                    "Union {} does not have a field {}",
+                    ctx[ctx.graph[id].name_id], field.key,
+                ));
+            }
+        };
+        let field_id = field_ids
+            .into_iter()
+            .find(|id| ctx[ctx.graph[*id].name_id] == field.key)
+            .ok_or_else(|| {
+                format!(
+                    "Type {} does not have a field named '{}'",
+                    ctx[ctx.definition_name_id(output.into())],
+                    field.key
+                )
+            })?;
+        ensure_type_compatibility(ctx, target, field_id)?;
+        None
+    };
+
+    Ok(BoundSelectedObjectField {
+        field: target.0.id(),
+        value,
+    })
+}
+
+fn bind_selected_list_value<T: Target>(
+    ctx: &mut GraphBuilder<'_>,
+    (output, output_wrapping): (CompositeTypeId, Wrapping),
+    (target, target_wrapping): (T, Wrapping),
+    list: SelectedListValue<'_>,
+) -> Result<BoundSelectedListValue<T::Id>, String> {
+    if target_wrapping.is_required() && output_wrapping.is_nullable() {
+        return Err(format!(
+            "Cannot map nullable list {} into required one {}",
+            ctx.type_name(TypeRecord {
+                definition_id: output.into(),
+                wrapping: output_wrapping
+            }),
+            target.display(ctx),
+        ));
+    }
+    let Some(target_wrapping) = target_wrapping.without_list() else {
+        return Err(format!("Cannot map a list into {}", target.display(ctx)));
+    };
+    let Some(output_wrapping) = output_wrapping.without_list() else {
+        return Err(format!(
+            "Cannot select a list in {}",
+            ctx.type_name(TypeRecord {
+                definition_id: output.into(),
+                wrapping: output_wrapping
+            })
+        ));
+    };
+    let value = bind_selected_value(ctx, (output, output_wrapping), (target, target_wrapping), list.0)?;
+    Ok(BoundSelectedListValue(value))
+}
+
+fn ensure_type_compatibility<T: Target>(
+    ctx: &GraphBuilder<'_>,
+    (target, wrapping): (T, Wrapping),
+    field_id: FieldDefinitionId,
+) -> Result<(), String> {
+    let field = &ctx.graph[field_id];
+    if !wrapping.is_equal_or_more_lenient_than(field.ty_record.wrapping) {
+        return Err(format!(
+            "Incompatible wrapping, cannot map {}.{} ({}) into {} ({})",
+            ctx[ctx.definition_name_id(ctx.graph[field_id].parent_entity_id.into())],
+            ctx[ctx.graph[field_id].name_id],
+            ctx.type_name(ctx.graph[field_id].ty_record),
+            target.display(ctx),
+            ctx.type_name(TypeRecord {
+                definition_id: target.type_definition(&ctx.graph),
+                wrapping
+            })
+        ));
+    }
+    let is_compatible = match (
+        target.type_definition(&ctx.graph),
+        ctx.graph[field_id].ty_record.definition_id,
+    ) {
+        (TypeDefinitionId::Scalar(a), TypeDefinitionId::Scalar(b)) => a == b,
+        (TypeDefinitionId::Enum(a), TypeDefinitionId::Enum(b)) => a == b,
+        _ => false,
+    };
+
+    if !is_compatible {
+        return Err(format!(
+            "Cannot map {}.{} ({}) into {} ({})",
+            ctx[ctx.definition_name_id(ctx.graph[field_id].parent_entity_id.into())],
+            ctx[ctx.graph[field_id].name_id],
+            ctx.type_name(ctx.graph[field_id].ty_record),
+            target.display(ctx),
+            ctx.type_name(TypeRecord {
+                definition_id: target.type_definition(&ctx.graph),
+                wrapping
+            })
+        ));
+    }
+
+    Ok(())
+}

--- a/crates/engine/schema/src/builder/coerce/field_selection_map/target.rs
+++ b/crates/engine/schema/src/builder/coerce/field_selection_map/target.rs
@@ -1,0 +1,124 @@
+use wrapping::Wrapping;
+
+use crate::{
+    EntityDefinitionId, FieldDefinitionId, Graph, InputObjectDefinitionId, InputValueDefinitionId, TypeDefinitionId,
+    builder::GraphBuilder,
+};
+
+pub(super) trait Target: Copy {
+    type Id: Copy;
+    fn id(self) -> Self::Id;
+    fn display(self, ctx: &GraphBuilder<'_>) -> String;
+    fn type_definition(self, graph: &Graph) -> TypeDefinitionId;
+    fn field(self, ctx: &GraphBuilder<'_>, name: &str) -> Option<(Self, Wrapping)>;
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum Input {
+    InputField {
+        input_object_id: InputObjectDefinitionId,
+        input_field_id: InputValueDefinitionId,
+    },
+    Argument {
+        field_id: FieldDefinitionId,
+        argument_id: InputValueDefinitionId,
+    },
+}
+
+impl Target for Input {
+    type Id = InputValueDefinitionId;
+
+    fn id(self) -> Self::Id {
+        match self {
+            Input::InputField { input_field_id, .. } => input_field_id,
+            Input::Argument { argument_id, .. } => argument_id,
+        }
+    }
+
+    fn display(self, ctx: &GraphBuilder<'_>) -> String {
+        match self {
+            Input::InputField {
+                input_object_id,
+                input_field_id,
+            } => {
+                let input_object = &ctx.graph[input_object_id];
+                let field = &ctx.graph[input_field_id];
+                format!("{}.{}", &ctx[input_object.name_id], &ctx[field.name_id])
+            }
+            Input::Argument { field_id, argument_id } => {
+                let field = &ctx.graph[field_id];
+                let argument = &ctx.graph[argument_id];
+                format!(
+                    "{}.{}.{}",
+                    ctx[ctx.definition_name_id(field.parent_entity_id.into())],
+                    ctx[field.name_id],
+                    ctx[argument.name_id]
+                )
+            }
+        }
+    }
+
+    fn type_definition(self, graph: &Graph) -> TypeDefinitionId {
+        graph[self.id()].ty_record.definition_id
+    }
+
+    fn field(self, ctx: &GraphBuilder<'_>, name: &str) -> Option<(Self, Wrapping)> {
+        ctx.graph[self.id()]
+            .ty_record
+            .definition_id
+            .as_input_object()
+            .and_then(|input_object_id| {
+                ctx.graph[input_object_id]
+                    .input_field_ids
+                    .into_iter()
+                    .find(|id| ctx[ctx.graph[*id].name_id] == name)
+                    .map(|id| {
+                        (
+                            Input::InputField {
+                                input_object_id,
+                                input_field_id: id,
+                            },
+                            ctx.graph[id].ty_record.wrapping,
+                        )
+                    })
+            })
+    }
+}
+
+impl Target for FieldDefinitionId {
+    type Id = FieldDefinitionId;
+
+    fn id(self) -> Self::Id {
+        self
+    }
+
+    fn display(self, ctx: &GraphBuilder<'_>) -> String {
+        let field = &ctx.graph[self];
+        format!(
+            "{}.{}",
+            ctx[ctx.definition_name_id(field.parent_entity_id.into())],
+            ctx[field.name_id],
+        )
+    }
+
+    fn type_definition(self, graph: &Graph) -> TypeDefinitionId {
+        graph[self].ty_record.definition_id
+    }
+
+    fn field(self, ctx: &GraphBuilder<'_>, name: &str) -> Option<(Self, Wrapping)> {
+        ctx.graph[self]
+            .ty_record
+            .definition_id
+            .as_entity()
+            .and_then(|entity_id| {
+                let field_ids = match entity_id {
+                    EntityDefinitionId::Interface(id) => ctx.graph[id].field_ids,
+                    EntityDefinitionId::Object(id) => ctx.graph[id].field_ids,
+                };
+                field_ids
+                    .into_iter()
+                    .find(|id| ctx[ctx.graph[*id].name_id] == name)
+                    .map(|id| (id, ctx.graph[id].ty_record.wrapping))
+            })
+    }
+}

--- a/crates/engine/schema/src/builder/coerce/field_set.rs
+++ b/crates/engine/schema/src/builder/coerce/field_set.rs
@@ -273,7 +273,7 @@ fn convert_field_arguments(
     Ok(IdRange::from(start..ctx.selections.arguments.len()))
 }
 
-fn is_disjoint(ctx: &GraphBuilder<'_>, left: CompositeTypeId, right: CompositeTypeId) -> bool {
+pub(super) fn is_disjoint(ctx: &GraphBuilder<'_>, left: CompositeTypeId, right: CompositeTypeId) -> bool {
     let left: &[ObjectDefinitionId] = match &left {
         CompositeTypeId::Object(id) => std::array::from_ref(id),
         CompositeTypeId::Interface(id) => &ctx.graph[*id].possible_type_ids,

--- a/crates/engine/schema/src/builder/coerce/mod.rs
+++ b/crates/engine/schema/src/builder/coerce/mod.rs
@@ -1,5 +1,6 @@
 mod error;
 mod extension;
+mod field_selection_map;
 mod field_set;
 mod input_value_set;
 mod path;

--- a/crates/engine/schema/src/builder/graph/mod.rs
+++ b/crates/engine/schema/src/builder/graph/mod.rs
@@ -96,17 +96,19 @@ impl GraphBuilder<'_> {
         })
     }
 
+    pub(crate) fn definition_name_id(&self, ty: TypeDefinitionId) -> StringId {
+        match ty {
+            TypeDefinitionId::Scalar(id) => self.graph[id].name_id,
+            TypeDefinitionId::Object(id) => self.graph[id].name_id,
+            TypeDefinitionId::Interface(id) => self.graph[id].name_id,
+            TypeDefinitionId::Union(id) => self.graph[id].name_id,
+            TypeDefinitionId::Enum(id) => self.graph[id].name_id,
+            TypeDefinitionId::InputObject(id) => self.graph[id].name_id,
+        }
+    }
+
     pub(crate) fn type_name(&self, ty: TypeRecord) -> String {
-        let name = match ty.definition_id {
-            TypeDefinitionId::Scalar(id) => &self.ctx[self.graph[id].name_id],
-            TypeDefinitionId::Object(id) => &self.ctx[self.graph[id].name_id],
-            TypeDefinitionId::Interface(id) => &self.ctx[self.graph[id].name_id],
-            TypeDefinitionId::Union(id) => &self.ctx[self.graph[id].name_id],
-            TypeDefinitionId::Enum(id) => &self.ctx[self.graph[id].name_id],
-            TypeDefinitionId::InputObject(id) => &self.ctx[self.graph[id].name_id],
-        };
-        let mut s = String::new();
-        ty.wrapping.write_type_string(name, &mut s).unwrap();
-        s
+        let name = &self.ctx[self.definition_name_id(ty.definition_id)];
+        ty.wrapping.type_display(name).to_string()
     }
 }

--- a/crates/engine/schema/src/builder/sdl/directives.rs
+++ b/crates/engine/schema/src/builder/sdl/directives.rs
@@ -3,6 +3,19 @@ use cynic_parser_deser::{ConstDeserializer, DeserValue, ValueDeserialize, value:
 
 use crate::builder::error::Error;
 
+///```ignore,graphql
+/// directive @composite__is(
+///     graph: join__Graph!,
+///     field: String!
+/// ) repeatable on FIELD_DEFINITION | ARGUMENT_DEFINITION
+///```
+#[derive(Debug, ValueDeserialize)]
+pub(crate) struct IsDirective<'a> {
+    pub graph: GraphName<'a>,
+    #[deser(rename = "field")]
+    pub field_selection_map: &'a str,
+}
+
 #[derive(ValueDeserialize)]
 pub struct CostDirective {
     pub weight: i32,

--- a/crates/engine/schema/src/ty.rs
+++ b/crates/engine/schema/src/ty.rs
@@ -2,7 +2,7 @@ use crate::{Type, TypeRecord};
 
 impl std::fmt::Display for Type<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.wrapping.write_type_string(self.definition().name(), f)
+        self.wrapping.type_display(self.definition().name()).fmt(f)
     }
 }
 

--- a/crates/graphql-wrapping-types/src/mutable.rs
+++ b/crates/graphql-wrapping-types/src/mutable.rs
@@ -14,10 +14,6 @@ impl MutableWrapping {
         self.inner.is_required()
     }
 
-    pub fn write_type_string(&self, name: &str, formatter: &mut dyn std::fmt::Write) -> Result<(), std::fmt::Error> {
-        self.inner.write_type_string(name, formatter)
-    }
-
     pub fn pop_outermost_list_wrapping(&mut self) -> Option<ListWrapping> {
         let end = self.inner.get_list_length();
         if end == 0 {

--- a/crates/integration-tests/tests/gateway/composite/is/argument.rs
+++ b/crates/integration-tests/tests/gateway/composite/is/argument.rs
@@ -1,0 +1,35 @@
+use integration_tests::{gateway::Gateway, runtime};
+
+#[ignore] // doens't work yet with @lookup validation.
+#[test]
+fn basic() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@is", "@key"])
+
+                type Query {
+                    productBatch(input: ProductInput! @is(field: "{ id }")): Product! @lookup
+                }
+
+                input ProductInput {
+                    id: ID!
+                }
+
+                type Product @key(fields: "id") {
+                    id: ID!
+                    code: String!
+                }
+                "#,
+            )
+            .try_build()
+            .await;
+
+        if let Err(err) = result {
+            panic!("{err}");
+        }
+    })
+}

--- a/crates/integration-tests/tests/gateway/composite/is/field.rs
+++ b/crates/integration-tests/tests/gateway/composite/is/field.rs
@@ -1,0 +1,324 @@
+use integration_tests::{gateway::Gateway, runtime};
+
+#[test]
+fn basic() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@is"])
+
+                type Query {
+                    productBatch(ids: [ID!]!): [Product!]!
+                }
+
+                type Product {
+                    id: ID!
+                    code: String!
+                    author_id: ID!
+                    user: User! @is(field: "{ id: author_id }")
+                }
+
+                type User {
+                    id: ID!
+                }
+                "#,
+            )
+            .try_build()
+            .await;
+
+        if let Err(err) = result {
+            panic!("{err}");
+        }
+    })
+}
+
+#[test]
+fn invalid_type() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@is"])
+
+                type Query {
+                    productBatch(ids: [ID!]!): [Product!]!
+                }
+
+                type Product {
+                    id: ID!
+                    code: String!
+                    author_id: Int!
+                    user: User! @is(field: "{ id: author_id }")
+                }
+
+                type User {
+                    id: ID!
+                }
+                "#,
+            )
+            .try_build()
+            .await;
+
+        insta::assert_debug_snapshot!(result.err(), @r#"
+        Some(
+            "At site Product.user, for directive @composite__is Cannot map Product.author_id (Int!) into User.id (ID!). See schema at 25:29:\n(graph: EXT, field: \"{ id: author_id }\")",
+        )
+        "#);
+    })
+}
+
+#[test]
+fn multiple_fields_mapping() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@is"])
+
+                type Query {
+                    productBatch(ids: [ID!]!): [Product!]!
+                }
+
+                type Product {
+                    id: ID!
+                    code: String!
+                    author_id: ID!
+                    category_id: ID!
+                    user: User! @is(field: "{ id: author_id category: category_id }")
+                }
+
+                type User {
+                    id: ID!
+                    category: ID!
+                }
+                "#,
+            )
+            .try_build()
+            .await;
+
+        if let Err(err) = result {
+            panic!("{err}");
+        }
+    })
+}
+
+#[test]
+fn direct_field_mapping() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@is"])
+
+                type Query {
+                    productBatch(ids: [ID!]!): [Product!]!
+                }
+
+                type Product {
+                    id: ID!
+                    code: String!
+                    author_id: ID!
+                    user_id: ID! @is(field: "author_id")
+                }
+                "#,
+            )
+            .try_build()
+            .await;
+
+        if let Err(err) = result {
+            panic!("{err}");
+        }
+    })
+}
+
+#[test]
+fn incompatible_wrapping() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@is"])
+
+                type Query {
+                    productBatch(ids: [ID!]!): [Product!]!
+                }
+
+                type Product {
+                    id: ID!
+                    code: String!
+                    author_ids: [ID!]!
+                    user: User! @is(field: "{ id: author_ids }")
+                }
+
+                type User {
+                    id: ID!
+                }
+                "#,
+            )
+            .try_build()
+            .await;
+
+        insta::assert_debug_snapshot!(result.err(), @r#"
+        Some(
+            "At site Product.user, for directive @composite__is Incompatible wrapping, cannot map Product.author_ids ([ID!]!) into User.id (ID!). See schema at 25:29:\n(graph: EXT, field: \"{ id: author_ids }\")",
+        )
+        "#);
+    })
+}
+
+#[test]
+fn inexistent_field() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@is"])
+
+                type Query {
+                    productBatch(ids: [ID!]!): [Product!]!
+                }
+
+                type Product {
+                    id: ID!
+                    code: String!
+                    user: User! @is(field: "{ id: non_existent_field }")
+                }
+
+                type User {
+                    id: ID!
+                }
+                "#,
+            )
+            .try_build()
+            .await;
+
+        insta::assert_debug_snapshot!(result.err(), @r#"
+        Some(
+            "At site Product.user, for directive @composite__is Type Product does not have a field named 'non_existent_field'. See schema at 24:29:\n(graph: EXT, field: \"{ id: non_existent_field }\")",
+        )
+        "#);
+    })
+}
+
+#[test]
+fn inexistent_target_field() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@is"])
+
+                type Query {
+                    productBatch(ids: [ID!]!): [Product!]!
+                }
+
+                type Product {
+                    id: ID!
+                    code: String!
+                    user: User! @is(field: "{ non_existent_field: id }")
+                }
+
+                type User {
+                    id: ID!
+                }
+                "#,
+            )
+            .try_build()
+            .await;
+
+        insta::assert_debug_snapshot!(result.err(), @r#"
+        Some(
+            "At site Product.user, for directive @composite__is Field 'non_existent_field' does not exist on Product.user. See schema at 24:29:\n(graph: EXT, field: \"{ non_existent_field: id }\")",
+        )
+        "#);
+    })
+}
+
+#[test]
+fn nullable_vs_required() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@is"])
+
+                type Query {
+                    productBatch(ids: [ID!]!): [Product!]!
+                }
+
+                type Product {
+                    id: ID!
+                    code: String!
+                    author_id: ID
+                    user: User! @is(field: "{ id: author_id }")
+                }
+
+                type User {
+                    id: ID!
+                }
+                "#,
+            )
+            .try_build()
+            .await;
+
+        insta::assert_debug_snapshot!(result.err(), @r#"
+        Some(
+            "At site Product.user, for directive @composite__is Incompatible wrapping, cannot map Product.author_id (ID) into User.id (ID!). See schema at 25:29:\n(graph: EXT, field: \"{ id: author_id }\")",
+        )
+        "#);
+    })
+}
+
+#[test]
+fn multiple_fields_without_rename() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@is"])
+
+                type Query {
+                    productBatch(ids: [ID!]!): [Product!]!
+                }
+
+                type Product {
+                    id: ID!
+                    code: String!
+                    author_id: ID!
+                    category: String!
+                    user: User! @is(field: "{ id: author_id category }")
+                }
+
+                type User {
+                    id: ID!
+                    category: String!
+                }
+                "#,
+            )
+            .try_build()
+            .await;
+
+        if let Err(err) = result {
+            panic!("{err}");
+        }
+    })
+}

--- a/crates/integration-tests/tests/gateway/composite/is/mod.rs
+++ b/crates/integration-tests/tests/gateway/composite/is/mod.rs
@@ -1,0 +1,2 @@
+mod argument;
+mod field;

--- a/crates/integration-tests/tests/gateway/composite/mod.rs
+++ b/crates/integration-tests/tests/gateway/composite/mod.rs
@@ -1,1 +1,2 @@
+mod is;
 mod lookup;


### PR DESCRIPTION
I'm binding the `FieldSelectionMap` in the engine now. Validation isn't
finished though, especially for its original use in `@lookup`. But that should be enough for me to get started on the computed fields
