### PR TITLE
fix (examples): Fix rest example by updating the API URL

### DIFF
--- a/examples/rest-extension/schema.graphql
+++ b/examples/rest-extension/schema.graphql
@@ -8,5 +8,5 @@ type Country {
 
 type Query {
   countries: [Country!]!
-    @rest(method: GET, endpoint: "countries", path: "/all", selection: "[.[] | { name: .name.official }]")
+    @rest(method: GET, endpoint: "countries", path: "/all?fields=name", selection: "[.[] | { name: .name.official }]")
 }


### PR DESCRIPTION
The API has recently been updated to only allow requests that specifies the fields needed.
So our example is returning 400 errors when testing currently.

https://gitlab.com/restcountries/restcountries/-/issues/265