### PR TITLE
feat(engine): @is on FIELD_DEFINITION ingestion

### DIFF
--- a/crates/engine/codegen/domain/schema.graphql
+++ b/crates/engine/codegen/domain/schema.graphql
@@ -98,6 +98,7 @@ type FieldDefinition @meta(module: "field", debug: false) @indexed(id_size: "u32
   "The arguments referenced by this range are sorted by their name (string)"
   arguments: [InputValueDefinition!]!
   directives: [TypeSystemDirective!]!
+  computed: [ComputedObject!]!
 }
 
 type SubgraphType @meta(module: "field/subgraph_type") @copy {
@@ -113,6 +114,16 @@ type FieldProvides @meta(module: "field/provides") {
 type FieldRequires @meta(module: "field/requires") {
   subgraph: Subgraph!
   field_set: FieldSet!
+}
+
+type ComputedObject @meta(module: "field/computed") {
+  subgraph: Subgraph!
+  fields: [ComputedField!]!
+}
+
+type ComputedField @meta(module: "field/computed") {
+  from: FieldDefinition!
+  target: FieldDefinition!
 }
 
 type Type @meta(module: "ty", derive: ["PartialEq", "Eq"]) @copy {

--- a/crates/engine/schema/src/builder/coerce/field_selection_map/model.rs
+++ b/crates/engine/schema/src/builder/coerce/field_selection_map/model.rs
@@ -5,6 +5,16 @@ pub(crate) struct BoundSelectedValue<Id> {
     pub alternatives: Vec<BoundSelectedValueEntry<Id>>,
 }
 
+impl<Id> BoundSelectedValue<Id> {
+    pub fn into_single(self) -> Option<BoundSelectedValueEntry<Id>> {
+        if self.alternatives.len() == 1 {
+            Some(self.alternatives.into_iter().next().unwrap())
+        } else {
+            None
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum BoundSelectedValueEntry<Id> {
     Path(BoundPath),
@@ -19,8 +29,34 @@ pub(crate) enum BoundSelectedValueEntry<Id> {
     Object(BoundSelectedObjectValue<Id>),
 }
 
+impl<Id> BoundSelectedValueEntry<Id> {
+    pub fn into_object(self) -> Option<BoundSelectedObjectValue<Id>> {
+        match self {
+            BoundSelectedValueEntry::Object(obj) => Some(obj),
+            _ => None,
+        }
+    }
+
+    pub fn into_path(self) -> Option<BoundPath> {
+        match self {
+            BoundSelectedValueEntry::Path(path) => Some(path),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct BoundPath(pub Vec<FieldDefinitionId>);
+
+impl BoundPath {
+    pub fn into_single(self) -> Option<FieldDefinitionId> {
+        if self.0.len() == 1 {
+            Some(self.0.into_iter().next().unwrap())
+        } else {
+            None
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct BoundSelectedObjectValue<Id> {

--- a/crates/engine/schema/src/builder/coerce/mod.rs
+++ b/crates/engine/schema/src/builder/coerce/mod.rs
@@ -8,6 +8,7 @@ mod schema;
 
 pub(crate) use error::*;
 pub(crate) use extension::*;
+pub(crate) use field_selection_map::*;
 pub(crate) use path::*;
 
 fn can_coerce_to_int(float: f64) -> bool {

--- a/crates/engine/schema/src/builder/error.rs
+++ b/crates/engine/schema/src/builder/error.rs
@@ -15,7 +15,7 @@ impl Error {
         };
         let location = translator.span_to_location(span).unwrap();
         let sdl = &translator.sdl[span.start..span.end];
-        format!("{text}. See schema at {location}:\n{sdl}")
+        format!("{text}\nSee schema at {location}:\n{sdl}")
     }
 
     pub fn with_prefix(self, mut prefix: String) -> Self {

--- a/crates/engine/schema/src/builder/graph/definitions.rs
+++ b/crates/engine/schema/src/builder/graph/definitions.rs
@@ -232,6 +232,7 @@ impl<'a> Ingester<'a> {
                 provides_records: Default::default(),
                 requires_records: Default::default(),
                 directive_ids: Default::default(),
+                computed_records: Default::default(),
             });
         }
         let end = self.graph.field_definitions.len();
@@ -570,6 +571,7 @@ impl<'a> Ingester<'a> {
                 provides_records: Default::default(),
                 requires_records: Default::default(),
                 directive_ids: Default::default(),
+                computed_records: Default::default(),
             });
         }
     }

--- a/crates/engine/schema/src/builder/graph/directives/common/mod.rs
+++ b/crates/engine/schema/src/builder/graph/directives/common/mod.rs
@@ -51,7 +51,7 @@ impl<'sdl> DirectivesIngester<'_, 'sdl> {
                     directive_ids.push(TypeSystemDirectiveId::Extension(id))
                 }
                 name if name.starts_with("composite__") => self
-                    .ingest_composite_directive(def, directive)
+                    .ingest_composite_directive_before_federation(def, directive)
                     .map_err(|err| err.with_span_if_absent(directive.arguments_span()))?,
                 _ => {}
             };

--- a/crates/engine/schema/src/builder/graph/directives/composite/is.rs
+++ b/crates/engine/schema/src/builder/graph/directives/composite/is.rs
@@ -1,0 +1,84 @@
+use cynic_parser_deser::ConstDeserializer as _;
+
+use crate::{
+    ComputedFieldRecord, ComputedObjectRecord, EntityDefinitionId,
+    builder::{BoundSelectedObjectField, DirectivesIngester, Error, sdl},
+};
+
+pub(super) fn ingest_field<'sdl>(
+    ingester: &mut DirectivesIngester<'_, 'sdl>,
+    def: sdl::FieldSdlDefinition<'sdl>,
+    dir: sdl::Directive<'sdl>,
+) -> Result<(), Error> {
+    let sdl::IsDirective {
+        graph,
+        field: field_selection_map,
+    } = dir
+        .deserialize()
+        .map_err(|err| (err.to_string(), dir.arguments_span()))?;
+    let subgraph_id = ingester.subgraphs.try_get(graph, dir.arguments_span())?;
+
+    let Some(target_entity_id) = ingester.graph[def.id].ty_record.definition_id.as_entity() else {
+        return Err((
+            "@is can only be used on fields to compute an object/interface.",
+            def.span(),
+        )
+            .into());
+    };
+    let target_field_ids = match target_entity_id {
+        EntityDefinitionId::Interface(id) => ingester.graph[id].field_ids,
+        EntityDefinitionId::Object(id) => ingester.graph[id].field_ids,
+    };
+
+    let output = ingester.graph[def.id].parent_entity_id;
+    let object = ingester
+        .parse_field_selection_map_for_field(output, subgraph_id, def.id, field_selection_map)?
+        .into_single()
+        .ok_or_else(|| {
+            (
+                "Computed fields do not support multiple alternatives",
+                dir.arguments_span(),
+            )
+        })?
+        .into_object()
+        .ok_or_else(|| ("Computed fields must be objects", dir.arguments_span()))?;
+
+    let mut field_records: Vec<ComputedFieldRecord> = Vec::new();
+    for BoundSelectedObjectField {
+        field: target_id,
+        value,
+    } in object.fields
+    {
+        let from_id = if let Some(value) = value {
+            value
+                .into_single()
+                .and_then(|value| value.into_path())
+                .and_then(|path| path.into_single())
+                .ok_or_else(|| {
+                    (
+                        "Computed object fields can only be mapped to parent scalar/enum fields",
+                        dir.arguments_span(),
+                    )
+                })?
+        } else {
+            target_field_ids
+                .into_iter()
+                .find(|id| ingester.graph[*id].name_id == ingester.graph[target_id].name_id)
+                .unwrap()
+        };
+        field_records.push(ComputedFieldRecord { from_id, target_id });
+    }
+    let computed = &mut ingester.graph[def.id].computed_records;
+    if computed.iter().any(|c| c.subgraph_id == subgraph_id) {
+        return Err((
+            "Multiple @composite__is were used in the same subgraph",
+            dir.name_span(),
+        )
+            .into());
+    }
+    computed.push(ComputedObjectRecord {
+        subgraph_id,
+        field_records,
+    });
+    Ok(())
+}

--- a/crates/engine/schema/src/builder/graph/directives/supergraph.rs
+++ b/crates/engine/schema/src/builder/graph/directives/supergraph.rs
@@ -1,0 +1,21 @@
+use crate::builder::{Error, sdl};
+
+use super::DirectivesIngester;
+
+impl<'sdl> DirectivesIngester<'_, 'sdl> {
+    pub fn ingest_federation_aware_directives(
+        &mut self,
+        def: sdl::SdlDefinition<'sdl>,
+        directives: &[sdl::Directive<'sdl>],
+    ) -> Result<(), Error> {
+        for &directive in directives {
+            match directive.name() {
+                name if name.starts_with("composite__") => self
+                    .ingest_composite_directive_after_federation(def, directive)
+                    .map_err(|err| err.with_span_if_absent(directive.arguments_span()))?,
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/engine/schema/src/generated/field.rs
+++ b/crates/engine/schema/src/generated/field.rs
@@ -3,6 +3,7 @@
 //! ===================
 //! Generated with: `cargo run -p engine-codegen`
 //! Source file: <engine-codegen dir>/domain/schema.graphql
+mod computed;
 mod provides;
 mod requires;
 mod subgraph_type;
@@ -15,6 +16,7 @@ use crate::{
     },
     prelude::*,
 };
+pub use computed::*;
 pub use provides::*;
 pub use requires::*;
 pub use subgraph_type::*;
@@ -38,6 +40,7 @@ use walker::{Iter, Walk};
 ///   "The arguments referenced by this range are sorted by their name (string)"
 ///   arguments: [InputValueDefinition!]!
 ///   directives: [TypeSystemDirective!]!
+///   computed: [ComputedObject!]!
 /// }
 /// ```
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -55,6 +58,7 @@ pub struct FieldDefinitionRecord {
     /// The arguments referenced by this range are sorted by their name (string)
     pub argument_ids: IdRange<InputValueDefinitionId>,
     pub directive_ids: Vec<TypeSystemDirectiveId>,
+    pub computed_records: Vec<ComputedObjectRecord>,
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
@@ -113,6 +117,9 @@ impl<'a> FieldDefinition<'a> {
     }
     pub fn directives(&self) -> impl Iter<Item = TypeSystemDirective<'a>> + 'a {
         self.as_ref().directive_ids.walk(self.schema)
+    }
+    pub fn computed(&self) -> impl Iter<Item = ComputedObject<'a>> + 'a {
+        self.as_ref().computed_records.walk(self.schema)
     }
 }
 

--- a/crates/engine/schema/src/generated/field/computed.rs
+++ b/crates/engine/schema/src/generated/field/computed.rs
@@ -1,0 +1,145 @@
+//! ===================
+//! !!! DO NOT EDIT !!!
+//! ===================
+//! Generated with: `cargo run -p engine-codegen`
+//! Source file: <engine-codegen dir>/domain/schema.graphql
+use crate::{
+    generated::{FieldDefinition, FieldDefinitionId, Subgraph, SubgraphId},
+    prelude::*,
+};
+#[allow(unused_imports)]
+use walker::{Iter, Walk};
+
+/// Generated from:
+///
+/// ```custom,{.language-graphql}
+/// type ComputedObject @meta(module: "field/computed") {
+///   subgraph: Subgraph!
+///   fields: [ComputedField!]!
+/// }
+/// ```
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct ComputedObjectRecord {
+    pub subgraph_id: SubgraphId,
+    pub field_records: Vec<ComputedFieldRecord>,
+}
+
+#[derive(Clone, Copy)]
+pub struct ComputedObject<'a> {
+    pub(crate) schema: &'a Schema,
+    pub(crate) ref_: &'a ComputedObjectRecord,
+}
+
+impl std::ops::Deref for ComputedObject<'_> {
+    type Target = ComputedObjectRecord;
+    fn deref(&self) -> &Self::Target {
+        self.ref_
+    }
+}
+
+impl<'a> ComputedObject<'a> {
+    #[allow(clippy::should_implement_trait)]
+    pub fn as_ref(&self) -> &'a ComputedObjectRecord {
+        self.ref_
+    }
+    pub fn subgraph(&self) -> Subgraph<'a> {
+        self.subgraph_id.walk(self.schema)
+    }
+    pub fn fields(&self) -> impl Iter<Item = ComputedField<'a>> + 'a {
+        self.as_ref().field_records.walk(self.schema)
+    }
+}
+
+impl<'a> Walk<&'a Schema> for &ComputedObjectRecord {
+    type Walker<'w>
+        = ComputedObject<'w>
+    where
+        Self: 'w,
+        'a: 'w;
+    fn walk<'w>(self, schema: impl Into<&'a Schema>) -> Self::Walker<'w>
+    where
+        Self: 'w,
+        'a: 'w,
+    {
+        ComputedObject {
+            schema: schema.into(),
+            ref_: self,
+        }
+    }
+}
+
+impl std::fmt::Debug for ComputedObject<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ComputedObject")
+            .field("subgraph", &self.subgraph())
+            .field("fields", &self.fields())
+            .finish()
+    }
+}
+
+/// Generated from:
+///
+/// ```custom,{.language-graphql}
+/// type ComputedField @meta(module: "field/computed") {
+///   from: FieldDefinition!
+///   target: FieldDefinition!
+/// }
+/// ```
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct ComputedFieldRecord {
+    pub from_id: FieldDefinitionId,
+    pub target_id: FieldDefinitionId,
+}
+
+#[derive(Clone, Copy)]
+pub struct ComputedField<'a> {
+    pub(crate) schema: &'a Schema,
+    pub(crate) ref_: &'a ComputedFieldRecord,
+}
+
+impl std::ops::Deref for ComputedField<'_> {
+    type Target = ComputedFieldRecord;
+    fn deref(&self) -> &Self::Target {
+        self.ref_
+    }
+}
+
+impl<'a> ComputedField<'a> {
+    #[allow(clippy::should_implement_trait)]
+    pub fn as_ref(&self) -> &'a ComputedFieldRecord {
+        self.ref_
+    }
+    pub fn from(&self) -> FieldDefinition<'a> {
+        self.from_id.walk(self.schema)
+    }
+    pub fn target(&self) -> FieldDefinition<'a> {
+        self.target_id.walk(self.schema)
+    }
+}
+
+impl<'a> Walk<&'a Schema> for &ComputedFieldRecord {
+    type Walker<'w>
+        = ComputedField<'w>
+    where
+        Self: 'w,
+        'a: 'w;
+    fn walk<'w>(self, schema: impl Into<&'a Schema>) -> Self::Walker<'w>
+    where
+        Self: 'w,
+        'a: 'w,
+    {
+        ComputedField {
+            schema: schema.into(),
+            ref_: self,
+        }
+    }
+}
+
+impl std::fmt::Debug for ComputedField<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ComputedField")
+            .field("from", &self.from())
+            .field("target", &self.target())
+            .finish()
+    }
+}

