### PR TITLE
cli: rename list-plugins subcommand to plugins

### DIFF
--- a/cli/changelog/unreleased.md
+++ b/cli/changelog/unreleased.md
@@ -1,0 +1,3 @@
+## Breaking changes
+
+- The `list-plugins` subcommand is renamed to `plugins` to better fit the conventions of the other subcommands (https://github.com/grafbase/grafbase/pull/3154).

--- a/cli/src/cli_input.rs
+++ b/cli/src/cli_input.rs
@@ -57,7 +57,7 @@ const HELP_TEMPLATE: &str = color_print::cstr!(
 
 <bold><underline>Commands:</underline></bold>
 {subcommands}
-{tab}<bold>...</bold>               Run `grafbase list-plugins` for a list of available plugins.
+{tab}<bold>...</bold>               Run `grafbase plugins` for a list of available plugins.
 
 <bold><underline>Options:</underline></bold>
 {options}

--- a/cli/src/cli_input/sub_command.rs
+++ b/cli/src/cli_input/sub_command.rs
@@ -17,7 +17,7 @@ pub(crate) enum SubCommand {
     /// appropriate location for your shell
     Completions(CompletionsCommand),
     /// List all plugin subcommands. To list first-party subcommands, run `grafbase help`.
-    ListPlugins,
+    Plugins,
     /// Logs into your Grafbase account
     Login(LoginCommand),
     /// Logs out of your Grafbase account

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -136,7 +136,7 @@ fn try_main(args: Args) -> Result<(), CliError> {
             upgrade::install_grafbase().map_err(Into::into)
         }
         SubCommand::Lint(cmd) => lint::lint(cmd.schema),
-        SubCommand::ListPlugins => Ok(plugins::list()?),
+        SubCommand::Plugins => Ok(plugins::list()?),
         SubCommand::Branch(cmd) => match cmd.command {
             BranchSubCommand::Delete(cmd) => branch::delete(cmd.branch_ref),
             BranchSubCommand::Create(cmd) => branch::create(cmd.branch_ref),

--- a/cli/src/plugins.rs
+++ b/cli/src/plugins.rs
@@ -22,7 +22,7 @@ pub(crate) fn execute(args: &[String]) -> anyhow::Result<()> {
     match which::which(&binary_name) {
         Err(err) => {
             anyhow::bail!(
-                "The binary '{binary_name}' is not installed ({err})\nRun `grafbase help` to list built-in commands or `grafbase list-plugins` to list available plugin commands."
+                "The binary '{binary_name}' is not installed ({err})\nRun `grafbase help` to list built-in commands or `grafbase plugins` to list available plugin commands."
             )
         }
         #[cfg(unix)]
@@ -71,7 +71,7 @@ pub(crate) fn list() -> anyhow::Result<()> {
 
 fn print_plugin_list(plugins: &mut Vec<String>) {
     if plugins.is_empty() {
-        eprintln!("Found no plugin");
+        eprintln!("No plugins found.");
         return;
     }
 


### PR DESCRIPTION
Fits better with the conventions in the rest of the CLI.