### PR TITLE
cli: always unpack assets in debug builds

### DIFF
--- a/cli/build.rs
+++ b/cli/build.rs
@@ -4,6 +4,7 @@ use std::fs::exists;
 
 fn main() {
     println!("cargo:rustc-env=TARGET={}", std::env::var("TARGET").unwrap());
+    println!("cargo:rustc-env=DEBUG={}", std::env::var("DEBUG").unwrap());
 
     cynic_codegen::register_schema("grafbase")
         .from_sdl_file("src/api/graphql/api.graphql")

--- a/cli/src/dev/assets.rs
+++ b/cli/src/dev/assets.rs
@@ -46,7 +46,9 @@ pub(crate) async fn export_assets() -> Result<(), BackendError> {
         let version = fs::read_to_string(version_file)
             .await
             .map_err(BackendError::ReadAssetVersion)?;
-        if version == CARGO_PKG_VERSION {
+
+        // Skip unpacking the assets if they are already at the right version, and this is not a debug build of the CLI.
+        if version == CARGO_PKG_VERSION && env!("DEBUG") != "true" {
             tracing::info!("CLI assets already exist in the latest version. Skipping.");
 
             return Ok(());


### PR DESCRIPTION
In development, assets are not unpacked again until you bump the version in Cargo.toml. This is not convenient for iteration, so this PR makes it so that debug builds of the CLI will always unpack the assets they were compiled with, which means slower startup, but potentially easier iteration on the CLI app integration.

closes GB-9037