### PR TITLE
gateway: release 0.40.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3987,7 +3987,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "ascii",

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.39.0"
+version = "0.40.0"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/changelog/0.40.0.md
+++ b/gateway/changelog/0.40.0.md
@@ -1,0 +1,15 @@
+## Improvements
+
+- The optional MCP endpoint now populates the [`annotations` field in tool descriptions](https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations). This makes it compatible with recent versions of clients like Cursor. (https://github.com/grafbase/grafbase/pull/3190)
+
+## Breaking changes
+
+- The optional service that exposes federated graphs and trusted documents to the gateway, previously called GDN, has a new implementation that uses different paths for the assets. This change is only relevant if:
+  1. You use the self-hosted Enterprise Platform (in which case you should upgrade to 0.7.1 when you upgrade to this version of the gateway)
+  1. You define a different endpoint for it using the `GRAFBASE_GDN_URL` environment variable. In which case, use the `GRAFBASE_OBJECT_STORAGE_URL` environment variable from this version up.
+- The optional MCP server gained a `transport` configuration option. It defaults to `"streaming-http"`. Set it to `"sse"` for the previous behaviour. (https://github.com/grafbase/grafbase/pull/3193)
+
+## Fixes
+
+- Generated subgraph queries would sometimes result in name collisions in subgraphs because the same variables could be named differently.
+- Using the same variable on fields of different types (requiredness) would sometimes cause issues. Fixed in https://github.com/grafbase/grafbase/pull/3199

--- a/gateway/changelog/unreleased.md
+++ b/gateway/changelog/unreleased.md
@@ -1,9 +1,0 @@
-## Fixes
-
-- Generated subgraph queries would sometimes result in name collisions in subgraphs because the same variables could be named differently.
-
-## Breaking changes
-
-- The optional service that exposes federated graphs and trusted documents to the gateway, previously called GDN, has a new implementation that uses different paths for the assets. This change is only relevant if:
-  1. You use the self-hosted Enterprise Platform (in which case you should upgrade to 0.7.1 when you upgrade to this version of the gateway)
-  1. You define a different endpoint for it using the `GRAFBASE_GDN_URL` environment variable. In which case, use the `GRAFBASE_OBJECT_STORAGE_URL` environment variable from this version up.


### PR DESCRIPTION
## Improvements

- The optional MCP endpoint now populates the [`annotations` field in tool descriptions](https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations). This makes it compatible with recent versions of clients like Cursor. (https://github.com/grafbase/grafbase/pull/3190)

## Breaking changes

- The optional service that exposes federated graphs and trusted documents to the gateway, previously called GDN, has a new implementation that uses different paths for the assets. This change is only relevant if:
  1. You use the self-hosted Enterprise Platform (in which case you should upgrade to 0.7.1 when you upgrade to this version of the gateway)
  1. You define a different endpoint for it using the `GRAFBASE_GDN_URL` environment variable. In which case, use the `GRAFBASE_OBJECT_STORAGE_URL` environment variable from this version up.

## Fixes

- Generated subgraph queries would sometimes result in name collisions in subgraphs because the same variables could be named differently.
- Using the same variable on fields of different types (requiredness) would sometimes cause issues. Fixed in https://github.com/grafbase/grafbase/pull/3199
