### PR TITLE
mcp: align JSON schema and implementation for variables

### DIFF
--- a/crates/mcp/src/tools/execute.rs
+++ b/crates/mcp/src/tools/execute.rs
@@ -19,6 +19,8 @@ pub struct ExecuteTool<R: engine::Runtime> {
 #[derive(serde::Deserialize, serde::Serialize)]
 pub struct Request {
     pub query: String,
+    // Note: accept empty variables, in case the LLM fails to send variables, although they are required.
+    #[serde(default)]
     pub variables: RawVariables,
 }
 
@@ -46,11 +48,12 @@ impl schemars::JsonSchema for Request {
                 );
             }
             {
+                // Note: variables must be required. Cursor 1.0 does not deal well with them being optional, but it can happily send an empty object.
                 schemars::_private::insert_object_property::<serde_json::Map<String, serde_json::Value>>(
                     object_validation,
                     "variables",
                     false,
-                    false,
+                    true,
                     generator.subschema_for::<serde_json::Map<String, serde_json::Value>>(),
                 );
             }


### PR DESCRIPTION
The JSON schema says `variables` is optional in the request, but the implementation requires it. That leads to errors in Cursor.

We can either advertise the `variables` parameter as required, or make it optional to align schema and implementation.

This commit does both, because I couldn't persuade Cursor that it's OK for variables to be optional. So make the variables parameter explicitly required, so Cursor always sends it, but in case it doesn't, it is actually optional.

closes GB-9184