### PR TITLE
Release grafbase 0.94.0 and grafbase-gateway 0.37.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.93.4"
+version = "0.94.0"
 dependencies = [
  "anyhow",
  "askama",
@@ -3914,7 +3914,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "ascii",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.93.4"
+version = "0.94.0"
 name = "grafbase"
 description = "The Grafbase command line interface"
 categories = ["command-line-utilities"]

--- a/cli/changelog/0.94.0.md
+++ b/cli/changelog/0.94.0.md
@@ -3,3 +3,8 @@
 - Added support for CLI plugins (https://github.com/grafbase/grafbase/pull/3133).
 
   Any binary in your `$PATH` that starts with `grafbase-` will be automatically detected and usable as a subcommand. For example, if you have the `grafbase-postgres` plugin installed, you can run it with `grafbase postgres`. Subsequent arguments are forwarded to the plugin. A new `grafbase list-plugins` command is also introduced. If you are familiar with these, this is similar to how cargo and git plugins work.
+
+## Improvements
+
+- `grafbase dev` and `grafbase extension install` now only download extensions that are not already installed.
+- Composition no longer requires `Query` to be non-empty. At least one field must be defined across the query, mutation and subscription roots instead.

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.93.4",
+  "version": "0.94.0",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.93.4",
+  "version": "0.94.0",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.93.4",
+  "version": "0.94.0",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.93.4",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.93.4",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.93.4",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.93.4",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.93.4"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.94.0",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.94.0",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.94.0",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.94.0",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.94.0"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.93.4",
+  "version": "0.94.0",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.93.4",
+  "version": "0.94.0",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.93.4",
+  "version": "0.94.0",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.37.0"
+version = "0.37.1"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/changelog/0.37.1.md
+++ b/gateway/changelog/0.37.1.md
@@ -1,0 +1,3 @@
+## Improvements
+
+- Improvements to composite schema spec support.


### PR DESCRIPTION
# CLI

## Features

- Added support for CLI plugins (https://github.com/grafbase/grafbase/pull/3133).

  Any binary in your `$PATH` that starts with `grafbase-` will be automatically detected and usable as a subcommand. For example, if you have the `grafbase-postgres` plugin installed, you can run it with `grafbase postgres`. Subsequent arguments are forwarded to the plugin. A new `grafbase list-plugins` command is also introduced. If you are familiar with these, this is similar to how cargo and git plugins work.

## Improvements

- `grafbase dev` and `grafbase extension install` now only download extensions that are not already installed.
- Composition no longer requires `Query` to be non-empty. At least one field must be defined across the query, mutation and subscription roots instead.

# Gateway

- Improvements to composite schema spec support.