### PR TITLE
feat(gateway): Better errors for extension configuration failures

### DIFF
--- a/crates/integration-tests/src/gateway/builder/engine.rs
+++ b/crates/integration-tests/src/gateway/builder/engine.rs
@@ -109,7 +109,7 @@ pub(super) async fn build(
                 access_log: access_log_sender,
             },
         )
-        .await;
+        .await?;
 
     println!("=== CONFIG ===\n{:#?}\n", config);
 

--- a/crates/integration-tests/src/gateway/runtime/extension/builder.rs
+++ b/crates/integration-tests/src/gateway/runtime/extension/builder.rs
@@ -167,7 +167,7 @@ impl ExtensionsBuilder {
 
             WasmExtensions::new(shared_resources, &self.catalog, config, schema)
                 .await
-                .unwrap()
+                .map_err(|err| err.to_string())?
         } else {
             // If no real wasm extensions was used, we skip the initialization as it would compile
             // the placeholder extension for nothing and we have a lot of extension tests, most of

--- a/crates/integration-tests/src/gateway/runtime/mod.rs
+++ b/crates/integration-tests/src/gateway/runtime/mod.rs
@@ -46,7 +46,7 @@ impl TestRuntimeBuilder {
         config: &mut Config,
         schema: &Arc<Schema>,
         shared_resources: SharedResources,
-    ) -> TestRuntime {
+    ) -> Result<TestRuntime, String> {
         let TestRuntimeBuilder {
             trusted_documents,
             hooks,
@@ -56,8 +56,7 @@ impl TestRuntimeBuilder {
 
         let (extensions, catalog) = extensions
             .build_and_ingest_catalog_into_config(config, schema, shared_resources.clone())
-            .await
-            .unwrap();
+            .await?;
 
         let hooks = if let Some(hooks_config) = config.hooks.clone() {
             let loader = ComponentLoader::hooks(hooks_config)
@@ -78,7 +77,7 @@ impl TestRuntimeBuilder {
 
         let (_, rx) = watch::channel(Default::default());
 
-        TestRuntime {
+        Ok(TestRuntime {
             fetcher: fetcher.unwrap_or_else(|| {
                 DynamicFetcher::wrap(NativeFetcher::new(config).expect("couldnt construct NativeFetcher"))
             }),
@@ -91,7 +90,7 @@ impl TestRuntimeBuilder {
             operation_cache: InMemoryOperationCache::default(),
             extensions,
             authentication,
-        }
+        })
     }
 }
 

--- a/crates/integration-tests/tests/gateway/extensions/selection_set_resolver/config.rs
+++ b/crates/integration-tests/tests/gateway/extensions/selection_set_resolver/config.rs
@@ -49,7 +49,7 @@ fn can_read_config() {
 #[test]
 fn can_fail_reading_config_with_nullable_field() {
     runtime().block_on(async move {
-        let engine = Gateway::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "echo-config",
                 r#"
@@ -67,29 +67,17 @@ fn can_fail_reading_config_with_nullable_field() {
                 error = "This is an error"
                 "#,
             )
-            .build()
+            .try_build()
             .await;
 
-        let response = engine.post(r#"query { test }"#).await;
-        insta::assert_json_snapshot!(response, @r#"
-        {
-          "errors": [
-            {
-              "message": "Internal extension error",
-              "extensions": {
-                "code": "EXTENSION_ERROR"
-              }
-            }
-          ]
-        }
-        "#);
+        insta::assert_snapshot!(result.unwrap_err(), @r#"Error { extensions: [], message: "This is an error" }"#);
     });
 }
 
 #[test]
 fn can_fail_reading_config_with_required_field() {
     runtime().block_on(async move {
-        let engine = Gateway::builder()
+        let result = Gateway::builder()
             .with_subgraph_sdl(
                 "echo-config",
                 r#"
@@ -107,21 +95,9 @@ fn can_fail_reading_config_with_required_field() {
                 error = "This is an error"
                 "#,
             )
-            .build()
+            .try_build()
             .await;
 
-        let response = engine.post(r#"query { test }"#).await;
-        insta::assert_json_snapshot!(response, @r#"
-        {
-          "errors": [
-            {
-              "message": "Internal extension error",
-              "extensions": {
-                "code": "EXTENSION_ERROR"
-              }
-            }
-          ]
-        }
-        "#);
+        insta::assert_snapshot!(result.unwrap_err(), @r#"Error { extensions: [], message: "This is an error" }"#);
     });
 }

--- a/crates/wasi-component-loader/src/extension/manager/pool.rs
+++ b/crates/wasi-component-loader/src/extension/manager/pool.rs
@@ -42,12 +42,10 @@ impl Pool {
 
     pub(super) async fn get(&self) -> crate::Result<ExtensionGuard> {
         let span = info_span!("get extension from pool");
-        let inner = self
-            .inner
-            .get()
-            .instrument(span)
-            .await
-            .map_err(|err| crate::Error::Internal(err.into()))?;
+        let inner = self.inner.get().instrument(span).await.map_err(|err| match err {
+            managed::PoolError::Backend(err) => err,
+            err => crate::Error::Internal(err.into()),
+        })?;
 
         Ok(ExtensionGuard { inner })
     }


### PR DESCRIPTION
- SDK error is clearer if configuration is null
- We immediately try to load one extension when creating the pool and
  made the error a bit clearer.