--- a/crates/engine/schema/src/introspection.rs
+++ b/crates/engine/schema/src/introspection.rs
@@ -675,6 +675,7 @@ impl GraphBuilder<'_> {
                 resolver_ids: Vec::new(),
                 argument_ids: IdRange::empty(),
                 subgraph_type_records: Vec::new(),
+                computed_records: Default::default(),
             });
 
             out_fields.push((id, tag));

--- a/crates/graphql-wrapping-types/src/lib.rs
+++ b/crates/graphql-wrapping-types/src/lib.rs
@@ -364,7 +364,7 @@ mod tests {
     }
 
     #[test]
-    fn test_is_compatible_with() {
+    fn test_is_equal_or_more_lenient_than() {
         let non_null_list = Wrapping::required().list();
         let non_null_list_non_null = Wrapping::required().list_non_null();
         assert!(non_null_list.is_equal_or_more_lenient_than(non_null_list_non_null));

--- a/crates/integration-tests/src/gateway/mod.rs
+++ b/crates/integration-tests/src/gateway/mod.rs
@@ -30,6 +30,12 @@ pub struct Gateway {
     subgraphs: subgraph::Subgraphs,
 }
 
+impl std::fmt::Debug for Gateway {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Gateway").finish_non_exhaustive()
+    }
+}
+
 pub struct TestRuntimeContext {
     pub access_log_receiver: AccessLogReceiver,
 }

--- a/crates/integration-tests/tests/gateway/basic/one_of.rs
+++ b/crates/integration-tests/tests/gateway/basic/one_of.rs
@@ -240,7 +240,9 @@ fn validate_default_argument() {
             )
             .try_build()
             .await;
-        insta::assert_debug_snapshot!(result.err(), @"None");
+        if let Err(err) = result {
+            panic!("{err}")
+        }
 
         let result = Gateway::builder()
             .with_subgraph_sdl(
@@ -260,7 +262,9 @@ fn validate_default_argument() {
             )
             .try_build()
             .await;
-        insta::assert_debug_snapshot!(result.err(), @"None");
+        if let Err(err) = result {
+            panic!("{err}")
+        }
 
         let result = Gateway::builder()
             .with_subgraph_sdl(
@@ -280,10 +284,10 @@ fn validate_default_argument() {
             )
             .try_build()
             .await;
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At Query.test.input, found an invalid default value: Exactly one field must be provided for TestInput with @oneOf: No field was provided at path '.input'. See schema at 19:27:\n{}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At Query.test.input, found an invalid default value: Exactly one field must be provided for TestInput with @oneOf: No field was provided at path '.input'
+        See schema at 19:27:
+        {}
         "#);
 
         let result = Gateway::builder()
@@ -304,10 +308,10 @@ fn validate_default_argument() {
             )
             .try_build()
             .await;
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At Query.test.input, found an invalid default value: Exactly one field must be provided for TestInput with @oneOf: 2 fields (a,b) were provided at path '.input'. See schema at 19:27:\n{a: 1, b: \"1\"}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At Query.test.input, found an invalid default value: Exactly one field must be provided for TestInput with @oneOf: 2 fields (a,b) were provided at path '.input'
+        See schema at 19:27:
+        {a: 1, b: "1"}
         "#);
     })
 }

--- a/crates/integration-tests/tests/gateway/composite/is/field.rs
+++ b/crates/integration-tests/tests/gateway/composite/is/field.rs
@@ -405,7 +405,7 @@ fn cannot_map_an_object_into_a_field() {
             .await;
 
         insta::assert_snapshot!(result.unwrap_err(), @r#"
-        At site Product.user, for directive @composite__is: Computed object fields can only be mapped to parent fields
+        At site Product.user, for directive @composite__is: Computed object fields can only be mapped to parent scalar/enum fields
         See schema at 26:29:
         (graph: EXT, field: "{ id: author_id category: category.{ id name } }")
         "#);

--- a/crates/integration-tests/tests/gateway/composite/is/field.rs
+++ b/crates/integration-tests/tests/gateway/composite/is/field.rs
@@ -64,10 +64,10 @@ fn invalid_type() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Product.user, for directive @composite__is Cannot map Product.author_id (Int!) into User.id (ID!). See schema at 25:29:\n(graph: EXT, field: \"{ id: author_id }\")",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Product.user, for directive @composite__is: Cannot map Product.author_id (Int!) into User.id (ID!)
+        See schema at 25:29:
+        (graph: EXT, field: "{ id: author_id }")
         "#);
     })
 }
@@ -110,6 +110,423 @@ fn multiple_fields_mapping() {
 }
 
 #[test]
+fn parsing_failure() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@is"])
+
+                type Query {
+                    productBatch(ids: [ID!]!): [Product!]!
+                }
+
+                type Product {
+                    id: ID!
+                    code: String!
+                    author_id: ID!
+                    category: Category!
+                    user: User! @is(field: "{[]}")
+                }
+
+                type User {
+                    id: ID!
+                    category: Category!
+                }
+
+                type Category {
+                    id: ID!
+                    name: String!
+                }
+                "#,
+            )
+            .try_build()
+            .await;
+
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Product.user, for directive @composite__is: 
+        {[]}
+         ^
+        invalid object
+
+        See schema at 26:29:
+        (graph: EXT, field: "{[]}")
+        "#);
+    })
+}
+
+#[test]
+fn missing_field_argument() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_federated_sdl(
+                r#"
+                type Product
+                  @join__type(graph: EXT)
+                {
+                  author_id: ID!
+                  code: String!
+                  id: ID!
+                  user: User! @composite__is(graph: EXT)
+                }
+
+                type User
+                  @join__type(graph: EXT)
+                {
+                  id: ID!
+                }
+
+                type Query
+                {
+                  productBatch(ids: [ID!]!): [Product!]! @join__field(graph: EXT)
+                }
+
+                enum join__Graph
+                {
+                  EXT @join__graph(name: "ext")
+                }
+                "#,
+            )
+            .try_build()
+            .await;
+
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Product.user, for directive @composite__is: missing field: field
+        See schema at 7:29:
+        (graph: EXT)
+        "#);
+    })
+}
+
+#[test]
+fn missing_graph_argument() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_federated_sdl(
+                r#"
+                type Product
+                  @join__type(graph: EXT)
+                {
+                  author_id: ID!
+                  code: String!
+                  id: ID!
+                  user: User! @composite__is(field: "{ id: author_id }")
+                }
+
+                type User
+                  @join__type(graph: EXT)
+                {
+                  id: ID!
+                }
+
+                type Query
+                {
+                  productBatch(ids: [ID!]!): [Product!]! @join__field(graph: EXT)
+                }
+
+                enum join__Graph
+                {
+                  EXT @join__graph(name: "ext")
+                }
+                "#,
+            )
+            .try_build()
+            .await;
+
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Product.user, for directive @composite__is: missing field: graph
+        See schema at 7:29:
+        (field: "{ id: author_id }")
+        "#);
+    })
+}
+
+#[test]
+fn invalid_directive_argument_type() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_federated_sdl(
+                r#"
+                type Product
+                  @join__type(graph: EXT)
+                {
+                  author_id: ID!
+                  code: String!
+                  id: ID!
+                  user: User! @composite__is(graph: EXT, field: 0)
+                }
+
+                type User
+                  @join__type(graph: EXT)
+                {
+                  id: ID!
+                }
+
+                type Query
+                {
+                  productBatch(ids: [ID!]!): [Product!]! @join__field(graph: EXT)
+                }
+
+                enum join__Graph
+                {
+                  EXT @join__graph(name: "ext")
+                }
+                "#,
+            )
+            .try_build()
+            .await;
+
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Product.user, for directive @composite__is: found a Int where we expected a String
+        See schema at 7:29:
+        (graph: EXT, field: 0)
+        "#);
+    })
+}
+
+#[test]
+fn unknown_directive_argument() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_federated_sdl(
+                r#"
+                type Product
+                  @join__type(graph: EXT)
+                {
+                  author_id: ID!
+                  code: String!
+                  id: ID!
+                  user: User! @composite__is(graph: EXT, field: "{ id: author_id }", yes: true)
+                }
+
+                type User
+                  @join__type(graph: EXT)
+                {
+                  id: ID!
+                }
+
+                type Query
+                {
+                  productBatch(ids: [ID!]!): [Product!]! @join__field(graph: EXT)
+                }
+
+                enum join__Graph
+                {
+                  EXT @join__graph(name: "ext")
+                }
+                "#,
+            )
+            .try_build()
+            .await;
+
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Product.user, for directive @composite__is: unknown field: yes
+        See schema at 7:29:
+        (graph: EXT, field: "{ id: author_id }", yes: true)
+        "#);
+    })
+}
+
+#[test]
+fn cannot_map_an_object_into_a_field() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@is"])
+
+                type Query {
+                    productBatch(ids: [ID!]!): [Product!]!
+                }
+
+                type Product {
+                    id: ID!
+                    code: String!
+                    author_id: ID!
+                    category: Category!
+                    user: User! @is(field: "{ id: author_id category }")
+                }
+
+                type User {
+                    id: ID!
+                    category: Category!
+                }
+
+                type Category {
+                    id: ID!
+                    name: String!
+                }
+                "#,
+            )
+            .try_build()
+            .await;
+
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Product.user, for directive @composite__is: Fields must be explictely selected on Product.category (Category!), it's not a scalar or enum
+        See schema at 26:29:
+        (graph: EXT, field: "{ id: author_id category }")
+        "#);
+
+        let result = Gateway::builder()
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@is"])
+
+                type Query {
+                    productBatch(ids: [ID!]!): [Product!]!
+                }
+
+                type Product {
+                    id: ID!
+                    code: String!
+                    author_id: ID!
+                    category: Category!
+                    user: User! @is(field: "{ id: author_id category: category.{ id name } }")
+                }
+
+                type User {
+                    id: ID!
+                    category: Category!
+                }
+
+                type Category {
+                    id: ID!
+                    name: String!
+                }
+                "#,
+            )
+            .try_build()
+            .await;
+
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Product.user, for directive @composite__is: Computed object fields can only be mapped to parent fields
+        See schema at 26:29:
+        (graph: EXT, field: "{ id: author_id category: category.{ id name } }")
+        "#);
+    })
+}
+
+#[test]
+fn missing_required_field() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@is"])
+
+                type Query {
+                    productBatch(ids: [ID!]!): [Product!]!
+                }
+
+                type Product {
+                    id: ID!
+                    code: String!
+                    author_id: ID!
+                    category_id: ID!
+                    user: User! @is(field: "{ id: author_id }")
+                }
+
+                type User {
+                    id: ID!
+                    category: ID!
+                }
+                "#,
+            )
+            .try_build()
+            .await;
+
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Product.user, for directive @composite__is: For Product.user, field 'category' is required but doesn't have any mapping
+        See schema at 26:29:
+        (graph: EXT, field: "{ id: author_id }")
+        "#);
+    })
+}
+
+#[test]
+fn missing_required_external_field() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@external"])
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@is", "@key"])
+
+                type Query {
+                    productBatch(ids: [ID!]!): [Product!]!
+                }
+
+                type Product {
+                    id: ID!
+                    code: String!
+                    author_id: ID!
+                    category_id: ID!
+                    user: User! @is(field: "{ id: author_id }")
+                }
+
+                type User @key(fields: "id") {
+                    id: ID!
+                    category: String! @external
+                }
+                "#,
+            )
+            .try_build()
+            .await;
+
+        if let Err(err) = result {
+            panic!("{err}");
+        }
+    })
+}
+
+#[test]
+fn missing_nullable_field() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@is"])
+
+                type Query {
+                    productBatch(ids: [ID!]!): [Product!]!
+                }
+
+                type Product {
+                    id: ID!
+                    code: String!
+                    author_id: ID!
+                    category_id: ID!
+                    user: User! @is(field: "{ id: author_id }")
+                }
+
+                type User {
+                    id: ID!
+                    name: String
+                }
+                "#,
+            )
+            .try_build()
+            .await;
+
+        if let Err(err) = result {
+            panic!("{err}");
+        }
+    })
+}
+
+#[test]
 fn direct_field_mapping() {
     runtime().block_on(async {
         let result = Gateway::builder()
@@ -134,9 +551,11 @@ fn direct_field_mapping() {
             .try_build()
             .await;
 
-        if let Err(err) = result {
-            panic!("{err}");
-        }
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Product.user_id, for directive @composite__is: @is can only be used on fields to compute an object/interface.
+        See schema at 25:3:
+        user_id: ID! @composite__is(graph: EXT, field: "author_id")
+        "#);
     })
 }
 
@@ -169,10 +588,10 @@ fn incompatible_wrapping() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Product.user, for directive @composite__is Incompatible wrapping, cannot map Product.author_ids ([ID!]!) into User.id (ID!). See schema at 25:29:\n(graph: EXT, field: \"{ id: author_ids }\")",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Product.user, for directive @composite__is: Incompatible wrapping, cannot map Product.author_ids ([ID!]!) into User.id (ID!)
+        See schema at 25:29:
+        (graph: EXT, field: "{ id: author_ids }")
         "#);
     })
 }
