### PR TITLE
feat(field-selection-map): Add identity "." and list without path

### DIFF
--- a/crates/engine/field-selection-map/src/model.rs
+++ b/crates/engine/field-selection-map/src/model.rs
@@ -31,29 +31,40 @@ impl fmt::Display for SelectedValue<'_> {
 /// Represents one possible entry in a SelectedValue (potentially unioned with |).
 #[derive(Debug, Clone, PartialEq)]
 pub enum SelectedValueEntry<'a> {
+    Identity,
     /// A path to a scalar or enum value. `field` or `object.field`
     Path(Path<'a>),
-    /// A path followed by an object selection. `path.{ field1 field2 }`
-    ObjectWithPath {
-        path: Path<'a>,
+    /// object selection. `{ field1 field2 }`
+    /// or a path followed by an object selection. `path.{ field1 field2 }`
+    Object {
+        path: Option<Path<'a>>,
         object: SelectedObjectValue<'a>,
     },
-    /// A path followed by a list selection. `path[ ... ]`
-    ListWithPath {
-        path: Path<'a>,
+    /// list selection. `[ ... ]`
+    /// or a path followed by a list selection. `path[ ... ]`
+    List {
+        path: Option<Path<'a>>,
         list: SelectedListValue<'a>,
     },
-    /// A standalone object selection. `{ field1 field2 }`
-    Object(SelectedObjectValue<'a>),
 }
 
 impl fmt::Display for SelectedValueEntry<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             SelectedValueEntry::Path(p) => write!(f, "{}", p),
-            SelectedValueEntry::ObjectWithPath { path, object } => write!(f, "{}.{}", path, object),
-            SelectedValueEntry::ListWithPath { path, list } => write!(f, "{}{}", path, list),
-            SelectedValueEntry::Object(o) => write!(f, "{}", o),
+            SelectedValueEntry::Object { path, object } => {
+                if let Some(path) = path {
+                    write!(f, "{}.", path)?
+                };
+                write!(f, "{}", object)
+            }
+            SelectedValueEntry::List { path, list } => {
+                if let Some(path) = path {
+                    write!(f, "{}", path)?
+                };
+                write!(f, "{}", list)
+            }
+            SelectedValueEntry::Identity => write!(f, "."),
         }
     }
 }

--- a/crates/engine/schema/src/builder/coerce/field_selection_map/model.rs
+++ b/crates/engine/schema/src/builder/coerce/field_selection_map/model.rs
@@ -17,22 +17,22 @@ impl<Id> BoundSelectedValue<Id> {
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum BoundSelectedValueEntry<Id> {
+    Identity,
     Path(BoundPath),
-    ObjectWithPath {
-        path: BoundPath,
+    Object {
+        path: Option<BoundPath>,
         object: BoundSelectedObjectValue<Id>,
     },
-    ListWithPath {
-        path: BoundPath,
+    List {
+        path: Option<BoundPath>,
         list: BoundSelectedListValue<Id>,
     },
-    Object(BoundSelectedObjectValue<Id>),
 }
 
 impl<Id> BoundSelectedValueEntry<Id> {
-    pub fn into_object(self) -> Option<BoundSelectedObjectValue<Id>> {
+    pub fn into_object_without_path(self) -> Option<BoundSelectedObjectValue<Id>> {
         match self {
-            BoundSelectedValueEntry::Object(obj) => Some(obj),
+            BoundSelectedValueEntry::Object { path: None, object } => Some(object),
             _ => None,
         }
     }

--- a/crates/engine/schema/src/builder/graph/directives/composite/derive.rs
+++ b/crates/engine/schema/src/builder/graph/directives/composite/derive.rs
@@ -89,7 +89,7 @@ pub(super) fn ingest<'sdl>(
                     is_directive.arguments_span(),
                 )
             })?
-            .into_object()
+            .into_object_without_path()
             .ok_or_else(|| {
                 (
                     "for associated @is directive, derived fields must be objects",


### PR DESCRIPTION
Add Identify `.`  for `@derive`

```
type Post {
  commentIds: [ID!]
  comments: [Comment!] @derive @is(field: "commentIds[{ id: . }]")
}
```

And list without path wich will be used for `@require` with batching:

```
type Post {
  commentId: ID
  comment(ids: [ID!]! @require(field: "[commentId]")): Comment
}
```

(note: The batching detection with `@require` is pretty hidden and a bit weird, but not sure yet if we can do better.)
