### PR TITLE
cli: delete cli_app directory before unpacking new version

### DIFF
--- a/cli/changelog/unreleased.md
+++ b/cli/changelog/unreleased.md
@@ -1,3 +1,7 @@
+## Improvements
+
+- The assets directory in ~/.grafbase is now cleaned up every time a new assets version is unpacked.
+
 ## Fixes
 
 - `grafbase list-plugins` would list plugins that were installed in multiple directories in `$PATH` multiple times. That list is now dedpuplicated. (https://github.com/grafbase/grafbase/pull/3140)

--- a/cli/src/dev/assets.rs
+++ b/cli/src/dev/assets.rs
@@ -59,8 +59,20 @@ pub(crate) async fn export_assets() -> Result<(), BackendError> {
 
     let tar = include_bytes!("../../assets/cli-app.tar.gz");
 
+    let cli_app_path = dot_grafbase_dir.join(ASSETS_DIR_NAME);
+
+    if cli_app_path.exists() {
+        fs::remove_dir_all(&cli_app_path).await.map_err(|err| {
+            anyhow::anyhow!(
+                "Failed to clean up assets directory at {}: {}",
+                cli_app_path.display(),
+                err
+            )
+        })?;
+    }
+
     Archive::new(GzDecoder::new(tar.as_slice()))
-        .unpack(dot_grafbase_dir.join(ASSETS_DIR_NAME))
+        .unpack(cli_app_path)
         .map_err(BackendError::UnpackCliAppArchive)?;
 
     fs::write(dot_grafbase_dir.join(VERSION_FILE_NAME), CARGO_PKG_VERSION)

--- a/cli/src/errors.rs
+++ b/cli/src/errors.rs
@@ -92,7 +92,6 @@ impl CliError {
 
 #[derive(Error, Debug)]
 pub(crate) enum BackendError {
-    // wraps a [`CommonError`]
     #[error(transparent)]
     CommonError(#[from] CommonError),
     #[error(transparent)]


### PR DESCRIPTION
Just so we start clean every time.

closes GB-9062