@@ -205,10 +624,10 @@ fn inexistent_field() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Product.user, for directive @composite__is Type Product does not have a field named 'non_existent_field'. See schema at 24:29:\n(graph: EXT, field: \"{ id: non_existent_field }\")",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Product.user, for directive @composite__is: Type Product does not have a field named 'non_existent_field'
+        See schema at 24:29:
+        (graph: EXT, field: "{ id: non_existent_field }")
         "#);
     })
 }
@@ -241,10 +660,10 @@ fn inexistent_target_field() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Product.user, for directive @composite__is Field 'non_existent_field' does not exist on Product.user. See schema at 24:29:\n(graph: EXT, field: \"{ non_existent_field: id }\")",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Product.user, for directive @composite__is: Field 'non_existent_field' does not exist on Product.user
+        See schema at 24:29:
+        (graph: EXT, field: "{ non_existent_field: id }")
         "#);
     })
 }
@@ -278,10 +697,10 @@ fn nullable_vs_required() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Product.user, for directive @composite__is Incompatible wrapping, cannot map Product.author_id (ID) into User.id (ID!). See schema at 25:29:\n(graph: EXT, field: \"{ id: author_id }\")",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Product.user, for directive @composite__is: Incompatible wrapping, cannot map Product.author_id (ID) into User.id (ID!)
+        See schema at 25:29:
+        (graph: EXT, field: "{ id: author_id }")
         "#);
     })
 }

