### PR TITLE
fix(gateway): panic when using compression with streams

### DIFF
--- a/cli/tests/extension/authorization.rs
+++ b/cli/tests/extension/authorization.rs
@@ -44,13 +44,13 @@ fn init() {
     codegen-units = 1
 
     [dependencies]
-    grafbase-sdk = "0.15.4"
+    grafbase-sdk = "0.15.5"
     serde = { version = "1", features = ["derive"] }
 
     [dev-dependencies]
     indoc = "2"
     insta = { version = "1", features = ["json"] }
-    grafbase-sdk = { version = "0.15.4", features = ["test-utils"] }
+    grafbase-sdk = { version = "0.15.5", features = ["test-utils"] }
     tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
     serde_json = "1"
     "#);

--- a/cli/tests/extension/mod.rs
+++ b/cli/tests/extension/mod.rs
@@ -50,13 +50,13 @@ fn init_resolver() {
     codegen-units = 1
 
     [dependencies]
-    grafbase-sdk = "0.15.4"
+    grafbase-sdk = "0.15.5"
     serde = { version = "1", features = ["derive"] }
 
     [dev-dependencies]
     indoc = "2"
     insta = { version = "1", features = ["json"] }
-    grafbase-sdk = { version = "0.15.4", features = ["test-utils"] }
+    grafbase-sdk = { version = "0.15.5", features = ["test-utils"] }
     tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
     serde_json = "1"
     "#);
@@ -310,13 +310,13 @@ fn init_auth() {
     codegen-units = 1
 
     [dependencies]
-    grafbase-sdk = "0.15.4"
+    grafbase-sdk = "0.15.5"
     serde = { version = "1", features = ["derive"] }
 
     [dev-dependencies]
     indoc = "2"
     insta = { version = "1", features = ["json"] }
-    grafbase-sdk = { version = "0.15.4", features = ["test-utils"] }
+    grafbase-sdk = { version = "0.15.5", features = ["test-utils"] }
     tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
     serde_json = "1"
     "#);

--- a/cli/tests/integration/data/Cargo.lock
+++ b/cli/tests/integration/data/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.15.3"
+version = "0.15.5"
 dependencies = [
  "chrono",
  "document-features",
@@ -392,6 +392,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "serde_urlencoded",
  "thiserror",
  "time",
@@ -994,6 +995,16 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
  "serde",
 ]
 


### PR DESCRIPTION
Using compression with a stream ends up in a panic today:

```
thread 'grafbase-gateway' panicked at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/futures-util-0.3.31/src/stream/unfold.rs:108:21:
Unfold must not be polled after it returned `Poll::Ready(None)`
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::panicking::panic
   3: <futures_util::stream::unfold::Unfold<T,F,Fut> as futures_core::stream::Stream>::poll_next
   4: <multipart_stream::serializer::Serializer<S,E> as futures_core::stream::Stream>::poll_next
   5: <futures_util::stream::try_stream::MapOk<St,F> as futures_core::stream::Stream>::poll_next
   6: <axum_core::body::StreamBody<S> as http_body::Body>::poll_frame
   7: <http_body_util::combinators::map_err::MapErr<B,F> as http_body::Body>::poll_frame
   8: <tower_http::compression_utils::BodyIntoStream<B> as http_body::Body>::poll_frame
   9: <tower_http::compression::body::CompressionBody<B> as http_body::Body>::poll_frame
  10: <http_body_util::combinators::map_err::MapErr<B,F> as http_body::Body>::poll_frame
  11: <hyper::server::conn::http1::UpgradeableConnection<I,S> as core::future::future::Future>::poll
  12: <hyper_util::server::conn::auto::UpgradeableConnection<I,S,E> as core::future::future::Future>::poll
  13: <core::future::poll_fn::PollFn<F> as core::future::future::Future>::poll
  14: axum_server::server::Server<A>::serve::{{closure}}::{{closure}}::{{closure}}
  15: tokio::runtime::task::core::Core<T,S>::poll
  16: tokio::runtime::task::harness::Harness<T,S>::poll
  17: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
  18: tokio::runtime::context::scoped::Scoped<T>::set
  19: tokio::runtime::context::runtime::enter_runtime
  20: tokio::runtime::scheduler::multi_thread::worker::run
  21: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll
  22: tokio::runtime::task::core::Core<T,S>::poll
  23: tokio::runtime::task::harness::Harness<T,S>::poll
  24: tokio::runtime::blocking::pool::Inner::run
```

There is an issue for `tower-http` explaining that compressed stream
doesn't work that well today:

https://github.com/tower-rs/tower-http/issues/292

So disabling it. Apollo Router team has implemented a solution by forking the codecs, so we might have to do the same later on.
