### PR TITLE
gateway: replace GDN with new object storage (#3181)

### DIFF
--- a/cli/tests/integration/data/Cargo.lock
+++ b/cli/tests/integration/data/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.15.7"
+version = "0.16.1"
 dependencies = [
  "chrono",
  "document-features",

--- a/crates/engine/src/prepare/trusted_documents.rs
+++ b/crates/engine/src/prepare/trusted_documents.rs
@@ -342,7 +342,7 @@ async fn handle_apq<'r, 'f>(
     ))
 }
 
-/// When a request contains a trusted document id, but the trusted document is not found in GDN. Default: INFO.
+/// When a request contains a trusted document id, but the trusted document is not found in object storage. Default: INFO.
 fn log_unknown_trusted_document_id<R: Runtime>(engine: &Engine<R>, document_id: &str) {
     const MESSAGE: &str = "Unknown trusted document";
 

--- a/crates/federated-server/src/lib.rs
+++ b/crates/federated-server/src/lib.rs
@@ -4,8 +4,8 @@
 
 mod hot_reload;
 pub use error::Error;
-pub use server::GdnResponse;
 pub use server::GraphFetchMethod;
+pub use server::ObjectStorageResponse;
 
 mod error;
 mod server;

--- a/crates/federated-server/src/server.rs
+++ b/crates/federated-server/src/server.rs
@@ -381,7 +381,7 @@ async fn graceful_shutdown(handle: axum_server::Handle) {
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 #[allow(dead_code)]
 /// Response from the API containing graph information
-pub struct GdnResponse {
+pub struct ObjectStorageResponse {
     /// Account id of the owner of the referenced graph
     pub account_id: Ulid,
     /// The id of the graph

--- a/crates/federated-server/src/server/gateway.rs
+++ b/crates/federated-server/src/server/gateway.rs
@@ -4,7 +4,7 @@ mod gateway_runtime;
 pub use self::{create_extension_catalog::Error as CreateExtensionCatalogError, gateway_runtime::GatewayRuntime};
 
 use self::create_extension_catalog::create_extension_catalog;
-use super::GdnResponse;
+use super::ObjectStorageResponse;
 use engine::Engine;
 use gateway_config::Config;
 use runtime::trusted_documents_client::{Client, TrustedDocumentsEnforcementMode};
@@ -23,8 +23,8 @@ pub(crate) type EngineWatcher<R> = watch::Receiver<Arc<Engine<R>>>;
 
 #[derive(Clone)]
 pub(crate) enum GraphDefinition {
-    /// Response from GDN.
-    Gdn(GdnResponse),
+    /// Response from object storage.
+    ObjectStorage(ObjectStorageResponse),
     /// Response from static file.
     Sdl(Option<PathBuf>, String),
 }
@@ -37,12 +37,12 @@ struct Graph {
 
 /// Generates a new gateway from the provided graph definition.
 ///
-/// This function takes a `GraphDefinition`, which can be either a response from GDN or a static SDL string,
+/// This function takes a `GraphDefinition`, which can be either a response from object storage or a static SDL string,
 /// and constructs an `Engine<GatewayRuntime>` based on the provided gateway configuration and optional hot reload settings.
 ///
 /// # Arguments
 ///
-/// - `graph_definition`: The definition of the graph, either from GDN or a static SDL string.
+/// - `graph_definition`: The definition of the graph, either from object storage or a static SDL string.
 /// - `gateway_config`: The configuration settings for the gateway.
 /// - `hot_reload_config_path`: An optional path for hot reload configuration.
 /// - `hooks`: The hooks to be used in the gateway.
@@ -61,7 +61,9 @@ pub(super) async fn generate(
             trusted_documents,
         },
     ) = match graph_definition {
-        GraphDefinition::Gdn(gdn_response) => (None, gdn_graph(gateway_config, gdn_response)),
+        GraphDefinition::ObjectStorage(object_storage_response) => {
+            (None, graph_from_object_storage(gateway_config, object_storage_response))
+        }
         GraphDefinition::Sdl(current_dir, federated_sdl) => (current_dir, sdl_graph(federated_sdl)),
     };
 
@@ -105,14 +107,14 @@ fn sdl_graph(federated_sdl: String) -> Graph {
     }
 }
 
-fn gdn_graph(
+fn graph_from_object_storage(
     gateway_config: &Config,
-    GdnResponse {
+    ObjectStorageResponse {
         branch_id,
         sdl,
         version_id,
         ..
-    }: GdnResponse,
+    }: ObjectStorageResponse,
 ) -> Graph {
     let trusted_documents = if gateway_config.trusted_documents.enabled {
         let enforcement_mode = if gateway_config.trusted_documents.enforced {

--- a/crates/federated-server/src/server/graph_fetch_method.rs
+++ b/crates/federated-server/src/server/graph_fetch_method.rs
@@ -34,7 +34,7 @@ impl GraphFetchMethod {
     ///
     /// This can happen in two ways: if providing a graph SDL, we return a new graph immediately.
     /// Alternatively, if a graph ref and access token is provided, the function returns
-    /// immediately, and runs a background process to fetch the graph definition from the GDN
+    /// immediately, and runs a background process to fetch the graph definition from object storage
     pub(crate) async fn into_stream(self) -> crate::Result<GraphStream> {
         #[cfg(feature = "lambda")]
         if matches!(self, GraphFetchMethod::FromGraphRef { .. }) {
@@ -51,9 +51,9 @@ impl GraphFetchMethod {
                 let (sender, receiver) = mpsc::channel(4);
 
                 tokio::spawn(async move {
-                    use super::graph_updater::GdnGraphUpdater;
+                    use super::graph_updater::ObjectStorageUpdater;
 
-                    GdnGraphUpdater::new(graph_ref, access_token, sender)?.poll().await;
+                    ObjectStorageUpdater::new(graph_ref, access_token, sender)?.poll().await;
 
                     Ok::<_, crate::Error>(())
                 });

--- a/crates/federated-server/src/server/graph_updater.rs
+++ b/crates/federated-server/src/server/graph_updater.rs
@@ -1,5 +1,5 @@
-mod gdn;
+mod object_storage;
 mod schema_file;
 
-pub(super) use gdn::GdnGraphUpdater;
+pub(super) use object_storage::ObjectStorageUpdater;
 pub(super) use schema_file::SchemaFileGraphUpdater;

--- a/crates/federated-server/src/server/graph_updater/object_storage.rs
+++ b/crates/federated-server/src/server/graph_updater/object_storage.rs
@@ -1,5 +1,5 @@
 use crate::{
-    GdnResponse,
+    ObjectStorageResponse,
     server::{engine_reloader::GraphSender, gateway::GraphDefinition},
 };
 
@@ -21,8 +21,8 @@ use url::Url;
 /// How often we poll updates to the graph.
 const TICK_INTERVAL: Duration = Duration::from_secs(10);
 
-/// How long we wait for a response from the schema registry.
-const GDN_TIMEOUT: Duration = Duration::from_secs(10);
+/// How long we wait for a response from object storage.
+const OBJECT_STORAGE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// How long we wait until a connection is successfully opened.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -39,8 +39,11 @@ const KEEPALIVE_WHILE_IDLE: bool = true;
 /// The HTTP user-agent header we sent to the schema registry.
 const USER_AGENT: &str = "grafbase-cli";
 
-/// The CDN host we load the graphs from.
-const GDN_HOST: &str = "https://gdn.grafbase.com";
+/// The default CDN host we load the graphs from.
+const DEFAULT_OBJECT_STORAGE_HOST: &str = "https://object-storage.grafbase.com";
+
+/// The name of the environment variable used to read the object storage host from.
+const OBJECT_STORAGE_HOST_ENV_VAR: &str = "GRAFBASE_OBJECT_STORAGE_URL";
 
 #[derive(Debug, Clone, Copy)]
 enum ResponseKind {
@@ -51,7 +54,7 @@ enum ResponseKind {
     /// Indicates that an HTTP error occurred while fetching the graph.
     HttpError,
     /// Indicates that a Grafbase-specific error occurred.
-    GdnError,
+    ObjectStorageError,
 }
 
 impl ResponseKind {
@@ -60,12 +63,12 @@ impl ResponseKind {
             ResponseKind::New => "NEW",
             ResponseKind::Unchanged => "UNCHANGED",
             ResponseKind::HttpError => "HTTP_ERROR",
-            ResponseKind::GdnError => "GDN_ERROR",
+            ResponseKind::ObjectStorageError => "OBJECT_STORAGE_ERROR",
         }
     }
 }
 
-struct GdnFetchLatencyAttributes {
+struct ObjectStorageFetchLatencyAttributes {
     /// The kind of response received from the server.
     kind: ResponseKind,
     /// The HTTP status code of the response, if applicable.
@@ -73,23 +76,23 @@ struct GdnFetchLatencyAttributes {
 }
 
 /// A struct representing a GraphUpdater, which is responsible for polling updates
-/// from the Graph Delivery Network and managing the associated state.
-pub struct GdnGraphUpdater {
-    gdn_url: Url,
-    gdn_client: reqwest::Client,
+/// from object storage and managing the associated state.
+pub struct ObjectStorageUpdater {
+    object_storage_url: Url,
+    object_storage_client: reqwest::Client,
     access_token: AsciiString,
     sender: GraphSender,
     current_id: Option<Ulid>,
     latencies: Histogram<u64>,
 }
 
-impl GdnGraphUpdater {
+impl ObjectStorageUpdater {
     /// Creates a new instance of `GraphUpdater`.
     ///
     /// # Arguments
     ///
     /// * `graph_ref` - A reference to the graph to be updated.
-    /// * `access_token` - The access token for authentication with the GDN.
+    /// * `access_token` - The access token for authentication with the object storage service.
     /// * `sender` - The sender used to send a new instance of the gateway to the server.
     /// * `gateway_config` - Configuration settings for the gateway.
     /// * `hooks` - Hooks for custom behavior during operation execution.
@@ -98,8 +101,8 @@ impl GdnGraphUpdater {
     ///
     /// Returns an error if the HTTP client cannot be built or if the URL parsing fails.
     pub fn new(graph_ref: GraphRef, access_token: AsciiString, sender: GraphSender) -> crate::Result<Self> {
-        let gdn_client = reqwest::ClientBuilder::new()
-            .timeout(GDN_TIMEOUT)
+        let object_storage_client = reqwest::ClientBuilder::new()
+            .timeout(OBJECT_STORAGE_TIMEOUT)
             .connect_timeout(CONNECT_TIMEOUT)
             .http2_keep_alive_interval(Some(KEEPALIVE_INTERVAL))
             .http2_keep_alive_timeout(KEEPALIVE_TIMEOUT)
@@ -108,36 +111,38 @@ impl GdnGraphUpdater {
             .build()
             .map_err(|e| crate::Error::InternalError(e.to_string()))?;
 
-        let gdn_host = match std::env::var("GRAFBASE_GDN_URL") {
+        let object_storage_host = match std::env::var(OBJECT_STORAGE_HOST_ENV_VAR) {
             Ok(host) => Cow::Owned(host),
-            Err(_) => Cow::Borrowed(GDN_HOST),
+            Err(_) => Cow::Borrowed(DEFAULT_OBJECT_STORAGE_HOST),
         };
 
-        let gdn_url = match graph_ref {
-            GraphRef::LatestProductionVersion { graph_slug } => format!("{gdn_host}/graphs/{graph_slug}/current"),
+        let object_storage_url = match graph_ref {
+            GraphRef::LatestProductionVersion { graph_slug } => {
+                format!("{object_storage_host}/graphs/{graph_slug}")
+            }
             GraphRef::LatestVersion {
                 graph_slug,
                 branch_name,
-            } => format!("{gdn_host}/graphs/{graph_slug}/{branch_name}/current"),
+            } => format!("{object_storage_host}/graphs/{graph_slug}/branch/{branch_name}"),
             GraphRef::Id {
                 graph_slug,
                 branch_name,
                 version,
-            } => format!("{gdn_host}/graphs/{graph_slug}/{branch_name}/{version}"),
+            } => format!("{object_storage_host}/graphs/{graph_slug}/branch/{branch_name}/version/{version}"),
         };
 
-        let gdn_url = gdn_url
+        let object_storage_url = object_storage_url
             .parse::<Url>()
             .map_err(|e| crate::Error::InternalError(e.to_string()))?;
 
         Ok(Self {
-            gdn_url,
-            gdn_client,
+            object_storage_url,
+            object_storage_client,
             access_token,
             sender,
             current_id: None,
             latencies: meter_from_global_provider()
-                .u64_histogram("gdn.request.duration")
+                .u64_histogram("object_storage.request.duration")
                 .build(),
         })
     }
@@ -152,7 +157,7 @@ impl GdnGraphUpdater {
     pub async fn poll(&mut self) {
         let mut interval = tokio::time::interval(TICK_INTERVAL);
 
-        // if we have a slow connection, this prevents bursts of connections to the GDN
+        // if we have a slow connection, this prevents bursts of connections to object storage
         // for all the missed ticks.
         interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
@@ -160,8 +165,8 @@ impl GdnGraphUpdater {
             interval.tick().await;
 
             let mut request = self
-                .gdn_client
-                .get(self.gdn_url.as_str())
+                .object_storage_client
+                .get(self.object_storage_url.as_str())
                 .bearer_auth(&self.access_token);
 
             if let Some(id) = self.current_id {
@@ -179,7 +184,7 @@ impl GdnGraphUpdater {
                 Ok(response) => response,
                 Err(e) => {
                     self.record_duration(
-                        GdnFetchLatencyAttributes {
+                        ObjectStorageFetchLatencyAttributes {
                             kind: ResponseKind::HttpError,
                             status_code: None,
                         },
@@ -193,7 +198,7 @@ impl GdnGraphUpdater {
 
             if response.status() == StatusCode::NOT_MODIFIED {
                 self.record_duration(
-                    GdnFetchLatencyAttributes {
+                    ObjectStorageFetchLatencyAttributes {
                         kind: ResponseKind::Unchanged,
                         status_code: Some(response.status()),
                     },
@@ -206,8 +211,8 @@ impl GdnGraphUpdater {
 
             if let Err(e) = response.error_for_status_ref() {
                 self.record_duration(
-                    GdnFetchLatencyAttributes {
-                        kind: ResponseKind::GdnError,
+                    ObjectStorageFetchLatencyAttributes {
+                        kind: ResponseKind::ObjectStorageError,
                         status_code: e.status(),
                     },
                     duration,
@@ -226,12 +231,12 @@ impl GdnGraphUpdater {
                 continue;
             }
 
-            let response: GdnResponse = match response.json().await {
+            let response: ObjectStorageResponse = match response.json().await {
                 Ok(response) => response,
                 Err(e) => {
                     self.record_duration(
-                        GdnFetchLatencyAttributes {
-                            kind: ResponseKind::GdnError,
+                        ObjectStorageFetchLatencyAttributes {
+                            kind: ResponseKind::ObjectStorageError,
                             status_code: e.status(),
                         },
                         duration,
@@ -247,7 +252,7 @@ impl GdnGraphUpdater {
             let version_id = response.version_id;
 
             self.record_duration(
-                GdnFetchLatencyAttributes {
+                ObjectStorageFetchLatencyAttributes {
                     kind: ResponseKind::New,
                     status_code: None,
                 },
@@ -257,7 +262,7 @@ impl GdnGraphUpdater {
             self.current_id = Some(version_id);
 
             self.sender
-                .send(GraphDefinition::Gdn(response))
+                .send(GraphDefinition::ObjectStorage(response))
                 .await
                 .expect("internal error: channel closed");
         }
@@ -265,12 +270,12 @@ impl GdnGraphUpdater {
 
     fn record_duration(
         &self,
-        GdnFetchLatencyAttributes { kind, status_code }: GdnFetchLatencyAttributes,
+        ObjectStorageFetchLatencyAttributes { kind, status_code }: ObjectStorageFetchLatencyAttributes,
         duration: Duration,
     ) {
         let mut attributes = vec![
-            KeyValue::new("server.address", self.gdn_url.to_string()),
-            KeyValue::new("gdn.response.kind", kind.as_str()),
+            KeyValue::new("server.address", self.object_storage_url.to_string()),
+            KeyValue::new("object_storage.response.kind", kind.as_str()),
         ];
 
         if let Some(status_code) = status_code {

--- a/crates/federated-server/src/server/trusted_documents_client.rs
+++ b/crates/federated-server/src/server/trusted_documents_client.rs
@@ -70,7 +70,7 @@ impl runtime::trusted_documents_client::TrustedDocumentsClient for TrustedDocume
         document_id: &str,
     ) -> runtime::trusted_documents_client::TrustedDocumentsResult<String> {
         let branch_id = self.branch_id;
-        let key = format!("trusted-documents/{branch_id}/{client_name}/{document_id}");
+        let key = format!("trusted-documents/branch/{branch_id}/{client_name}/{document_id}");
 
         let mut url = self.assets_host.clone();
         url.set_path(&key);

--- a/crates/gateway-config/src/trusted_documents.rs
+++ b/crates/gateway-config/src/trusted_documents.rs
@@ -12,7 +12,7 @@ pub struct TrustedDocumentsConfig {
     /// See [BypassHeader]
     #[serde(flatten)]
     pub bypass_header: BypassHeader,
-    /// The log level to emit logs when a request contains a trusted document id, but the trusted document is not found in GDN. Default: INFO.
+    /// The log level to emit logs when a request contains a trusted document id, but the trusted document is not found in object storage. Default: INFO.
     pub document_id_unknown_log_level: LogLevel,
     /// The log level to emit logs when a request contains a trusted document id and an inline document in `query`, but the trusted document body does not match the inline document. Default: INFO.
     pub document_id_and_query_mismatch_log_level: LogLevel,

--- a/gateway/changelog/unreleased.md
+++ b/gateway/changelog/unreleased.md
@@ -1,0 +1,5 @@
+## Breaking changes
+
+- The optional service that exposes federated graphs and trusted documents to the gateway, previously called GDN, has a new implementation that uses different paths for the assets. This change is only relevant if:
+  1. You use the self-hosted Enterprise Platform (in which case you should upgrade to 0.7.1 when you upgrade to this version of the gateway)
+  1. You define a different endpoint for it using the `GRAFBASE_GDN_URL` environment variable. In which case, use the `GRAFBASE_OBJECT_STORAGE_URL` environment variable from this version up.

--- a/gateway/tests/integration_tests.rs
+++ b/gateway/tests/integration_tests.rs
@@ -15,7 +15,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use crate::mocks::gdn::GdnResponseMock;
+use crate::mocks::object_storage::ObjectStorageResponseMock;
 use duct::{Handle, cmd};
 use futures_util::future::BoxFuture;
 use futures_util::{Future, FutureExt};
@@ -583,7 +583,7 @@ fn with_static_server<'a, F, T>(
 
 fn with_hybrid_server<F, T>(config: &str, graph_ref: &str, sdl: &str, test: T)
 where
-    T: FnOnce(Arc<Client>, GdnResponseMock, SocketAddr) -> F,
+    T: FnOnce(Arc<Client>, ObjectStorageResponseMock, SocketAddr) -> F,
     F: Future<Output = ()>,
 {
     let temp_dir = tempdir().unwrap();
@@ -593,14 +593,14 @@ where
 
     let addr = listen_address();
 
-    let gdn_response = GdnResponseMock::mock(sdl);
+    let gdn_response = ObjectStorageResponseMock::mock(sdl);
 
     let res = runtime().block_on(async {
         let response = ResponseTemplate::new(200).set_body_string(gdn_response.as_json().to_string());
         let server = wiremock::MockServer::start().await;
 
         Mock::given(method("GET"))
-            .and(path(format!("/graphs/{graph_ref}/current")))
+            .and(path(format!("/graphs/{graph_ref}")))
             .and(header("Authorization", format!("Bearer {ACCESS_TOKEN}")))
             .respond_with(response)
             .mount(&server)
@@ -617,7 +617,7 @@ where
         )
         .stdout_null()
         .stderr_null()
-        .env("GRAFBASE_GDN_URL", format!("http://{}", server.address()))
+        .env("GRAFBASE_OBJECT_STORAGE_URL", format!("http://{}", server.address()))
         .env("GRAFBASE_ACCESS_TOKEN", ACCESS_TOKEN);
 
         let mut commands = CommandHandles::new();

--- a/gateway/tests/mocks/mod.rs
+++ b/gateway/tests/mocks/mod.rs
@@ -1,1 +1,1 @@
-pub(crate) mod gdn;
+pub(crate) mod object_storage;

--- a/gateway/tests/mocks/object_storage.rs
+++ b/gateway/tests/mocks/object_storage.rs
@@ -3,21 +3,21 @@ use std::str::FromStr;
 
 use ulid::Ulid;
 
-use federated_server::GdnResponse;
+use federated_server::ObjectStorageResponse;
 
 #[derive(serde::Serialize, serde::Deserialize)]
-pub(crate) struct GdnResponseMock(GdnResponse);
-impl Deref for GdnResponseMock {
-    type Target = GdnResponse;
+pub(crate) struct ObjectStorageResponseMock(ObjectStorageResponse);
+impl Deref for ObjectStorageResponseMock {
+    type Target = ObjectStorageResponse;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl GdnResponseMock {
-    pub(crate) fn mock(sdl: &str) -> GdnResponseMock {
-        GdnResponseMock(GdnResponse {
+impl ObjectStorageResponseMock {
+    pub(crate) fn mock(sdl: &str) -> ObjectStorageResponseMock {
+        ObjectStorageResponseMock(ObjectStorageResponse {
             account_id: Ulid::from_str("01HR7NP3A4NDVWC10PZW6ZMC5P").unwrap(),
             graph_id: Ulid::from_str("01HR7NPB8E3YW29S5PPSY1AQKR").unwrap(),
             branch: "main".to_string(),

--- a/gateway/tests/telemetry/metrics.rs
+++ b/gateway/tests/telemetry/metrics.rs
@@ -13,7 +13,7 @@ use wiremock::{Mock, ResponseTemplate, matchers::method};
 use crate::{Client, clickhouse_client, load_schema, runtime, with_static_server};
 
 mod access_log;
-mod gdn;
+mod object_storage;
 mod operation;
 mod request;
 

--- a/gateway/tests/telemetry/metrics/object_storage.rs
+++ b/gateway/tests/telemetry/metrics/object_storage.rs
@@ -6,7 +6,7 @@ use crate::{
 use indoc::formatdoc;
 
 #[test]
-fn gdn_update() {
+fn object_storage_update() {
     let service_name = format!("service_{}", ulid::Ulid::new());
     let schema = load_schema("big");
     let clickhouse = clickhouse_client();
@@ -52,7 +52,7 @@ fn gdn_update() {
             FROM otel_metrics_exponential_histogram
             WHERE ServiceName = ?
                 AND ScopeName = 'grafbase'
-                AND MetricName = 'gdn.request.duration'
+                AND MetricName = 'object_storage.request.duration'
         "#};
 
         let row = clickhouse
@@ -64,10 +64,13 @@ fn gdn_update() {
             .unwrap();
 
         assert_eq!(1, row.count);
-        assert_eq!(Some("NEW"), row.attributes.get("gdn.response.kind").map(|s| s.as_str()),);
+        assert_eq!(
+            Some("NEW"),
+            row.attributes.get("object_storage.response.kind").map(|s| s.as_str()),
+        );
 
         assert_eq!(
-            Some(&format!("http://{addr}/graphs/test_graph/current")),
+            Some(&format!("http://{addr}/graphs/test_graph")),
             row.attributes.get("server.address"),
         );
     });


### PR DESCRIPTION
Most of the PR is renaming. The actual changes are:

- metric names (will update the docs)
- the name of the env var for the URL
- the paths of graphs in the service itself

closes GB-9149