--- a/crates/integration-tests/tests/gateway/composite/lookup/key/batch/composite.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/key/batch/composite.rs
@@ -611,10 +611,10 @@ fn no_arguments() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch: [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 30:3:
+        productBatch: [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -649,10 +649,10 @@ fn no_matching_argument() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(somethign: Int): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 30:3:
+        productBatch(somethign: Int): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -692,10 +692,10 @@ fn good_name_bad_type() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 37:3:\nproductBatch(key: [Key!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 37:3:
+        productBatch(key: [Key!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -735,10 +735,10 @@ fn good_name_not_a_list() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(key: Key): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 30:3:
+        productBatch(key: Key): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -778,10 +778,10 @@ fn cannot_inject_nullable_field_into_required() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(key: [Key!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 30:3:
+        productBatch(key: [Key!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -821,10 +821,10 @@ fn ambiguous_multiple_arg_matches() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(a: [Key!], b: [Key!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 30:3:
+        productBatch(a: [Key!], b: [Key!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -865,10 +865,10 @@ fn ambiguous_multiple_input_field_matches() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(key: [Key!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 30:3:
+        productBatch(key: [Key!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -908,10 +908,10 @@ fn extra_required_argument() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(ids: [Key!], required: Boolean!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 30:3:
+        productBatch(ids: [Key!], required: Boolean!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -952,10 +952,10 @@ fn extra_required_field() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(key: [Key!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 30:3:
+        productBatch(key: [Key!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }

--- a/crates/integration-tests/tests/gateway/composite/lookup/key/batch/composite.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/key/batch/composite.rs
@@ -613,7 +613,7 @@ fn no_arguments() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 30:3:\nproductBatch: [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch: [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -651,7 +651,7 @@ fn no_matching_argument() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 30:3:\nproductBatch(somethign: Int): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(somethign: Int): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -694,7 +694,7 @@ fn good_name_bad_type() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 37:3:\nproductBatch(key: [Key!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 37:3:\nproductBatch(key: [Key!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -737,7 +737,7 @@ fn good_name_not_a_list() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 30:3:\nproductBatch(key: Key): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(key: Key): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -780,7 +780,7 @@ fn cannot_inject_nullable_field_into_required() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 30:3:\nproductBatch(key: [Key!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(key: [Key!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -823,7 +823,7 @@ fn ambiguous_multiple_arg_matches() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 30:3:\nproductBatch(a: [Key!], b: [Key!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(a: [Key!], b: [Key!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -867,7 +867,7 @@ fn ambiguous_multiple_input_field_matches() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 30:3:\nproductBatch(key: [Key!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(key: [Key!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -910,7 +910,7 @@ fn extra_required_argument() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 30:3:\nproductBatch(ids: [Key!], required: Boolean!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(ids: [Key!], required: Boolean!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -954,7 +954,7 @@ fn extra_required_field() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 30:3:\nproductBatch(key: [Key!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(key: [Key!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })

--- a/crates/integration-tests/tests/gateway/composite/lookup/key/batch/mod.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/key/batch/mod.rs
@@ -485,7 +485,7 @@ fn no_arguments() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 29:3:\nproductBatch: [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch: [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -522,7 +522,7 @@ fn no_matching_argument() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 29:3:\nproductBatch(somethign: Int): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(somethign: Int): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -559,7 +559,7 @@ fn cannot_inject_nullable_into_required() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 29:3:\nproductBatch(id: [ID!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(id: [ID!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -596,7 +596,7 @@ fn good_name_bad_type() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 29:3:\nproductBatch(id: [Int]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(id: [Int]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -633,7 +633,7 @@ fn good_name_not_a_list() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 29:3:\nproductBatch(id: ID!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(id: ID!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -670,7 +670,7 @@ fn ambiguous_multiple_matches() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 29:3:\nproductBatch(a: [ID!], b: [ID!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(a: [ID!], b: [ID!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -707,7 +707,7 @@ fn extra_required_argument() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 29:3:\nproductBatch(ids: [ID!], required: Boolean!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(ids: [ID!], required: Boolean!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })

--- a/crates/integration-tests/tests/gateway/composite/lookup/key/batch/mod.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/key/batch/mod.rs
@@ -483,10 +483,10 @@ fn no_arguments() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch: [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 29:3:
+        productBatch: [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -520,10 +520,10 @@ fn no_matching_argument() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(somethign: Int): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 29:3:
+        productBatch(somethign: Int): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -557,10 +557,10 @@ fn cannot_inject_nullable_into_required() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(id: [ID!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 29:3:
+        productBatch(id: [ID!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -594,10 +594,10 @@ fn good_name_bad_type() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(id: [Int]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 29:3:
+        productBatch(id: [Int]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -631,10 +631,10 @@ fn good_name_not_a_list() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(id: ID!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 29:3:
+        productBatch(id: ID!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -668,10 +668,10 @@ fn ambiguous_multiple_matches() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(a: [ID!], b: [ID!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 29:3:
+        productBatch(a: [ID!], b: [ID!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -705,10 +705,10 @@ fn extra_required_argument() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(ids: [ID!], required: Boolean!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 29:3:
+        productBatch(ids: [ID!], required: Boolean!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }

--- a/crates/integration-tests/tests/gateway/composite/lookup/key/batch/nested.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/key/batch/nested.rs
@@ -637,7 +637,7 @@ fn no_arguments() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 36:3:\nproductBatch: [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 36:3:\nproductBatch: [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -682,7 +682,7 @@ fn no_matching_argument() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 36:3:\nproductBatch(somethign: Int): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 36:3:\nproductBatch(somethign: Int): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -727,7 +727,7 @@ fn no_matching_nested_field() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 36:3:\nproductBatch(nested: [NestedInput!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 36:3:\nproductBatch(nested: [NestedInput!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -772,7 +772,7 @@ fn arg_good_name_bad_type() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 36:3:\nproductBatch(nested: [Int]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 36:3:\nproductBatch(nested: [Int]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -817,7 +817,7 @@ fn field_good_name_bad_type() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 36:3:\nproductBatch(nested: [NestedInput!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 36:3:\nproductBatch(nested: [NestedInput!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -862,7 +862,7 @@ fn good_name_not_a_list() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 36:3:\nproductBatch(nested: NestedInput!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 36:3:\nproductBatch(nested: NestedInput!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -907,7 +907,7 @@ fn ambiguous_multiple_arg_matches() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 36:3:\nproductBatch(a: [NestedInput!], b: [NestedInput!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 36:3:\nproductBatch(a: [NestedInput!], b: [NestedInput!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -953,7 +953,7 @@ fn ambiguous_multiple_field_matches() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 36:3:\nproductBatch(a: [NestedInput!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 36:3:\nproductBatch(a: [NestedInput!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -998,7 +998,7 @@ fn extra_required_argument() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 36:3:\nproductBatch(nested: [NestedInput!], required: Boolean!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 36:3:\nproductBatch(nested: [NestedInput!], required: Boolean!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -1044,7 +1044,7 @@ fn extra_required_field() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 36:3:\nproductBatch(nested: [NestedInput!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 36:3:\nproductBatch(nested: [NestedInput!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })

--- a/crates/integration-tests/tests/gateway/composite/lookup/key/batch/nested.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/key/batch/nested.rs
@@ -635,10 +635,10 @@ fn no_arguments() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 36:3:\nproductBatch: [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 36:3:
+        productBatch: [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -680,10 +680,10 @@ fn no_matching_argument() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 36:3:\nproductBatch(somethign: Int): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 36:3:
+        productBatch(somethign: Int): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -725,10 +725,10 @@ fn no_matching_nested_field() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 36:3:\nproductBatch(nested: [NestedInput!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 36:3:
+        productBatch(nested: [NestedInput!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -770,10 +770,10 @@ fn arg_good_name_bad_type() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 36:3:\nproductBatch(nested: [Int]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 36:3:
+        productBatch(nested: [Int]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -815,10 +815,10 @@ fn field_good_name_bad_type() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 36:3:\nproductBatch(nested: [NestedInput!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 36:3:
+        productBatch(nested: [NestedInput!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -860,10 +860,10 @@ fn good_name_not_a_list() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 36:3:\nproductBatch(nested: NestedInput!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 36:3:
+        productBatch(nested: NestedInput!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -905,10 +905,10 @@ fn ambiguous_multiple_arg_matches() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 36:3:\nproductBatch(a: [NestedInput!], b: [NestedInput!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 36:3:
+        productBatch(a: [NestedInput!], b: [NestedInput!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -951,10 +951,10 @@ fn ambiguous_multiple_field_matches() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 36:3:\nproductBatch(a: [NestedInput!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 36:3:
+        productBatch(a: [NestedInput!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -996,10 +996,10 @@ fn extra_required_argument() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 36:3:\nproductBatch(nested: [NestedInput!], required: Boolean!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 36:3:
+        productBatch(nested: [NestedInput!], required: Boolean!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -1042,10 +1042,10 @@ fn extra_required_field() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 36:3:\nproductBatch(nested: [NestedInput!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 36:3:
+        productBatch(nested: [NestedInput!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }

--- a/crates/integration-tests/tests/gateway/composite/lookup/key/batch/oneof.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/key/batch/oneof.rs
@@ -367,10 +367,10 @@ fn good_name_not_a_list() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(id: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 29:3:
+        productBatch(id: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -408,10 +408,10 @@ fn ambiguous_multiple_arg_matches() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(a: Lookup!, b: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 29:3:
+        productBatch(a: Lookup!, b: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -449,10 +449,10 @@ fn lookup_arg_in_a_list() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(lookup: [Lookup!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 29:3:
+        productBatch(lookup: [Lookup!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -491,10 +491,10 @@ fn ambiguous_multiple_oneof_field_matches() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(lookup: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 29:3:
+        productBatch(lookup: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -532,10 +532,10 @@ fn extra_required_argument() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(lookup: Lookup!, required: Boolean!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 29:3:
+        productBatch(lookup: Lookup!, required: Boolean!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }

--- a/crates/integration-tests/tests/gateway/composite/lookup/key/batch/oneof.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/key/batch/oneof.rs
@@ -369,7 +369,7 @@ fn good_name_not_a_list() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 29:3:\nproductBatch(id: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(id: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -410,7 +410,7 @@ fn ambiguous_multiple_arg_matches() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 29:3:\nproductBatch(a: Lookup!, b: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(a: Lookup!, b: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -451,7 +451,7 @@ fn lookup_arg_in_a_list() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 29:3:\nproductBatch(lookup: [Lookup!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(lookup: [Lookup!]): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -493,7 +493,7 @@ fn ambiguous_multiple_oneof_field_matches() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 29:3:\nproductBatch(lookup: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(lookup: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -534,7 +534,7 @@ fn extra_required_argument() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 29:3:\nproductBatch(lookup: Lookup!, required: Boolean!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 29:3:\nproductBatch(lookup: Lookup!, required: Boolean!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })

--- a/crates/integration-tests/tests/gateway/composite/lookup/key/batch/oneof_composite.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/key/batch/oneof_composite.rs
@@ -422,10 +422,10 @@ fn not_a_list() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(input: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 30:3:
+        productBatch(input: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -469,10 +469,10 @@ fn ambiguous_multiple_arg_matches() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(a: Lookup!, b: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 30:3:
+        productBatch(a: Lookup!, b: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -517,10 +517,10 @@ fn ambiguous_multiple_oneof_input_field_matches() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(lookup: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 30:3:
+        productBatch(lookup: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -565,10 +565,10 @@ fn ambiguous_multiple_input_field_matches() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(lookup: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 30:3:
+        productBatch(lookup: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -612,10 +612,10 @@ fn extra_required_argument() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(lookup: Lookup!, required: Boolean!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 30:3:
+        productBatch(lookup: Lookup!, required: Boolean!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }
@@ -660,10 +660,10 @@ fn extra_required_field() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(lookup: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        See schema at 30:3:
+        productBatch(lookup: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)
         "#);
     })
 }

--- a/crates/integration-tests/tests/gateway/composite/lookup/key/batch/oneof_composite.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/key/batch/oneof_composite.rs
@@ -424,7 +424,7 @@ fn not_a_list() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 30:3:\nproductBatch(input: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(input: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -471,7 +471,7 @@ fn ambiguous_multiple_arg_matches() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 30:3:\nproductBatch(a: Lookup!, b: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(a: Lookup!, b: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -519,7 +519,7 @@ fn ambiguous_multiple_oneof_input_field_matches() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 30:3:\nproductBatch(lookup: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(lookup: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -567,7 +567,7 @@ fn ambiguous_multiple_input_field_matches() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 30:3:\nproductBatch(lookup: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(lookup: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -614,7 +614,7 @@ fn extra_required_argument() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 30:3:\nproductBatch(lookup: Lookup!, required: Boolean!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(lookup: Lookup!, required: Boolean!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })
@@ -662,7 +662,7 @@ fn extra_required_field() {
 
         insta::assert_debug_snapshot!(result.err(), @r#"
         Some(
-            "At site Query.productBatch, for directive @lookup no matching @key directive was found. See schema at 30:3:\nproductBatch(lookup: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
+            "At site Query.productBatch, for directive @lookup no matching @key directive was found\nSee schema at 30:3:\nproductBatch(lookup: Lookup!): [Product!]! @composite__lookup(graph: EXT) @join__field(graph: EXT)",
         )
         "#);
     })

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/arguments/enum_.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/arguments/enum_.rs
@@ -69,10 +69,10 @@ fn unknown_enum_value() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found an unknown enum value 'UNKNOWN' for the enum EchoEnum at path '.value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {fields: \"field(value: UNKNOWN)\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found an unknown enum value 'UNKNOWN' for the enum EchoEnum at path '.value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {fields: "field(value: UNKNOWN)"})
         "#);
     });
 }
@@ -103,10 +103,10 @@ fn invalid_enum_value() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a String value where we expected a EchoEnum enum value at path '.value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {fields: \"field(value: \\\"VALUE\\\")\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a String value where we expected a EchoEnum enum value at path '.value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {fields: "field(value: \"VALUE\")"})
         "#);
 
         let result = Gateway::builder()
@@ -132,10 +132,10 @@ fn invalid_enum_value() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a Integer value where we expected a EchoEnum enum value at path '.value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {fields: \"field(value: 1)\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a Integer value where we expected a EchoEnum enum value at path '.value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {fields: "field(value: 1)"})
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/arguments/fields.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/arguments/fields.rs
@@ -69,10 +69,10 @@ fn missing_required_field() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a null where we expected a String! at path '.input.value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {fields: \"field(input: {})\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a null where we expected a String! at path '.input.value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {fields: "field(input: {})"})
         "#);
     });
 }
@@ -103,10 +103,10 @@ fn too_many_fields() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Input object EchoInput does not have a field named 'other' at path '.input'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {fields: \"field(input: { value: \\\"test\\\", other: 1 })\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Input object EchoInput does not have a field named 'other' at path '.input'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {fields: "field(input: { value: \"test\", other: 1 })"})
         "#);
     });
 }
@@ -137,10 +137,10 @@ fn not_an_object() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a List value where we expected a 'EchoInput' input object at path '.input'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {fields: \"field(input: [])\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a List value where we expected a 'EchoInput' input object at path '.input'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {fields: "field(input: [])"})
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/arguments/list.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/arguments/list.rs
@@ -105,10 +105,10 @@ fn incompatible_list_wrapping() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a String value where we expected a [String!] at path '.value.0'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {fields: \"field(value: [\\\"something\\\"])\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a String value where we expected a [String!] at path '.value.0'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {fields: "field(value: [\"something\"])"})
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/arguments/non_null.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/arguments/non_null.rs
@@ -23,10 +23,10 @@ fn unexpected_null() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a null where we expected a String! at path '.value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {fields: \"field(value: null)\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a null where we expected a String! at path '.value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {fields: "field(value: null)"})
         "#);
     });
 }
@@ -53,10 +53,10 @@ fn missing_required_argument() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Missing required argument named 'value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {fields: \"field\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Missing required argument named 'value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {fields: "field"})
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/arguments/scalar/boolean.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/arguments/scalar/boolean.rs
@@ -61,10 +61,10 @@ fn invalid_boolean() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a Float value where we expected a Boolean scalar at path '.value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {fields: \"field(value: 7.123)\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a Float value where we expected a Boolean scalar at path '.value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {fields: "field(value: 7.123)"})
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/arguments/scalar/float.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/arguments/scalar/float.rs
@@ -99,10 +99,10 @@ fn invalid_float() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a String value where we expected a Float scalar at path '.value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {fields: \"field(value: \\\"7.123\\\")\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a String value where we expected a Float scalar at path '.value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {fields: "field(value: \"7.123\")"})
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/arguments/scalar/id.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/arguments/scalar/id.rs
@@ -61,10 +61,10 @@ fn invalid_id() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a Float value where we expected a ID scalar at path '.value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {fields: \"field(value: 7.123)\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a Float value where we expected a ID scalar at path '.value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {fields: "field(value: 7.123)"})
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/arguments/scalar/int.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/arguments/scalar/int.rs
@@ -99,10 +99,10 @@ fn invalid_int() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found value 9223372036854775807 which cannot be coerced into a Int scalar at path '.value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {fields: \"field(value: 9223372036854775807)\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found value 9223372036854775807 which cannot be coerced into a Int scalar at path '.value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {fields: "field(value: 9223372036854775807)"})
         "#);
 
         let result = Gateway::builder()
@@ -124,10 +124,10 @@ fn invalid_int() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a Float value where we expected a Int scalar at path '.value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {fields: \"field(value: 79.123)\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a Float value where we expected a Int scalar at path '.value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {fields: "field(value: 79.123)"})
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/arguments/scalar/string.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/arguments/scalar/string.rs
@@ -61,10 +61,10 @@ fn invalid_string() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a Float value where we expected a String scalar at path '.value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {fields: \"field(value: 7.123)\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Failed to coerce argument at path '.field': Found a Float value where we expected a String scalar at path '.value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {fields: "field(value: 7.123)"})
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/field.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/field.rs
@@ -58,60 +58,60 @@ fn can_select_multiple_fields() {
 
 #[test]
 fn cannot_select_unknown_fields() {
-    let err = run_with_field_set(graphql_subgraph(), "unknown").err();
-    insta::assert_debug_snapshot!(err, @r#"
-    Some(
-        "At site User.echo, for the extension 'echo-1.0.0' directive @echo: Unknown field 'unknown' on type 'User'. See schema at 23:35:\n(graph: B, extension: ECHO, name: \"echo\", arguments: {fields: \"unknown\"})",
-    )
+    let err = run_with_field_set(graphql_subgraph(), "unknown").unwrap_err();
+    insta::assert_snapshot!(err, @r#"
+    At site User.echo, for the extension 'echo-1.0.0' directive @echo: Unknown field 'unknown' on type 'User'
+    See schema at 23:35:
+    (graph: B, extension: ECHO, name: "echo", arguments: {fields: "unknown"})
     "#);
 }
 
 #[test]
 fn cannot_select_unknown_fields_nested() {
-    let err = run_with_field_set(graphql_subgraph(), "friends { friends { address { unknown } } }").err();
-    insta::assert_debug_snapshot!(err, @r#"
-    Some(
-        "At site User.echo, for the extension 'echo-1.0.0' directive @echo: Unknown field 'unknown' on type 'Address' at path '.friends.friends.address'. See schema at 23:35:\n(graph: B, extension: ECHO, name: \"echo\", arguments: {fields: \"friends { friends { address { unknown } } }\"})",
-    )
+    let err = run_with_field_set(graphql_subgraph(), "friends { friends { address { unknown } } }").unwrap_err();
+    insta::assert_snapshot!(err, @r#"
+    At site User.echo, for the extension 'echo-1.0.0' directive @echo: Unknown field 'unknown' on type 'Address' at path '.friends.friends.address'
+    See schema at 23:35:
+    (graph: B, extension: ECHO, name: "echo", arguments: {fields: "friends { friends { address { unknown } } }"})
     "#);
 }
 
 #[test]
 fn composite_type_cannot_be_a_leaf() {
-    let err = run_with_field_set(graphql_subgraph(), "id address").err();
-    insta::assert_debug_snapshot!(err, @r#"
-    Some(
-        "At site User.echo, for the extension 'echo-1.0.0' directive @echo: Leaf field 'address' must be a scalar or an enum, but is a Address.. See schema at 23:35:\n(graph: B, extension: ECHO, name: \"echo\", arguments: {fields: \"id address\"})",
-    )
+    let err = run_with_field_set(graphql_subgraph(), "id address").unwrap_err();
+    insta::assert_snapshot!(err, @r#"
+    At site User.echo, for the extension 'echo-1.0.0' directive @echo: Leaf field 'address' must be a scalar or an enum, but is a Address.
+    See schema at 23:35:
+    (graph: B, extension: ECHO, name: "echo", arguments: {fields: "id address"})
     "#);
 }
 
 #[test]
 fn composite_type_cannot_be_a_leaf_nested() {
-    let err = run_with_field_set(graphql_subgraph(), "id friends { address }").err();
-    insta::assert_debug_snapshot!(err, @r#"
-    Some(
-        "At site User.echo, for the extension 'echo-1.0.0' directive @echo: Leaf field 'address' at path '.friends' must be a scalar or an enum, but is a Address.. See schema at 23:35:\n(graph: B, extension: ECHO, name: \"echo\", arguments: {fields: \"id friends { address }\"})",
-    )
+    let err = run_with_field_set(graphql_subgraph(), "id friends { address }").unwrap_err();
+    insta::assert_snapshot!(err, @r#"
+    At site User.echo, for the extension 'echo-1.0.0' directive @echo: Leaf field 'address' at path '.friends' must be a scalar or an enum, but is a Address.
+    See schema at 23:35:
+    (graph: B, extension: ECHO, name: "echo", arguments: {fields: "id friends { address }"})
     "#);
 }
 
 #[test]
 fn scalars_cannot_have_selection_set() {
-    let err = run_with_field_set(graphql_subgraph(), "name { __typename }").err();
-    insta::assert_debug_snapshot!(err, @r#"
-    Some(
-        "At site User.echo, for the extension 'echo-1.0.0' directive @echo: Field 'name' cannot have a selection set, it's a String!. Only interfaces, unions and objects can.. See schema at 23:35:\n(graph: B, extension: ECHO, name: \"echo\", arguments: {fields: \"name { __typename }\"})",
-    )
+    let err = run_with_field_set(graphql_subgraph(), "name { __typename }").unwrap_err();
+    insta::assert_snapshot!(err, @r#"
+    At site User.echo, for the extension 'echo-1.0.0' directive @echo: Field 'name' cannot have a selection set, it's a String!. Only interfaces, unions and objects can.
+    See schema at 23:35:
+    (graph: B, extension: ECHO, name: "echo", arguments: {fields: "name { __typename }"})
     "#);
 }
 
 #[test]
 fn scalars_cannot_have_selection_set_nested() {
-    let err = run_with_field_set(graphql_subgraph(), "name friends { name { __typename } }").err();
-    insta::assert_debug_snapshot!(err, @r#"
-    Some(
-        "At site User.echo, for the extension 'echo-1.0.0' directive @echo: Field 'name' at path '.friends' cannot have a selection set, it's a String!. Only interfaces, unions and objects can.. See schema at 23:35:\n(graph: B, extension: ECHO, name: \"echo\", arguments: {fields: \"name friends { name { __typename } }\"})",
-    )
+    let err = run_with_field_set(graphql_subgraph(), "name friends { name { __typename } }").unwrap_err();
+    insta::assert_snapshot!(err, @r#"
+    At site User.echo, for the extension 'echo-1.0.0' directive @echo: Field 'name' at path '.friends' cannot have a selection set, it's a String!. Only interfaces, unions and objects can.
+    See schema at 23:35:
+    (graph: B, extension: ECHO, name: "echo", arguments: {fields: "name friends { name { __typename } }"})
     "#);
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/type_condition.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/type_condition.rs
@@ -52,11 +52,11 @@ fn can_have_inline_fragments_without_type_condition() {
 
 #[test]
 fn cannot_have_name_fragments() {
-    let error = run_with_field_set(graphql_subgraph(), "id ...NamedFragment").err();
-    insta::assert_debug_snapshot!(error, @r#"
-    Some(
-        "At site User.echo, for the extension 'echo-1.0.0' directive @echo: Cannot use named fragments inside a FieldSet. See schema at 23:35:\n(graph: B, extension: ECHO, name: \"echo\", arguments: {fields: \"id ...NamedFragment\"})",
-    )
+    let err = run_with_field_set(graphql_subgraph(), "id ...NamedFragment").unwrap_err();
+    insta::assert_snapshot!(err, @r#"
+    At site User.echo, for the extension 'echo-1.0.0' directive @echo: Cannot use named fragments inside a FieldSet
+    See schema at 23:35:
+    (graph: B, extension: ECHO, name: "echo", arguments: {fields: "id ...NamedFragment"})
     "#);
 }
 
@@ -140,11 +140,11 @@ fn type_condiiton_must_have_at_least_one_common_type_union() {
         ),
         "... on OtherUnion { ... on Other { id } }",
     )
-    .err();
-    insta::assert_debug_snapshot!(err, @r#"
-    Some(
-        "At site User.echo, for the extension 'echo-1.0.0' directive @echo: Type condition on 'OtherUnion' cannot be used in a 'User' selection_set. See schema at 27:35:\n(graph: B, extension: ECHO, name: \"echo\", arguments: {fields: \"... on OtherUnion { ... on Other { id } }\"})",
-    )
+    .unwrap_err();
+    insta::assert_snapshot!(err, @r#"
+    At site User.echo, for the extension 'echo-1.0.0' directive @echo: Type condition on 'OtherUnion' cannot be used in a 'User' selection_set
+    See schema at 27:35:
+    (graph: B, extension: ECHO, name: "echo", arguments: {fields: "... on OtherUnion { ... on Other { id } }"})
     "#);
 }
 
@@ -177,11 +177,11 @@ fn type_condiiton_must_have_at_least_one_common_type_interface() {
         ),
         "... on Node { id }",
     )
-    .err();
-    insta::assert_debug_snapshot!(err, @r#"
-    Some(
-        "At site User.echo, for the extension 'echo-1.0.0' directive @echo: Type condition on 'Node' cannot be used in a 'User' selection_set. See schema at 21:35:\n(graph: B, extension: ECHO, name: \"echo\", arguments: {fields: \"... on Node { id }\"})",
-    )
+    .unwrap_err();
+    insta::assert_snapshot!(err, @r#"
+    At site User.echo, for the extension 'echo-1.0.0' directive @echo: Type condition on 'Node' cannot be used in a 'User' selection_set
+    See schema at 21:35:
+    (graph: B, extension: ECHO, name: "echo", arguments: {fields: "... on Node { id }"})
     "#);
 }
 
@@ -342,21 +342,21 @@ fn can_select_fields_from_union() {
 
 #[test]
 fn unions_have_no_fields() {
-    let error = run_with_field_set(graphql_subgraph(), "pets { id }").err();
-    insta::assert_debug_snapshot!(error, @r#"
-    Some(
-        "At site User.echo, for the extension 'echo-1.0.0' directive @echo: Field 'id' at path '.pets' does not exists on Pet, it's a union. Only interfaces and objects have fields, consider using a fragment with a type condition.. See schema at 23:35:\n(graph: B, extension: ECHO, name: \"echo\", arguments: {fields: \"pets { id }\"})",
-    )
+    let error = run_with_field_set(graphql_subgraph(), "pets { id }").unwrap_err();
+    insta::assert_snapshot!(error, @r#"
+    At site User.echo, for the extension 'echo-1.0.0' directive @echo: Field 'id' at path '.pets' does not exists on Pet, it's a union. Only interfaces and objects have fields, consider using a fragment with a type condition.
+    See schema at 23:35:
+    (graph: B, extension: ECHO, name: "echo", arguments: {fields: "pets { id }"})
     "#);
 }
 
 #[test]
 fn inexsitant_type() {
-    let error = run_with_field_set(graphql_subgraph(), "... on Unknown { id }").err();
-    insta::assert_debug_snapshot!(error, @r#"
-    Some(
-        "At site User.echo, for the extension 'echo-1.0.0' directive @echo: Unknown type 'Unknown'. See schema at 23:35:\n(graph: B, extension: ECHO, name: \"echo\", arguments: {fields: \"... on Unknown { id }\"})",
-    )
+    let error = run_with_field_set(graphql_subgraph(), "... on Unknown { id }").unwrap_err();
+    insta::assert_snapshot!(error, @r#"
+    At site User.echo, for the extension 'echo-1.0.0' directive @echo: Unknown type 'Unknown'
+    See schema at 23:35:
+    (graph: B, extension: ECHO, name: "echo", arguments: {fields: "... on Unknown { id }"})
     "#);
 }
 
@@ -380,10 +380,10 @@ fn must_be_output_type() {
         ),
         "... on UserInput { id }",
     )
-    .err();
-    insta::assert_debug_snapshot!(error, @r#"
-    Some(
-        "At site User.echo, for the extension 'echo-1.0.0' directive @echo: UserInput is not an object, interface or union. See schema at 21:35:\n(graph: B, extension: ECHO, name: \"echo\", arguments: {fields: \"... on UserInput { id }\"})",
-    )
+    .unwrap_err();
+    insta::assert_snapshot!(error, @r#"
+    At site User.echo, for the extension 'echo-1.0.0' directive @echo: UserInput is not an object, interface or union
+    See schema at 21:35:
+    (graph: B, extension: ECHO, name: "echo", arguments: {fields: "... on UserInput { id }"})
     "#);
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/validation.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/field_set/validation.rs
@@ -2,10 +2,10 @@ use crate::gateway::extensions::field_resolver::injection::field_set::{graphql_s
 
 #[test]
 fn invalid_selection_set() {
-    let err = run_with_field_set(graphql_subgraph(), "{").err();
-    insta::assert_debug_snapshot!(err, @r#"
-    Some(
-        "At site User.echo, for the extension 'echo-1.0.0' directive @echo: Could not parse InputValueSet: unexpected open brace ('{') token (expected one of , \"...\"RawIdent, schema, query, mutation, subscription, ty, input, true, false, null, implements, interface, \"enum\", union, scalar, extend, directive, repeatable, on, fragment). See schema at 23:35:\n(graph: B, extension: ECHO, name: \"echo\", arguments: {fields: \"{\"})",
-    )
+    let err = run_with_field_set(graphql_subgraph(), "{").unwrap_err();
+    insta::assert_snapshot!(err, @r#"
+    At site User.echo, for the extension 'echo-1.0.0' directive @echo: Could not parse InputValueSet: unexpected open brace ('{') token (expected one of , "..."RawIdent, schema, query, mutation, subscription, ty, input, true, false, null, implements, interface, "enum", union, scalar, extend, directive, repeatable, on, fragment)
+    See schema at 23:35:
+    (graph: B, extension: ECHO, name: "echo", arguments: {fields: "{"})
     "#);
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/input_value_set/validation.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/input_value_set/validation.rs
@@ -28,7 +28,9 @@ fn invalid_location_but_not_used() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @"None");
+        if let Err(err) = result {
+            panic!("{err}")
+        }
     });
 }
 
@@ -59,10 +61,10 @@ fn invalid_location() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query, for the extension 'echo-1.0.0' directive @echo: InputValueSet can only be used in directive applied on FIELD_DEFINITION, but found on OBJECT. See schema at 18:24:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {input: \"something\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query, for the extension 'echo-1.0.0' directive @echo: InputValueSet can only be used in directive applied on FIELD_DEFINITION, but found on OBJECT
+        See schema at 18:24:
+        (graph: A, extension: ECHO, name: "echo", arguments: {input: "something"})
         "#);
     });
 }
@@ -104,10 +106,10 @@ fn unknown_field() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Unknown input value 'unknown'. See schema at 19:92:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {input: \"unknown\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Unknown input value 'unknown'
+        See schema at 19:92:
+        (graph: A, extension: ECHO, name: "echo", arguments: {input: "unknown"})
         "#);
     });
 }
@@ -149,10 +151,10 @@ fn unknown_nested_field() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Unknown input value 'unknown' at path '.filters.nested'. See schema at 19:92:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {input: \"filters { nested { unknown } }\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Unknown input value 'unknown' at path '.filters.nested'
+        See schema at 19:92:
+        (graph: A, extension: ECHO, name: "echo", arguments: {input: "filters { nested { unknown } }"})
         "#);
     });
 }
@@ -194,10 +196,10 @@ fn cannot_have_selection_set() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Type String cannot have a selecction set at path '.after'. See schema at 19:92:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {input: \"after { something }\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Type String cannot have a selecction set at path '.after'
+        See schema at 19:92:
+        (graph: A, extension: ECHO, name: "echo", arguments: {input: "after { something }"})
         "#);
     });
 }
@@ -239,10 +241,10 @@ fn cannot_have_fragments() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Cannot use fragments inside a InputValueSet. See schema at 19:92:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {input: \"filters { ... {  latest } }\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Cannot use fragments inside a InputValueSet
+        See schema at 19:92:
+        (graph: A, extension: ECHO, name: "echo", arguments: {input: "filters { ... {  latest } }"})
         "#);
     });
 }
@@ -284,10 +286,10 @@ fn must_be_valid_selection_set() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Could not parse InputValueSet: unexpected closing brace ('}') token (expected one of , \"...\"RawIdent, schema, query, mutation, subscription, ty, input, true, false, null, implements, interface, \"enum\", union, scalar, extend, directive, repeatable, on, fragment). See schema at 19:92:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {input: \"filters {\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Could not parse InputValueSet: unexpected closing brace ('}') token (expected one of , "..."RawIdent, schema, query, mutation, subscription, ty, input, true, false, null, implements, interface, "enum", union, scalar, extend, directive, repeatable, on, fragment)
+        See schema at 19:92:
+        (graph: A, extension: ECHO, name: "echo", arguments: {input: "filters {"})
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/link.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/injection/link.rs
@@ -28,11 +28,7 @@ fn invalid_link() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "For extension greet-1.0.0, failed to prase @link directive: Unknown argument `ur` in `@link` directive",
-        )
-        "#);
+        insta::assert_snapshot!(result.unwrap_err(), @"For extension greet-1.0.0, failed to prase @link directive: Unknown argument `ur` in `@link` directive");
     });
 }
 
@@ -62,6 +58,8 @@ fn valid_link() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @"None");
+        if let Err(err) = result {
+            panic!("{err}")
+        }
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/definition.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/definition.rs
@@ -29,10 +29,10 @@ fn unknown_type() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Unknown type 'EchoInput'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {value: {a: 1}})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Unknown type 'EchoInput'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {value: {a: 1}})
         "#);
 
         // Invalid schema directive
@@ -60,10 +60,10 @@ fn unknown_type() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Unknown type 'EchoInput'. See schema at 29:97:\n{graph: A, name: \"meta\", arguments: {value: {a: 1}}}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Unknown type 'EchoInput'
+        See schema at 29:97:
+        {graph: A, name: "meta", arguments: {value: {a: 1}}}
         "#);
     });
 }
@@ -97,10 +97,10 @@ fn not_a_input_type() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Type 'EchoInput' is used for an input value but is not a scalar, input object or enum.. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {value: {a: 1}})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Type 'EchoInput' is used for an input value but is not a scalar, input object or enum.
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {value: {a: 1}})
         "#);
 
         // Invalid schema directive
@@ -130,10 +130,10 @@ fn not_a_input_type() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Type 'EchoInput' is used for an input value but is not a scalar, input object or enum.. See schema at 29:97:\n{graph: A, name: \"meta\", arguments: {value: {a: 1}}}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Type 'EchoInput' is used for an input value but is not a scalar, input object or enum.
+        See schema at 29:97:
+        {graph: A, name: "meta", arguments: {value: {a: 1}}}
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/enum_.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/enum_.rs
@@ -84,10 +84,10 @@ fn unknown_enum_value() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found an unknown enum value 'UNKNOWN' for the enum EchoEnum at path '.value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {value: UNKNOWN})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found an unknown enum value 'UNKNOWN' for the enum EchoEnum at path '.value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {value: UNKNOWN})
         "#);
 
         // Invalid schema directive
@@ -117,10 +117,10 @@ fn unknown_enum_value() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found an unknown enum value 'UNKNOWN' for the enum EchoEnum at path '.value'. See schema at 29:97:\n{graph: A, name: \"meta\", arguments: {value: UNKNOWN}}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found an unknown enum value 'UNKNOWN' for the enum EchoEnum at path '.value'
+        See schema at 29:97:
+        {graph: A, name: "meta", arguments: {value: UNKNOWN}}
         "#);
     });
 }
@@ -154,10 +154,10 @@ fn invalid_enum_value() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found a String value where we expected a EchoEnum enum value at path '.value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {value: \"VALID\"})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found a String value where we expected a EchoEnum enum value at path '.value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {value: "VALID"})
         "#);
 
         // Invalid schema directive
@@ -187,10 +187,10 @@ fn invalid_enum_value() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found a Integer value where we expected a EchoEnum enum value at path '.value'. See schema at 29:97:\n{graph: A, name: \"meta\", arguments: {value: 1}}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found a Integer value where we expected a EchoEnum enum value at path '.value'
+        See schema at 29:97:
+        {graph: A, name: "meta", arguments: {value: 1}}
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/fields.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/fields.rs
@@ -83,10 +83,10 @@ fn missing_required_field() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found a null where we expected a String! at path '.input.value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {input: {}})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found a null where we expected a String! at path '.input.value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {input: {}})
         "#);
 
         // Invalid schema directive
@@ -116,10 +116,10 @@ fn missing_required_field() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found a null where we expected a String! at path '.input.value'. See schema at 29:97:\n{graph: A, name: \"meta\", arguments: {input: {}}}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found a null where we expected a String! at path '.input.value'
+        See schema at 29:97:
+        {graph: A, name: "meta", arguments: {input: {}}}
         "#);
     });
 }
@@ -153,10 +153,10 @@ fn too_many_fields() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Input object EchoInput does not have a field named 'other' at path '.input'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {input: {value: \"test\", other: 1}})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Input object EchoInput does not have a field named 'other' at path '.input'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {input: {value: "test", other: 1}})
         "#);
 
         // Invalid schema directive
@@ -186,10 +186,10 @@ fn too_many_fields() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Input object EchoInput does not have a field named 'other' at path '.input'. See schema at 29:97:\n{graph: A, name: \"meta\", arguments: {input: {value: \"test\", other: 1}}}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Input object EchoInput does not have a field named 'other' at path '.input'
+        See schema at 29:97:
+        {graph: A, name: "meta", arguments: {input: {value: "test", other: 1}}}
         "#);
     });
 }
@@ -223,10 +223,10 @@ fn not_an_object() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found a List value where we expected a 'EchoInput' input object at path '.input'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {input: []})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found a List value where we expected a 'EchoInput' input object at path '.input'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {input: []})
         "#);
 
         // Invalid schema directive
@@ -256,10 +256,10 @@ fn not_an_object() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found a List value where we expected a 'EchoInput' input object at path '.input'. See schema at 29:97:\n{graph: A, name: \"meta\", arguments: {input: []}}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found a List value where we expected a 'EchoInput' input object at path '.input'
+        See schema at 29:97:
+        {graph: A, name: "meta", arguments: {input: []}}
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/list.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/list.rs
@@ -137,10 +137,10 @@ fn incompatible_list_wrapping() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found a String value where we expected a [String!] at path '.value.0'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {value: [\"something\"]})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found a String value where we expected a [String!] at path '.value.0'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {value: ["something"]})
         "#);
 
         // Invalid schema directive
@@ -166,10 +166,10 @@ fn incompatible_list_wrapping() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found a String value where we expected a [String!] at path '.value.0'. See schema at 29:97:\n{graph: A, name: \"meta\", arguments: {value: [\"meta\"]}}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found a String value where we expected a [String!] at path '.value.0'
+        See schema at 29:97:
+        {graph: A, name: "meta", arguments: {value: ["meta"]}}
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/location.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/location.rs
@@ -29,10 +29,10 @@ fn invalid_location() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, extension echo-1.0.0 directive @meta used in the wrong location FIELD_DEFINITION, expected one of: SCHEMA. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"meta\", arguments: {})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, extension echo-1.0.0 directive @meta used in the wrong location FIELD_DEFINITION, expected one of: SCHEMA
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "meta", arguments: {})
         "#);
 
         // Invalid schema directive
@@ -60,10 +60,10 @@ fn invalid_location() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site subgraph named 'a', extension echo-1.0.0 directive @echo used in the wrong location SCHEMA, expected one of: FIELD_DEFINITION. See schema at 29:97:\n{graph: A, name: \"echo\", arguments: {}}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site subgraph named 'a', extension echo-1.0.0 directive @echo used in the wrong location SCHEMA, expected one of: FIELD_DEFINITION
+        See schema at 29:97:
+        {graph: A, name: "echo", arguments: {}}
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/mod.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/mod.rs
@@ -166,10 +166,10 @@ fn too_many_arguments() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Unknown argumant named 'other'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {value: \"ste\", other: 1})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Unknown argumant named 'other'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {value: "ste", other: 1})
         "#);
 
         // Invalid schema directive
@@ -197,10 +197,10 @@ fn too_many_arguments() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Unknown argumant named 'other'. See schema at 29:97:\n{graph: A, name: \"meta\", arguments: {value: \"str\", other: 1}}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Unknown argumant named 'other'
+        See schema at 29:97:
+        {graph: A, name: "meta", arguments: {value: "str", other: 1}}
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/non_null.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/non_null.rs
@@ -27,10 +27,10 @@ fn unexpected_null() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found a null where we expected a String! at path '.value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {value: null})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found a null where we expected a String! at path '.value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {value: null})
         "#);
 
         // Invalid schema directive
@@ -56,10 +56,10 @@ fn unexpected_null() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found a null where we expected a String! at path '.value'. See schema at 29:97:\n{graph: A, name: \"meta\", arguments: {value: null}}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found a null where we expected a String! at path '.value'
+        See schema at 29:97:
+        {graph: A, name: "meta", arguments: {value: null}}
         "#);
     });
 }
@@ -89,10 +89,10 @@ fn missing_required_argument() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Missing required argument named 'value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Missing required argument named 'value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {})
         "#);
 
         // Invalid schema directive
@@ -118,10 +118,10 @@ fn missing_required_argument() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Missing required argument named 'value'. See schema at 29:97:\n{graph: A, name: \"meta\", arguments: {}}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Missing required argument named 'value'
+        See schema at 29:97:
+        {graph: A, name: "meta", arguments: {}}
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/one_of.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/one_of.rs
@@ -34,7 +34,9 @@ fn validate() {
             .with_extension(ext)
             .try_build()
             .await;
-        insta::assert_debug_snapshot!(result.err(), @"None");
+        if let Err(err) = result {
+            panic!("{err}")
+        }
 
         let result = Gateway::builder()
             .with_subgraph_sdl(
@@ -52,7 +54,9 @@ fn validate() {
             .with_extension(ext)
             .try_build()
             .await;
-        insta::assert_debug_snapshot!(result.err(), @"None");
+        if let Err(err) = result {
+            panic!("{err}")
+        }
 
         //
         // { b: "1" }
@@ -73,7 +77,9 @@ fn validate() {
             .with_extension(ext)
             .try_build()
             .await;
-        insta::assert_debug_snapshot!(result.err(), @"None");
+        if let Err(err) = result {
+            panic!("{err}")
+        }
 
         let result = Gateway::builder()
             .with_subgraph_sdl(
@@ -91,7 +97,9 @@ fn validate() {
             .with_extension(ext)
             .try_build()
             .await;
-        insta::assert_debug_snapshot!(result.err(), @"None");
+        if let Err(err) = result {
+            panic!("{err}")
+        }
 
         //
         // {}
@@ -112,10 +120,10 @@ fn validate() {
             .with_extension(ext)
             .try_build()
             .await;
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Exactly one field must be provided for Test with @oneOf: No field was provided at path '.value'. See schema at 17:34:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {value: {}})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Exactly one field must be provided for Test with @oneOf: No field was provided at path '.value'
+        See schema at 17:34:
+        (graph: A, extension: ECHO, name: "echo", arguments: {value: {}})
         "#);
 
         let result = Gateway::builder()
@@ -134,10 +142,10 @@ fn validate() {
             .with_extension(ext)
             .try_build()
             .await;
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Exactly one field must be provided for Test with @oneOf: No field was provided at path '.value'. See schema at 27:97:\n{graph: A, name: \"meta\", arguments: {value: {}}}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Exactly one field must be provided for Test with @oneOf: No field was provided at path '.value'
+        See schema at 27:97:
+        {graph: A, name: "meta", arguments: {value: {}}}
         "#);
 
         //
@@ -160,10 +168,10 @@ fn validate() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Exactly one field must be provided for Test with @oneOf: 2 fields (a,b) were provided at path '.value'. See schema at 17:34:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {value: {a: 1, b: \"1\"}})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Exactly one field must be provided for Test with @oneOf: 2 fields (a,b) were provided at path '.value'
+        See schema at 17:34:
+        (graph: A, extension: ECHO, name: "echo", arguments: {value: {a: 1, b: "1"}})
         "#);
         let result = Gateway::builder()
             .with_subgraph_sdl(
@@ -182,10 +190,10 @@ fn validate() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Exactly one field must be provided for Test with @oneOf: 2 fields (a,b) were provided at path '.value'. See schema at 27:97:\n{graph: A, name: \"meta\", arguments: {value: {a: 1, b: \"1\"}}}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Exactly one field must be provided for Test with @oneOf: 2 fields (a,b) were provided at path '.value'
+        See schema at 27:97:
+        {graph: A, name: "meta", arguments: {value: {a: 1, b: "1"}}}
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/scalar/boolean.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/scalar/boolean.rs
@@ -76,10 +76,10 @@ fn invalid_boolean() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found a Float value where we expected a Boolean scalar at path '.value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {value: 7.123})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found a Float value where we expected a Boolean scalar at path '.value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {value: 7.123})
         "#);
 
         // Invalid schema directive
@@ -105,10 +105,10 @@ fn invalid_boolean() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found a String value where we expected a Boolean scalar at path '.value'. See schema at 29:97:\n{graph: A, name: \"meta\", arguments: {value: \"test\"}}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found a String value where we expected a Boolean scalar at path '.value'
+        See schema at 29:97:
+        {graph: A, name: "meta", arguments: {value: "test"}}
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/scalar/float.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/scalar/float.rs
@@ -125,10 +125,10 @@ fn invalid_float() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found a Object value where we expected a Float scalar at path '.value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {value: {}})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found a Object value where we expected a Float scalar at path '.value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {value: {}})
         "#);
 
         // Invalid schema directive
@@ -154,10 +154,10 @@ fn invalid_float() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found a String value where we expected a Float scalar at path '.value'. See schema at 29:97:\n{graph: A, name: \"meta\", arguments: {value: \"79.123\"}}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found a String value where we expected a Float scalar at path '.value'
+        See schema at 29:97:
+        {graph: A, name: "meta", arguments: {value: "79.123"}}
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/scalar/id.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/scalar/id.rs
@@ -76,10 +76,10 @@ fn invalid_id() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found a Float value where we expected a ID scalar at path '.value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {value: 7.123})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found a Float value where we expected a ID scalar at path '.value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {value: 7.123})
         "#);
 
         // Invalid schema directive
@@ -105,10 +105,10 @@ fn invalid_id() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found a List value where we expected a ID scalar at path '.value'. See schema at 29:97:\n{graph: A, name: \"meta\", arguments: {value: []}}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found a List value where we expected a ID scalar at path '.value'
+        See schema at 29:97:
+        {graph: A, name: "meta", arguments: {value: []}}
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/scalar/int.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/scalar/int.rs
@@ -125,10 +125,10 @@ fn invalid_int() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found value 9223372036854775807 which cannot be coerced into a Int scalar at path '.value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {value: 9223372036854775807})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found value 9223372036854775807 which cannot be coerced into a Int scalar at path '.value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {value: 9223372036854775807})
         "#);
 
         // Invalid schema directive
@@ -154,10 +154,10 @@ fn invalid_int() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found a Float value where we expected a Int scalar at path '.value'. See schema at 29:97:\n{graph: A, name: \"meta\", arguments: {value: 79.123}}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found a Float value where we expected a Int scalar at path '.value'
+        See schema at 29:97:
+        {graph: A, name: "meta", arguments: {value: 79.123}}
         "#);
     });
 }

--- a/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/scalar/string.rs
+++ b/crates/integration-tests/tests/gateway/extensions/field_resolver/validation/scalar/string.rs
@@ -76,10 +76,10 @@ fn invalid_string() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found a Float value where we expected a String scalar at path '.value'. See schema at 19:35:\n(graph: A, extension: ECHO, name: \"echo\", arguments: {value: 7.123})",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site Query.echo, for the extension 'echo-1.0.0' directive @echo: Found a Float value where we expected a String scalar at path '.value'
+        See schema at 19:35:
+        (graph: A, extension: ECHO, name: "echo", arguments: {value: 7.123})
         "#);
 
         // Invalid schema directive
@@ -105,10 +105,10 @@ fn invalid_string() {
             .try_build()
             .await;
 
-        insta::assert_debug_snapshot!(result.err(), @r#"
-        Some(
-            "At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found a List value where we expected a String scalar at path '.value'. See schema at 29:97:\n{graph: A, name: \"meta\", arguments: {value: []}}",
-        )
+        insta::assert_snapshot!(result.unwrap_err(), @r#"
+        At site subgraph named 'a', for the extension 'echo-1.0.0' directive @meta: Found a List value where we expected a String scalar at path '.value'
+        See schema at 29:97:
+        {graph: A, name: "meta", arguments: {value: []}}
         "#);
     });
 }


### PR DESCRIPTION
I'm adding the following to the schema:
```graphql
type FieldDefinition {
  # ... 
  computed: [ComputedObject!]!
}

type ComputedObject @meta(module: "field/computed") {
  subgraph: Subgraph!
  fields: [ComputedField!]!
}

type ComputedField @meta(module: "field/computed") {
  from: FieldDefinition!
  target: FieldDefinition!
}
```

to handle `@is` computed fields. I'm restricting it to only objects using parent scalar/enum fields, added more validation and improved the snapshots of a bunch of tests which blows up the line count.

It's not used yet though, that's for the next PR.