### PR TITLE
Release graphql-composition and grafbase-sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4035,7 +4035,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "anyhow",
  "async-tungstenite",
@@ -4306,7 +4306,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-composition"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bitflags 2.9.0",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "graphql-federated-graph"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "bitflags 2.9.0",
  "cynic-parser",

--- a/cli/tests/extension/authorization.rs
+++ b/cli/tests/extension/authorization.rs
@@ -44,13 +44,13 @@ fn init() {
     codegen-units = 1
 
     [dependencies]
-    grafbase-sdk = "0.15.5"
+    grafbase-sdk = "0.15.6"
     serde = { version = "1", features = ["derive"] }
 
     [dev-dependencies]
     indoc = "2"
     insta = { version = "1", features = ["json"] }
-    grafbase-sdk = { version = "0.15.5", features = ["test-utils"] }
+    grafbase-sdk = { version = "0.15.6", features = ["test-utils"] }
     tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
     serde_json = "1"
     "#);

--- a/cli/tests/extension/mod.rs
+++ b/cli/tests/extension/mod.rs
@@ -50,13 +50,13 @@ fn init_resolver() {
     codegen-units = 1
 
     [dependencies]
-    grafbase-sdk = "0.15.5"
+    grafbase-sdk = "0.15.6"
     serde = { version = "1", features = ["derive"] }
 
     [dev-dependencies]
     indoc = "2"
     insta = { version = "1", features = ["json"] }
-    grafbase-sdk = { version = "0.15.5", features = ["test-utils"] }
+    grafbase-sdk = { version = "0.15.6", features = ["test-utils"] }
     tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
     serde_json = "1"
     "#);
@@ -310,13 +310,13 @@ fn init_auth() {
     codegen-units = 1
 
     [dependencies]
-    grafbase-sdk = "0.15.5"
+    grafbase-sdk = "0.15.6"
     serde = { version = "1", features = ["derive"] }
 
     [dev-dependencies]
     indoc = "2"
     insta = { version = "1", features = ["json"] }
-    grafbase-sdk = { version = "0.15.5", features = ["test-utils"] }
+    grafbase-sdk = { version = "0.15.6", features = ["test-utils"] }
     tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
     serde_json = "1"
     "#);

--- a/cli/tests/integration/data/Cargo.lock
+++ b/cli/tests/integration/data/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.15.5"
+version = "0.15.6"
 dependencies = [
  "chrono",
  "document-features",

--- a/crates/grafbase-sdk/Cargo.toml
+++ b/crates/grafbase-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-sdk"
-version = "0.15.5"
+version = "0.15.6"
 description = "An SDK to implement extensions for the Grafbase Gateway"
 edition = "2024"
 license.workspace = true
@@ -68,10 +68,10 @@ duct = { workspace = true, optional = true }
 fslock = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }
 grafbase-sdk-mock = { version = "0.1.2", path = "mock", optional = true }
-graphql-composition = { version = "0.7.3", features = [
+graphql-composition = { version = "0.8.0", features = [
     "grafbase-extensions",
 ], optional = true, path = "../graphql-composition" }
-graphql-federated-graph = { version = "0.7.2", optional = true, path = "../graphql-federated-graph" }
+graphql-federated-graph = { version = "0.8.0", optional = true, path = "../graphql-federated-graph" }
 graphql-ws-client = { workspace = true, optional = true }
 hashbrown = { workspace = true, optional = true }
 indoc = { workspace = true, optional = true }

--- a/crates/grafbase-sdk/changelog/0.15.6.md
+++ b/crates/grafbase-sdk/changelog/0.15.6.md
@@ -1,0 +1,3 @@
+## Fixes
+
+- Upgraded graphql-composition (used in the test harness) to 0.8.0

--- a/crates/graphql-composition/CHANGELOG.md
+++ b/crates/graphql-composition/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## Unreleased
+## 0.8.0 - 2025-05-16
+
+### Breaking changes
+
+- The import url for the composite schemas spec changed from "https://specs.grafbase.com/composite-schema/v1" to "https://specs.grafbase.com/composite-schemas/v1"
 
 ## 0.7.3 - 2025-04-30
 

--- a/crates/graphql-composition/Cargo.toml
+++ b/crates/graphql-composition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graphql-composition"
-version = "0.7.3"
+version = "0.8.0"
 edition = "2024"
 license = "MPL-2.0"
 description = "An implementation of GraphQL federated schema composition"
@@ -19,7 +19,7 @@ bitflags.workspace = true
 cynic-parser = { workspace = true, features = ["report"] }
 cynic-parser-deser.workspace = true
 fixedbitset.workspace = true
-graphql-federated-graph = { path = "../graphql-federated-graph", version = "0.7.2" }
+graphql-federated-graph = { path = "../graphql-federated-graph", version = "0.8.0" }
 indexmap.workspace = true
 itertools.workspace = true
 url.workspace = true

--- a/crates/graphql-federated-graph/Cargo.toml
+++ b/crates/graphql-federated-graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graphql-federated-graph"
-version = "0.7.2"
+version = "0.8.0"
 edition = "2024"
 license = "MPL-2.0"
 description = "A serializable federated GraphQL graph representation"


### PR DESCRIPTION
https://github.com/grafbase/extensions/pull/90 needs to happen to comply with current composition logic, but the crate isn't published, so the SDK test harness hasn't picked up the change yet.