### PR TITLE
cli: fix duplicate entries in `grafbase list-plugins`

### DIFF
--- a/cli/changelog/unreleased.md
+++ b/cli/changelog/unreleased.md
@@ -1,0 +1,3 @@
+## Fixes
+
+- `grafbase list-plugins` would list plugins that were installed in multiple directories in `$PATH` multiple times. That list is now dedpuplicated. (https://github.com/grafbase/grafbase/pull/3140)

--- a/cli/src/plugins.rs
+++ b/cli/src/plugins.rs
@@ -64,9 +64,20 @@ pub(crate) fn list() -> anyhow::Result<()> {
         }
     }
 
-    if external_commands.is_empty() {
+    print_plugin_list(&mut external_commands);
+
+    Ok(())
+}
+
+fn print_plugin_list(plugins: &mut Vec<String>) {
+    if plugins.is_empty() {
         eprintln!("Found no plugin");
+        return;
     }
+
+    // Deduplicate plugins, since they can be in several directories that are in $PATH
+    plugins.sort();
+    plugins.dedup();
 
     color_print::cprintln!("<bold><underline>Plugins:</underline></bold>");
     let base_command_name = env::args()
@@ -79,11 +90,9 @@ pub(crate) fn list() -> anyhow::Result<()> {
         })
         .unwrap_or_default();
 
-    for command in external_commands {
+    for command in plugins {
         println!("  {base_command_name} {command}")
     }
-
-    Ok(())
 }
 
 fn path() -> String {


### PR DESCRIPTION
If the plugin is available twice, in different directories that are part of `$PATH`, it would should up twice. Deduplicate the list before we print it to avoid that.

closes GB-9030