### PR TITLE
Add arm64 for rust-pr docker-gateway build

### DIFF
--- a/.github/workflows/rust-prs.yml
+++ b/.github/workflows/rust-prs.yml
@@ -466,6 +466,7 @@ jobs:
           project: ${{ env.DEPOT_PROJECT }}
           token: ${{ secrets.DEPOT_TOKEN }}
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/grafbase/gateway:${{ env.COMMIT_SHA }}
           file: ./gateway/Dockerfile
 


### PR DESCRIPTION
Couldn't share an image otherwise.