### PR TITLE
cli: release 0.94.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3833,7 +3833,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.94.0"
+version = "0.94.1"
 dependencies = [
  "anyhow",
  "askama",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.37.2"
+version = "0.94.1"
 dependencies = [
  "anyhow",
  "ascii",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.94.0"
+version = "0.94.1"
 name = "grafbase"
 description = "The Grafbase command line interface"
 categories = ["command-line-utilities"]

--- a/cli/changelog/0.94.1.md
+++ b/cli/changelog/0.94.1.md
@@ -1,5 +1,6 @@
-## Improvements
+## Improvements
 
+- New version of the web app served by `grafbase dev` with the explorer, schema viewer and AI chat.
 - The assets directory in ~/.grafbase is now cleaned up every time a new assets version is unpacked.
 
 ## Fixes

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.94.0",
+  "version": "0.94.1",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.94.0",
+  "version": "0.94.1",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.94.0",
+  "version": "0.94.1",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.94.0",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.94.0",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.94.0",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.94.0",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.94.0"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.94.1",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.94.1",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.94.1",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.94.1",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.94.1"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.94.0",
+  "version": "0.94.1",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.94.0",
+  "version": "0.94.1",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.94.0",
+  "version": "0.94.1",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.37.2"
+version = "0.94.1"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true


### PR DESCRIPTION
## Improvements

- New version of the web app served by `grafbase dev` with the explorer, schema viewer and AI chat.
- The assets directory in ~/.grafbase is now cleaned up every time a new assets version is unpacked.

## Fixes

- `grafbase list-plugins` would list plugins that were installed in multiple directories in `$PATH` multiple times. That list is now dedpuplicated. (https://github.com/grafbase/grafbase/pull/3140)