### PR TITLE
mcp: upgrade rmcp and add tool annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5490,7 +5490,7 @@ dependencies = [
  "serde_with",
  "sha2 0.10.8",
  "similar-asserts",
- "sse-stream",
+ "sse-stream 0.1.3",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
@@ -8200,36 +8200,41 @@ dependencies = [
 [[package]]
 name = "rmcp"
 version = "0.1.5"
-source = "git+https://github.com/grafbase/rust-sdk?branch=reduce-logging#6874317649aa104991cb600143af3e5ec44c234a"
+source = "git+https://github.com/modelcontextprotocol/rust-sdk#a66f66ae345a0fafde1e2ee496ec137d77aef82a"
 dependencies = [
  "axum 0.8.3",
- "base64 0.21.7",
+ "base64 0.22.1",
+ "bytes",
  "chrono",
  "futures",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
  "paste",
  "pin-project-lite",
  "rand 0.9.1",
- "reqwest 0.12.15",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
- "sse-stream",
+ "sse-stream 0.2.0",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower-service",
  "tracing",
- "url",
+ "uuid",
 ]
 
 [[package]]
 name = "rmcp-macros"
 version = "0.1.5"
-source = "git+https://github.com/grafbase/rust-sdk?branch=reduce-logging#6874317649aa104991cb600143af3e5ec44c234a"
+source = "git+https://github.com/modelcontextprotocol/rust-sdk#a66f66ae345a0fafde1e2ee496ec137d77aef82a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "serde_json",
  "syn 2.0.100",
 ]
 
@@ -8631,6 +8636,7 @@ version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "schemars_derive",
  "serde",
@@ -9527,6 +9533,19 @@ name = "sse-stream"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "150ffbc62464270222a175e9d9ffae6ba2f5c5534da0fcd2d953f4b71dda9e08"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f649a9f9e91db2ed32f3724516eac2bc09fab77fc33be8f670f5619b9dc6c3f"
 dependencies = [
  "bytes",
  "futures-util",

--- a/crates/grafbase-workspace-hack/Cargo.toml
+++ b/crates/grafbase-workspace-hack/Cargo.toml
@@ -31,7 +31,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 bumpalo = { version = "3", features = ["allocator-api2"] }
 byteorder = { version = "1" }
 bytes = { version = "1", features = ["serde"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "wasmbind"] }
 ciborium = { version = "0.2" }
 clap = { version = "4", features = ["cargo", "derive", "env", "wrap_help"] }
 clap_builder = { version = "4", default-features = false, features = ["cargo", "color", "env", "std", "suggestions", "usage", "wrap_help"] }
@@ -163,7 +163,7 @@ bumpalo = { version = "3", features = ["allocator-api2"] }
 byteorder = { version = "1" }
 bytes = { version = "1", features = ["serde"] }
 cc = { version = "1", default-features = false, features = ["parallel"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "wasmbind"] }
 ciborium = { version = "0.2" }
 clap = { version = "4", features = ["cargo", "derive", "env", "wrap_help"] }
 clap_builder = { version = "4", default-features = false, features = ["cargo", "color", "env", "std", "suggestions", "usage", "wrap_help"] }
@@ -285,6 +285,7 @@ zstd-sys = { version = "2", default-features = false, features = ["experimental"
 
 [target.aarch64-apple-darwin.dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
+chrono = { version = "0.4" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
@@ -300,6 +301,7 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 
 [target.aarch64-apple-darwin.build-dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
+chrono = { version = "0.4" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
@@ -315,6 +317,7 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 
 [target.x86_64-apple-darwin.dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
+chrono = { version = "0.4" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
@@ -331,6 +334,7 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 
 [target.x86_64-apple-darwin.build-dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
+chrono = { version = "0.4" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
@@ -346,6 +350,7 @@ spin = { version = "0.9" }
 tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features = false, features = ["timeout"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
+chrono = { version = "0.4" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
 idna = { version = "1" }
@@ -358,6 +363,7 @@ windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52", feat
 windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Diagnostics_Debug", "Win32_System_Registry", "Win32_System_Time", "Win32_UI_Shell"] }
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
+chrono = { version = "0.4" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
 idna = { version = "1" }
@@ -371,6 +377,7 @@ windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", feat
 
 [target.x86_64-unknown-linux-musl.dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
+chrono = { version = "0.4" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
@@ -389,6 +396,7 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 
 [target.x86_64-unknown-linux-musl.build-dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
+chrono = { version = "0.4" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
@@ -407,6 +415,7 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 
 [target.aarch64-unknown-linux-musl.dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
+chrono = { version = "0.4" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }
@@ -424,6 +433,7 @@ tower-d8f496e17d97b5cb = { package = "tower", version = "0.5", default-features 
 
 [target.aarch64-unknown-linux-musl.build-dependencies]
 addr2line = { version = "0.24", default-features = false, features = ["std"] }
+chrono = { version = "0.4" }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12", "webpki-tokio"] }

--- a/crates/integration-tests/tests/gateway/mcp/basic.rs
+++ b/crates/integration-tests/tests/gateway/mcp/basic.rs
@@ -100,7 +100,9 @@ fn list_tools() {
                 }
               }
             },
-            "annotations": null
+            "annotations": {
+              "readOnlyHint": true
+            }
           },
           {
             "name": "search",
@@ -121,7 +123,9 @@ fn list_tools() {
                 }
               }
             },
-            "annotations": null
+            "annotations": {
+              "readOnlyHint": true
+            }
           },
           {
             "name": "execute",
@@ -144,7 +148,10 @@ fn list_tools() {
                 }
               }
             },
-            "annotations": null
+            "annotations": {
+              "destructiveHint": true,
+              "openWorldHint": true
+            }
           }
         ]
       }

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -26,9 +26,9 @@ itertools.workspace = true
 minicbor-serde.workspace = true
 ordered-float.workspace = true
 priority-queue.workspace = true
-rmcp = { git = "https://github.com/grafbase/rust-sdk", branch = "reduce-logging", features = [
-    "transport-sse",
+rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", features = [
     "transport-sse-server",
+    "transport-streamable-http-server",
 ] }
 schemars.workspace = true
 serde.workspace = true

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(unused_crate_dependencies)]
-use convert_case as _;
 use grafbase_workspace_hack as _;
 
 mod server;

--- a/crates/mcp/src/tools/execute.rs
+++ b/crates/mcp/src/tools/execute.rs
@@ -93,6 +93,10 @@ impl<R: engine::Runtime> Tool for ExecuteTool<R> {
             is_error: None,
         })
     }
+
+    fn annotations(&self) -> rmcp::model::ToolAnnotations {
+        rmcp::model::ToolAnnotations::new().destructive(true).open_world(true)
+    }
 }
 
 struct EngineResponse {

--- a/crates/mcp/src/tools/introspect.rs
+++ b/crates/mcp/src/tools/introspect.rs
@@ -25,6 +25,10 @@ impl<R: engine::Runtime> Tool for IntrospectTool<R> {
     async fn call(&self, parameters: Self::Parameters) -> anyhow::Result<CallToolResult> {
         Ok(self.introspect(parameters.types).into())
     }
+
+    fn annotations(&self) -> rmcp::model::ToolAnnotations {
+        rmcp::model::ToolAnnotations::new().read_only(true)
+    }
 }
 
 #[derive(Deserialize, JsonSchema)]

--- a/crates/mcp/src/tools/search/mod.rs
+++ b/crates/mcp/src/tools/search/mod.rs
@@ -50,6 +50,10 @@ impl<R: engine::Runtime> Tool for SearchTool<R> {
         }
         .into())
     }
+
+    fn annotations(&self) -> rmcp::model::ToolAnnotations {
+        rmcp::model::ToolAnnotations::new().read_only(true)
+    }
 }
 
 #[derive(Deserialize, JsonSchema)]


### PR DESCRIPTION
[Tool annotations](https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations) are a new feature of the model context protocol added in [march](https://modelcontextprotocol.io/specification/2025-03-26/changelog).

I tested, and this does make our mcp server work in cursor again.

closes GB-9025