### PR TITLE
feat(gb-9187): shared context everywhere

### DIFF
--- a/crates/engine/src/engine/runtime.rs
+++ b/crates/engine/src/engine/runtime.rs
@@ -1,18 +1,19 @@
 use std::{future::Future, sync::Arc};
 
 use grafbase_telemetry::metrics::EngineMetrics;
-use runtime::{entity_cache::EntityCache, kv::KvStore, rate_limiting::RateLimiter};
+use runtime::{entity_cache::EntityCache, extension::ExtensionRuntime, kv::KvStore, rate_limiting::RateLimiter};
 
 use crate::CachedOperation;
 
 pub type WasmContext<R> = <<R as Runtime>::Hooks as runtime::hooks::Hooks>::Context;
+pub type WasmExtensionContext<R> = <<R as Runtime>::Extensions as ExtensionRuntime>::Context;
 
 pub trait Runtime: Send + Sync + 'static {
     type Hooks: runtime::hooks::Hooks;
     type Fetcher: runtime::fetch::Fetcher;
     type OperationCache: runtime::operation_cache::OperationCache<Arc<CachedOperation>>;
-    type Extensions: runtime::extension::ExtensionRuntime<Context = <Self::Hooks as runtime::hooks::Hooks>::Context>;
-    type Authenticate: runtime::authentication::Authenticate;
+    type Extensions: ExtensionRuntime<Context = <Self::Hooks as runtime::hooks::Hooks>::Context>;
+    type Authenticate: runtime::authentication::Authenticate<WasmExtensionContext<Self>>;
 
     fn fetcher(&self) -> &Self::Fetcher;
     fn kv(&self) -> &KvStore;

--- a/crates/engine/src/execution/operation/context.rs
+++ b/crates/engine/src/execution/operation/context.rs
@@ -7,6 +7,7 @@ use schema::{HeaderRule, Schema};
 
 use crate::{
     Engine, Runtime,
+    engine::WasmExtensionContext,
     execution::{GraphqlRequestContext, RequestContext, RequestHooks, apply_header_rules},
     prepare::{CachedOperationContext, OperationPlanContext, PreparedOperation, Shapes},
 };
@@ -14,7 +15,7 @@ use crate::{
 /// Context for a single prepared operation that only needs to be executed.
 pub(crate) struct ExecutionContext<'ctx, R: Runtime> {
     pub engine: &'ctx Arc<Engine<R>>,
-    pub request_context: &'ctx Arc<RequestContext>,
+    pub request_context: &'ctx Arc<RequestContext<WasmExtensionContext<R>>>,
     pub operation: &'ctx Arc<PreparedOperation>,
     pub gql_context: &'ctx GraphqlRequestContext<R>,
 }

--- a/crates/engine/src/execution/operation/response_modifier.rs
+++ b/crates/engine/src/execution/operation/response_modifier.rs
@@ -162,8 +162,8 @@ impl<'ctx, R: Runtime> ExecutionContext<'ctx, R> {
                     let result = self
                         .extensions()
                         .authorize_response(
+                            &self.request_context.extension_context,
                             directive.extension_id,
-                            &self.gql_context.wasm_context,
                             directive.name(),
                             DirectiveSiteId::from(rule_target).walk(self),
                             response_view.iter(),
@@ -267,8 +267,8 @@ impl<'ctx, R: Runtime> ExecutionContext<'ctx, R> {
                     let result = self
                         .extensions()
                         .authorize_response(
+                            &self.request_context.extension_context,
                             directive.extension_id,
-                            &self.gql_context.wasm_context,
                             directive.name(),
                             DirectiveSiteId::from(rule_target).walk(self),
                             response_view.iter(),

--- a/crates/engine/src/execution/request/context.rs
+++ b/crates/engine/src/execution/request/context.rs
@@ -21,7 +21,7 @@ pub(crate) struct EarlyHttpContext {
 
 /// Context associated with the HTTP request. For batch requests and a websocket session, a single RequestContext is
 /// created and shared.
-pub(crate) struct RequestContext {
+pub(crate) struct RequestContext<ExtensionContext> {
     pub can_mutate: bool,
     pub headers: http::HeaderMap,
     pub websocket_init_payload: Option<serde_json::Map<String, serde_json::Value>>,
@@ -31,6 +31,7 @@ pub(crate) struct RequestContext {
     pub subgraph_default_headers: http::HeaderMap,
     pub include_grafbase_response_extension: bool,
     pub include_mcp_response_extension: bool,
+    pub extension_context: ExtensionContext,
 }
 
 /// Context associated with a single operation within an HTTP request.

--- a/crates/engine/src/execution/request/stream.rs
+++ b/crates/engine/src/execution/request/stream.rs
@@ -17,7 +17,7 @@ use tracing::Instrument;
 
 use crate::{
     Engine, Runtime,
-    engine::WasmContext,
+    engine::{WasmContext, WasmExtensionContext},
     execution::{ResponseSender, default_response_extensions, errors, response_extension_for_prepared_operation},
     prepare::PrepareContext,
     response::{ErrorCode, ErrorCodeCounter, Response, ResponseExtensions},
@@ -34,7 +34,7 @@ pub(crate) struct StreamResponse<OnOperationResponseOutput> {
 impl<R: Runtime> Engine<R> {
     pub(super) fn execute_stream(
         self: &Arc<Self>,
-        request_context: Arc<RequestContext>,
+        request_context: Arc<RequestContext<WasmExtensionContext<R>>>,
         wasm_context: WasmContext<R>,
         request: Request,
     ) -> StreamResponse<<R::Hooks as Hooks>::OnOperationResponseOutput> {
@@ -137,24 +137,25 @@ impl<R: Runtime> PrepareContext<'_, R> {
         let result = self
             .engine
             .with_gateway_timeout(async {
-                let operation = match self.prepare_operation(request).await {
-                    Ok(operation_plan) => operation_plan,
-                    Err(response) => {
-                        let attributes = response.operation_attributes().cloned();
-                        sender
-                            .send(
-                                response
-                                    .with_extensions(default_response_extensions(self.schema(), self.request_context)),
-                            )
-                            .await
-                            .ok();
-                        return Err(attributes);
-                    }
-                };
+                let operation =
+                    match self.prepare_operation(request).await {
+                        Ok(operation_plan) => operation_plan,
+                        Err(response) => {
+                            let attributes = response.operation_attributes().cloned();
+                            sender
+                                .send(response.with_extensions(default_response_extensions::<R>(
+                                    self.schema(),
+                                    self.request_context,
+                                )))
+                                .await
+                                .ok();
+                            return Err(attributes);
+                        }
+                    };
 
                 if matches!(operation.cached.ty(), OperationType::Query | OperationType::Mutation) {
                     let extensions =
-                        response_extension_for_prepared_operation(self.schema(), self.request_context, &operation);
+                        response_extension_for_prepared_operation::<R>(self.schema(), self.request_context, &operation);
                     let response = self.execute_query_or_mutation(operation).await;
 
                     let attributes = response.operation_attributes().cloned();
@@ -171,7 +172,7 @@ impl<R: Runtime> PrepareContext<'_, R> {
             Some(Ok((ctx, operation))) => (ctx, operation),
             Some(Err(attributes)) => return attributes,
             None => {
-                let extensions = default_response_extensions(schema, request_context);
+                let extensions = default_response_extensions::<R>(schema, request_context);
 
                 sender
                     .send(errors::response::gateway_timeout().with_extensions(extensions))
@@ -200,7 +201,7 @@ impl<R: Runtime> PrepareContext<'_, R> {
             }
         }
 
-        let extensions = response_extension_for_prepared_operation(schema, request_context, &operation);
+        let extensions = response_extension_for_prepared_operation::<R>(schema, request_context, &operation);
         ctx.execute_subscription(
             operation,
             AddExtToFirstResponse {

--- a/crates/engine/src/execution/request/well_formed_graphql_request.rs
+++ b/crates/engine/src/execution/request/well_formed_graphql_request.rs
@@ -7,7 +7,7 @@ use runtime::hooks::Hooks;
 
 use crate::{
     Body, Engine,
-    engine::WasmContext,
+    engine::{WasmContext, WasmExtensionContext},
     graphql_over_http::{Http, ResponseFormat},
     response::Response,
 };
@@ -17,7 +17,7 @@ use super::{RequestContext, Runtime, response_extension::default_response_extens
 impl<R: Runtime> Engine<R> {
     pub(crate) async fn execute_well_formed_graphql_request(
         self: &Arc<Self>,
-        request_context: Arc<RequestContext>,
+        request_context: Arc<RequestContext<WasmExtensionContext<R>>>,
         wasm_context: WasmContext<R>,
         request: BatchRequest,
     ) -> http::Response<Body> {
@@ -86,7 +86,7 @@ impl<R: Runtime> Engine<R> {
 
     pub(crate) fn execute_websocket_well_formed_graphql_request(
         self: &Arc<Self>,
-        request_context: Arc<RequestContext>,
+        request_context: Arc<RequestContext<WasmExtensionContext<R>>>,
         wasm_context: WasmContext<R>,
         request: Request,
     ) -> StreamResponse<<R::Hooks as Hooks>::OnOperationResponseOutput> {
@@ -95,22 +95,22 @@ impl<R: Runtime> Engine<R> {
 
     fn bad_request_but_well_formed_graphql_over_http_request(
         &self,
-        request_context: &RequestContext,
+        request_context: &RequestContext<WasmExtensionContext<R>>,
         message: impl std::fmt::Display,
     ) -> http::Response<Body> {
         let error = GraphqlError::new(format!("Bad request: {message}"), ErrorCode::BadRequest);
         Http::error(
             request_context.response_format,
             Response::<()>::request_error([error])
-                .with_extensions(default_response_extensions(&self.schema, request_context)),
+                .with_extensions(default_response_extensions::<R>(&self.schema, request_context)),
         )
     }
 
-    fn gateway_timeout_error(&self, request_context: &RequestContext) -> http::Response<Body> {
+    fn gateway_timeout_error(&self, request_context: &RequestContext<WasmExtensionContext<R>>) -> http::Response<Body> {
         Http::error(
             request_context.response_format,
             super::errors::response::gateway_timeout::<()>()
-                .with_extensions(default_response_extensions(&self.schema, request_context)),
+                .with_extensions(default_response_extensions::<R>(&self.schema, request_context)),
         )
     }
 }

--- a/crates/engine/src/prepare/context.rs
+++ b/crates/engine/src/prepare/context.rs
@@ -10,7 +10,7 @@ use schema::Schema;
 
 use crate::{
     Engine, Runtime,
-    engine::WasmContext,
+    engine::{WasmContext, WasmExtensionContext},
     execution::{GraphqlRequestContext, RequestContext, RequestHooks},
 };
 
@@ -19,7 +19,7 @@ use crate::{
 /// if and only if operation preparation succeeds.
 pub(crate) struct PrepareContext<'ctx, R: Runtime> {
     pub engine: &'ctx Arc<Engine<R>>,
-    pub request_context: &'ctx Arc<RequestContext>,
+    pub request_context: &'ctx Arc<RequestContext<WasmExtensionContext<R>>>,
     pub gql_context: GraphqlRequestContext<R>,
     pub executed_operation_builder: ExecutedOperationBuilder<<R::Hooks as Hooks>::OnSubgraphResponseOutput>,
     // needs to be Send so that futures are Send.
@@ -29,7 +29,7 @@ pub(crate) struct PrepareContext<'ctx, R: Runtime> {
 impl<'ctx, R: Runtime> PrepareContext<'ctx, R> {
     pub fn new(
         engine: &'ctx Arc<Engine<R>>,
-        request_context: &'ctx Arc<RequestContext>,
+        request_context: &'ctx Arc<RequestContext<WasmExtensionContext<R>>>,
         wasm_context: WasmContext<R>,
     ) -> Self {
         Self {

--- a/crates/engine/src/prepare/operation_plan/query_modifications.rs
+++ b/crates/engine/src/prepare/operation_plan/query_modifications.rs
@@ -104,7 +104,9 @@ where
         let schema = self.ctx.schema();
         let operation_ctx = self.operation_ctx;
         let variables = &self.input_value_ctx.variables;
+
         let subgraph_default_headers_override = self.ctx.request_context.subgraph_default_headers.clone();
+
         let extensions = modifiers
             .by_extension
             .iter()
@@ -113,11 +115,12 @@ where
                 (extension_id, directive_range.into(), query_elements_range.into())
             })
             .collect::<Vec<_>>();
+
         let (mut subgraph_default_headers_override, decisions) = self
             .ctx
             .extensions()
             .authorize_query(
-                &self.ctx.gql_context.wasm_context,
+                &self.ctx.request_context.extension_context,
                 subgraph_default_headers_override,
                 self.ctx.access_token().as_ref(),
                 extensions,

--- a/crates/engine/src/resolver/extension/lookup.rs
+++ b/crates/engine/src/resolver/extension/lookup.rs
@@ -34,6 +34,7 @@ impl super::ExtensionResolver {
             .runtime()
             .extensions()
             .resolve(
+                &ctx.request_context.extension_context,
                 definition.directive(),
                 &prepared.extension_data,
                 // TODO: use Arc instead of clone?

--- a/crates/engine/src/resolver/extension/query_or_mutation.rs
+++ b/crates/engine/src/resolver/extension/query_or_mutation.rs
@@ -43,6 +43,7 @@ impl super::ExtensionResolver {
                 ctx.runtime()
                     .extensions()
                     .resolve(
+                        &ctx.request_context.extension_context,
                         definition.directive(),
                         &prepared.extension_data,
                         // TODO: use Arc instead of clone?
@@ -90,6 +91,7 @@ impl super::ExtensionResolver {
                     ctx.runtime()
                         .extensions()
                         .resolve(
+                            &ctx.request_context.extension_context,
                             definition.directive(),
                             &prepared.extension_data,
                             // TODO: use Arc instead of clone?

--- a/crates/engine/src/resolver/extension/subscription.rs
+++ b/crates/engine/src/resolver/extension/subscription.rs
@@ -26,6 +26,7 @@ impl super::ExtensionResolver {
             .runtime()
             .extensions()
             .resolve_subscription(
+                &ctx.request_context.extension_context,
                 definition.directive(),
                 &prepared.extension_data,
                 subgraph_headers,

--- a/crates/grafbase-sdk/src/component/authentication.rs
+++ b/crates/grafbase-sdk/src/component/authentication.rs
@@ -1,16 +1,18 @@
-use crate::wit::{AuthenticationGuest, ErrorResponse, Headers, Token};
+use crate::wit;
 
 use super::{Component, state};
 
-impl AuthenticationGuest for Component {
-    fn authenticate(headers: Headers) -> Result<Token, ErrorResponse> {
-        let result = state::extension()
-            .map_err(|err| ErrorResponse {
-                status_code: 500,
-                errors: vec![err],
-            })?
-            .authenticate(&headers.into());
+impl wit::AuthenticationGuest for Component {
+    fn authenticate(context: wit::SharedContext, headers: wit::Headers) -> Result<wit::Token, wit::ErrorResponse> {
+        state::with_context(context, || {
+            let result = state::extension()
+                .map_err(|err| wit::ErrorResponse {
+                    status_code: 500,
+                    errors: vec![err],
+                })?
+                .authenticate(&headers.into());
 
-        result.map(Into::into).map_err(Into::into)
+            result.map(Into::into).map_err(Into::into)
+        })
     }
 }

--- a/crates/grafbase-sdk/src/component/authorization.rs
+++ b/crates/grafbase-sdk/src/component/authorization.rs
@@ -1,25 +1,32 @@
-use crate::wit::{
-    AuthorizationDecisions, AuthorizationGuest, Error, ErrorResponse, Headers, QueryElements, ResponseElements, Token,
-};
+use crate::wit;
 
 use super::{Component, state};
 
-impl AuthorizationGuest for Component {
+impl wit::AuthorizationGuest for Component {
     fn authorize_query(
-        headers: Headers,
-        token: Token,
-        elements: QueryElements,
-    ) -> Result<(AuthorizationDecisions, Vec<u8>), ErrorResponse> {
-        state::extension()?
-            .authorize_query(&mut headers.into(), token.into(), (&elements).into())
-            .map(|(decisions, state)| (decisions.into(), state))
-            .map_err(Into::into)
+        context: wit::SharedContext,
+        headers: wit::Headers,
+        token: wit::Token,
+        elements: wit::QueryElements,
+    ) -> Result<(wit::AuthorizationDecisions, Vec<u8>), wit::ErrorResponse> {
+        state::with_context(context, || {
+            state::extension()?
+                .authorize_query(&mut headers.into(), token.into(), (&elements).into())
+                .map(|(decisions, state)| (decisions.into(), state))
+                .map_err(Into::into)
+        })
     }
 
-    fn authorize_response(state: Vec<u8>, elements: ResponseElements) -> Result<AuthorizationDecisions, Error> {
-        state::extension()?
-            .authorize_response(state, (&elements).into())
-            .map(Into::into)
-            .map_err(Into::into)
+    fn authorize_response(
+        context: wit::SharedContext,
+        state: Vec<u8>,
+        elements: wit::ResponseElements,
+    ) -> Result<wit::AuthorizationDecisions, wit::Error> {
+        state::with_context(context, || {
+            state::extension()?
+                .authorize_response(state, (&elements).into())
+                .map(Into::into)
+                .map_err(Into::into)
+        })
     }
 }

--- a/crates/grafbase-sdk/src/component/resolver.rs
+++ b/crates/grafbase-sdk/src/component/resolver.rs
@@ -1,53 +1,72 @@
 use super::{Component, state};
-use crate::wit::{ArgumentsId, Directive, Error, Field, FieldId, Headers, ResolverGuest, Response, SubscriptionItem};
+use crate::wit;
 
-impl ResolverGuest for Component {
+impl wit::ResolverGuest for Component {
     fn prepare(
+        ctx: wit::SharedContext,
         subgraph_name: String,
-        directive: Directive,
-        root_field_id: FieldId,
-        fields: Vec<Field>,
-    ) -> Result<Vec<u8>, Error> {
-        let result = state::extension()?.prepare(crate::types::ResolvedField {
-            subgraph_name: &subgraph_name,
-            directive_name: &directive.name,
-            directive_arguments: &directive.arguments,
-            fields: fields.into(),
-            root_field_ix: root_field_id as usize,
-        });
+        directive: wit::Directive,
+        root_field_id: wit::FieldId,
+        fields: Vec<wit::Field>,
+    ) -> Result<Vec<u8>, wit::Error> {
+        state::with_context(ctx, || {
+            let result = state::extension()?.prepare(crate::types::ResolvedField {
+                subgraph_name: &subgraph_name,
+                directive_name: &directive.name,
+                directive_arguments: &directive.arguments,
+                fields: fields.into(),
+                root_field_ix: root_field_id as usize,
+            });
 
-        result.map_err(Into::into)
-    }
-
-    fn resolve(prepared: Vec<u8>, headers: Headers, arguments: Vec<(ArgumentsId, Vec<u8>)>) -> Response {
-        state::extension()
-            .map(|ext| ext.resolve(&prepared, headers.into(), arguments.into()))
-            .into()
-    }
-
-    fn create_subscription(
-        prepared: Vec<u8>,
-        headers: Headers,
-        arguments: Vec<(ArgumentsId, Vec<u8>)>,
-    ) -> Result<Option<Vec<u8>>, Error> {
-        // SAFETY: We keep prepared Vec alive with the subscription callback until it's called. We
-        // also never modify the Vec at any point. Not providing a ref makes the API considerably
-        // more tricky to work with.
-        let slice: &'static [u8] = unsafe { std::mem::transmute(prepared.as_slice()) };
-        let (key, callback) = state::extension()?.resolve_subscription(slice, headers.into(), arguments.into())?;
-        state::set_subscription_callback(prepared, callback);
-        Ok(key)
-    }
-
-    fn resolve_next_subscription_item() -> Result<Option<SubscriptionItem>, Error> {
-        state::subscription().and_then(|sub| match sub.next() {
-            Ok(Some(item)) => Ok(Some(item.into())),
-            Ok(None) => Ok(None),
-            Err(err) => Err(err.into()),
+            result.map_err(Into::into)
         })
     }
 
-    fn drop_subscription() {
-        state::drop_subscription();
+    fn resolve(
+        ctx: wit::SharedContext,
+        prepared: Vec<u8>,
+        headers: wit::Headers,
+        arguments: Vec<(wit::ArgumentsId, Vec<u8>)>,
+    ) -> wit::Response {
+        state::with_context(ctx, || {
+            state::extension()
+                .map(|ext| ext.resolve(&prepared, headers.into(), arguments.into()))
+                .into()
+        })
+    }
+
+    fn create_subscription(
+        ctx: wit::SharedContext,
+        prepared: Vec<u8>,
+        headers: wit::Headers,
+        arguments: Vec<(wit::ArgumentsId, Vec<u8>)>,
+    ) -> Result<Option<Vec<u8>>, wit::Error> {
+        state::with_context(ctx, || {
+            // SAFETY: We keep prepared Vec alive with the subscription callback until it's called. We
+            // also never modify the Vec at any point. Not providing a ref makes the API considerably
+            // more tricky to work with.
+            let slice: &'static [u8] = unsafe { std::mem::transmute(prepared.as_slice()) };
+            let (key, callback) = state::extension()?.resolve_subscription(slice, headers.into(), arguments.into())?;
+
+            state::set_subscription_callback(prepared, callback);
+
+            Ok(key)
+        })
+    }
+
+    fn resolve_next_subscription_item(ctx: wit::SharedContext) -> Result<Option<wit::SubscriptionItem>, wit::Error> {
+        state::with_context(ctx, || {
+            state::subscription().and_then(|sub| match sub.next() {
+                Ok(Some(item)) => Ok(Some(item.into())),
+                Ok(None) => Ok(None),
+                Err(err) => Err(err.into()),
+            })
+        })
+    }
+
+    fn drop_subscription(ctx: wit::SharedContext) {
+        state::with_context(ctx, || {
+            state::drop_subscription();
+        })
     }
 }

--- a/crates/grafbase-sdk/src/types/configuration.rs
+++ b/crates/grafbase-sdk/src/types/configuration.rs
@@ -95,6 +95,6 @@ mod tests {
         let invalid_configuration = Configuration::new(invalid_bytes);
         let err = invalid_configuration.deserialize::<TestConfig<Settings>>().unwrap_err();
 
-        insta::assert_snapshot!(err, @"Missing configuration");
+        insta::assert_snapshot!(err, @"Failed to deserialize configuration: unexpected type null at position 0: expected map");
     }
 }

--- a/crates/grafbase-sdk/wit/since_0_17_0/authentication.wit
+++ b/crates/grafbase-sdk/wit/since_0_17_0/authentication.wit
@@ -2,6 +2,7 @@ interface authentication {
     use headers.{headers};
     use error.{error-response};
     use token.{token};
+    use shared-context.{shared-context};
 
     /// Authenticates a request using the provided headers.
     ///
@@ -15,6 +16,7 @@ interface authentication {
     /// - `Ok(token)`: Authentication successful, returns a valid token
     /// - `Err(error-response)`: Authentication failed, returns error details
     authenticate: func(
+        context: shared-context,
         headers: headers,
     ) -> result<token, error-response>;
 }

--- a/crates/grafbase-sdk/wit/since_0_17_0/authorization.wit
+++ b/crates/grafbase-sdk/wit/since_0_17_0/authorization.wit
@@ -3,14 +3,17 @@ interface authorization {
     use headers.{headers};
     use token.{token};
     use authorization-types.{authorization-decisions, query-elements, response-elements};
+    use shared-context.{shared-context};
 
     authorize-query: func(
+        context: shared-context,
         headers: headers,
         token: token,
         elements: query-elements
     ) -> result<tuple<authorization-decisions, list<u8>>, error-response>;
 
     authorize-response: func(
+        context: shared-context,
         state: list<u8>,
         elements: response-elements
     ) -> result<authorization-decisions, error>;

--- a/crates/grafbase-sdk/wit/since_0_17_0/resolver.wit
+++ b/crates/grafbase-sdk/wit/since_0_17_0/resolver.wit
@@ -3,8 +3,10 @@ interface resolver {
     use schema.{definition-id, directive};
     use resolver-types.{response, field-id, field, arguments-id, subscription-item};
     use headers.{headers};
+    use shared-context.{shared-context};
 
     prepare: func(
+        context: shared-context,
         subgraph-name: string,
         directive: directive,
         root-field-id: field-id,
@@ -12,12 +14,14 @@ interface resolver {
     ) -> result<list<u8>, error>;
 
     resolve: func(
+        context: shared-context,
         prepared: list<u8>,
         headers: headers,
         arguments: list<tuple<arguments-id, list<u8>>>
     ) -> response;
 
     create-subscription: func(
+        context: shared-context,
         prepared: list<u8>,
         headers: headers,
         arguments: list<tuple<arguments-id, list<u8>>>
@@ -25,9 +29,13 @@ interface resolver {
 
     // resolves the next item in a subscription stream. Must be called after resolve-subscription
     // If data is null, it means the subscription is done and no more items will be requested.
-    resolve-next-subscription-item: func() -> result<option<subscription-item>, error>;
+    resolve-next-subscription-item: func(
+        context: shared-context,
+    ) -> result<option<subscription-item>, error>;
 
     // Called if the key provided by resolve-subscription is enough and any stored state can be dropped.
     // This implies resolve-next-subscription-item will never be called.
-    drop-subscription: func();
+    drop-subscription: func(
+        context: shared-context,
+    );
 }

--- a/crates/integration-tests/src/gateway/runtime/extension/impls/authentication.rs
+++ b/crates/integration-tests/src/gateway/runtime/extension/impls/authentication.rs
@@ -13,6 +13,7 @@ use crate::gateway::{
 impl AuthenticationExtension<ExtContext> for ExtensionsDispatcher {
     async fn authenticate(
         &self,
+        context: &ExtContext,
         extension_ids: &[ExtensionId],
         gateway_headers: http::HeaderMap,
     ) -> (http::HeaderMap, Result<Token, ErrorResponse>) {
@@ -31,9 +32,13 @@ impl AuthenticationExtension<ExtContext> for ExtensionsDispatcher {
         );
 
         if !wasm_extensions.is_empty() {
-            self.wasm.authenticate(&wasm_extensions, gateway_headers).await
+            self.wasm
+                .authenticate(&context.wasm, &wasm_extensions, gateway_headers)
+                .await
         } else {
-            self.test.authenticate(&test_extensions, gateway_headers).await
+            self.test
+                .authenticate(&context.test, &test_extensions, gateway_headers)
+                .await
         }
     }
 }
@@ -41,6 +46,7 @@ impl AuthenticationExtension<ExtContext> for ExtensionsDispatcher {
 impl AuthenticationExtension<DynHookContext> for TestExtensions {
     async fn authenticate(
         &self,
+        _: &DynHookContext,
         extension_ids: &[ExtensionId],
         headers: http::HeaderMap,
     ) -> (http::HeaderMap, Result<Token, ErrorResponse>) {
@@ -66,6 +72,7 @@ impl AuthenticationExtension<DynHookContext> for TestExtensions {
         }
 
         drop(futures);
+
         (headers, Err(last_error.unwrap()))
     }
 }

--- a/crates/integration-tests/tests/gateway/extensions/authorization/deny_all.rs
+++ b/crates/integration-tests/tests/gateway/extensions/authorization/deny_all.rs
@@ -14,7 +14,7 @@ impl AuthorizationTestExtension for DenyAll {
     #[allow(clippy::manual_async_fn)]
     async fn authorize_query(
         &self,
-        _wasm_context: &DynHookContext,
+        _wasm_context: DynHookContext,
         _headers: &tokio::sync::RwLock<http::HeaderMap>,
         _token: TokenRef<'_>,
         _elements_grouped_by_directive_name: Vec<(&str, Vec<QueryElement<'_, serde_json::Value>>)>,

--- a/crates/integration-tests/tests/gateway/extensions/authorization/deny_some.rs
+++ b/crates/integration-tests/tests/gateway/extensions/authorization/deny_some.rs
@@ -34,7 +34,7 @@ impl AuthorizationTestExtension for DenySites {
     #[allow(clippy::manual_async_fn)]
     async fn authorize_query(
         &self,
-        _wasm_context: &DynHookContext,
+        _wasm_context: DynHookContext,
         _headers: &tokio::sync::RwLock<http::HeaderMap>,
         _token: TokenRef<'_>,
         elements_grouped_by_directive_name: Vec<(&str, Vec<QueryElement<'_, serde_json::Value>>)>,
@@ -63,7 +63,7 @@ impl AuthorizationTestExtension for DenySites {
 
     async fn authorize_response(
         &self,
-        _wasm_context: &DynHookContext,
+        _wasm_context: DynHookContext,
         _directive_name: &str,
         directive_site: DirectiveSite<'_>,
         _items: Vec<serde_json::Value>,

--- a/crates/integration-tests/tests/gateway/extensions/authorization/error_response.rs
+++ b/crates/integration-tests/tests/gateway/extensions/authorization/error_response.rs
@@ -14,7 +14,7 @@ impl AuthorizationTestExtension for Failure {
     #[allow(clippy::manual_async_fn)]
     async fn authorize_query(
         &self,
-        _wasm_context: &DynHookContext,
+        _wasm_context: DynHookContext,
         _headers: &tokio::sync::RwLock<http::HeaderMap>,
         _token: TokenRef<'_>,
         _elements_grouped_by_directive_name: Vec<(&str, Vec<QueryElement<'_, serde_json::Value>>)>,

--- a/crates/integration-tests/tests/gateway/extensions/authorization/grant_all.rs
+++ b/crates/integration-tests/tests/gateway/extensions/authorization/grant_all.rs
@@ -15,7 +15,7 @@ impl AuthorizationTestExtension for GrantAll {
     #[allow(clippy::manual_async_fn)]
     async fn authorize_query(
         &self,
-        _wasm_context: &DynHookContext,
+        _wasm_context: DynHookContext,
         _headers: &tokio::sync::RwLock<http::HeaderMap>,
         _token: TokenRef<'_>,
         _elements_grouped_by_directive_name: Vec<(&str, Vec<QueryElement<'_, serde_json::Value>>)>,
@@ -25,7 +25,7 @@ impl AuthorizationTestExtension for GrantAll {
 
     async fn authorize_response(
         &self,
-        _wasm_context: &DynHookContext,
+        _wasm_context: DynHookContext,
         _directive_name: &str,
         _directive_site: DirectiveSite<'_>,
         _items: Vec<serde_json::Value>,

--- a/crates/integration-tests/tests/gateway/extensions/authorization/headers.rs
+++ b/crates/integration-tests/tests/gateway/extensions/authorization/headers.rs
@@ -16,7 +16,7 @@ impl AuthorizationTestExtension for InsertTokenAsHeader {
     #[allow(clippy::manual_async_fn)]
     async fn authorize_query(
         &self,
-        _wasm_context: &DynHookContext,
+        _wasm_context: DynHookContext,
         headers: &tokio::sync::RwLock<http::HeaderMap>,
         token: TokenRef<'_>,
         _elements_grouped_by_directive_name: Vec<(&str, Vec<QueryElement<'_, serde_json::Value>>)>,

--- a/crates/integration-tests/tests/gateway/extensions/authorization/injection/mod.rs
+++ b/crates/integration-tests/tests/gateway/extensions/authorization/injection/mod.rs
@@ -16,7 +16,7 @@ impl AuthorizationTestExtension for EchoInjections {
     #[allow(clippy::manual_async_fn)]
     async fn authorize_query(
         &self,
-        wasm_context: &DynHookContext,
+        wasm_context: DynHookContext,
         _headers: &tokio::sync::RwLock<http::HeaderMap>,
         _token: TokenRef<'_>,
         elements_grouped_by_directive_name: Vec<(&str, Vec<QueryElement<'_, serde_json::Value>>)>,
@@ -40,7 +40,7 @@ impl AuthorizationTestExtension for EchoInjections {
 
     async fn authorize_response(
         &self,
-        ctx: &DynHookContext,
+        ctx: DynHookContext,
         directive_name: &str,
         directive_site: DirectiveSite<'_>,
         items: Vec<serde_json::Value>,

--- a/crates/integration-tests/tests/gateway/extensions/authorization/multiple.rs
+++ b/crates/integration-tests/tests/gateway/extensions/authorization/multiple.rs
@@ -14,7 +14,7 @@ impl AuthorizationTestExtension for MultiDirectives {
     #[allow(clippy::manual_async_fn)]
     async fn authorize_query(
         &self,
-        _wasm_context: &DynHookContext,
+        _wasm_context: DynHookContext,
         _headers: &tokio::sync::RwLock<http::HeaderMap>,
         _token: TokenRef<'_>,
         elements_grouped_by_directive_name: Vec<(&str, Vec<QueryElement<'_, serde_json::Value>>)>,
@@ -52,7 +52,7 @@ impl AuthorizationTestExtension for MultiDirectivesBis {
     #[allow(clippy::manual_async_fn)]
     async fn authorize_query(
         &self,
-        _wasm_context: &DynHookContext,
+        _wasm_context: DynHookContext,
         _headers: &tokio::sync::RwLock<http::HeaderMap>,
         _token: TokenRef<'_>,
         elements_grouped_by_directive_name: Vec<(&str, Vec<QueryElement<'_, serde_json::Value>>)>,

--- a/crates/integration-tests/tests/gateway/extensions/authorization/requires_scopes.rs
+++ b/crates/integration-tests/tests/gateway/extensions/authorization/requires_scopes.rs
@@ -21,7 +21,7 @@ struct Arguments {
 impl AuthorizationTestExtension for RequiresScopes {
     async fn authorize_query(
         &self,
-        _wasm_context: &DynHookContext,
+        _wasm_context: DynHookContext,
         _headers: &tokio::sync::RwLock<http::HeaderMap>,
         token: TokenRef<'_>,
         elements_grouped_by_directive_name: Vec<(&str, Vec<QueryElement<'_, serde_json::Value>>)>,

--- a/crates/runtime/src/authentication.rs
+++ b/crates/runtime/src/authentication.rs
@@ -66,9 +66,10 @@ impl LegacyToken {
     }
 }
 
-pub trait Authenticate {
+pub trait Authenticate<Context> {
     fn authenticate(
         &self,
+        context: &Context,
         headers: http::HeaderMap,
     ) -> impl Future<Output = Result<(http::HeaderMap, LegacyToken), ErrorResponse>> + Send;
 }

--- a/crates/runtime/src/extension/authentication.rs
+++ b/crates/runtime/src/extension/authentication.rs
@@ -6,6 +6,7 @@ use extension_catalog::ExtensionId;
 pub trait AuthenticationExtension<Context: Send + Sync + 'static>: Send + Sync + 'static {
     fn authenticate(
         &self,
+        context: &Context,
         extension_ids: &[ExtensionId],
         gateway_headers: http::HeaderMap,
     ) -> impl Future<Output = (http::HeaderMap, Result<Token, ErrorResponse>)> + Send;

--- a/crates/runtime/src/extension/authorization.rs
+++ b/crates/runtime/src/extension/authorization.rs
@@ -11,7 +11,7 @@ use super::TokenRef;
 pub trait AuthorizationExtension<Context: Send + Sync + 'static>: Send + Sync + 'static {
     fn authorize_query<'ctx, 'fut, Extensions, Arguments>(
         &'ctx self,
-        wasm_context: &'ctx Context,
+        context: &Context,
         subgraph_headers: http::HeaderMap,
         token: TokenRef<'ctx>,
         extensions: Extensions,
@@ -32,8 +32,8 @@ pub trait AuthorizationExtension<Context: Send + Sync + 'static>: Send + Sync + 
 
     fn authorize_response<'ctx, 'fut>(
         &'ctx self,
+        wasm_context: &Context,
         extension_id: ExtensionId,
-        wasm_context: &'ctx Context,
         directive_name: &'ctx str,
         directive_site: DirectiveSite<'ctx>,
         items: impl IntoIterator<Item: Anything<'ctx>>,

--- a/crates/runtime/src/extension/hooks.rs
+++ b/crates/runtime/src/extension/hooks.rs
@@ -10,13 +10,13 @@ pub trait HooksExtension: Send + Sync + 'static {
 
     fn on_request(
         &self,
-        context: Self::Context,
+        context: &Self::Context,
         parts: request::Parts,
     ) -> impl Future<Output = Result<request::Parts, ErrorResponse>> + Send;
 
     fn on_response(
         &self,
-        context: Self::Context,
+        context: &Self::Context,
         parts: response::Parts,
     ) -> impl Future<Output = Result<response::Parts, String>> + Send;
 }
@@ -26,11 +26,11 @@ impl HooksExtension for () {
 
     fn new_context(&self) -> Self::Context {}
 
-    async fn on_request(&self, _: Self::Context, parts: request::Parts) -> Result<request::Parts, ErrorResponse> {
+    async fn on_request(&self, _: &Self::Context, parts: request::Parts) -> Result<request::Parts, ErrorResponse> {
         Ok(parts)
     }
 
-    async fn on_response(&self, _: Self::Context, parts: response::Parts) -> Result<response::Parts, String> {
+    async fn on_response(&self, _: &Self::Context, parts: response::Parts) -> Result<response::Parts, String> {
         Ok(parts)
     }
 }

--- a/crates/runtime/src/extension/mod.rs
+++ b/crates/runtime/src/extension/mod.rs
@@ -19,7 +19,7 @@ pub trait ExtensionRuntime:
     + AuthorizationExtension<Self::Context>
     + FieldResolverExtension<Self::Context>
     + SelectionSetResolverExtension
-    + ResolverExtension
+    + ResolverExtension<Self::Context>
     + Send
     + Sync
     + 'static

--- a/crates/runtime/src/extension/resolver.rs
+++ b/crates/runtime/src/extension/resolver.rs
@@ -43,9 +43,10 @@ impl From<ArgumentsId> for u16 {
     }
 }
 
-pub trait ResolverExtension: Send + Sync + 'static {
+pub trait ResolverExtension<Context: Send + Sync + 'static>: Send + Sync + 'static {
     fn prepare<'ctx, F: Field<'ctx>>(
         &'ctx self,
+        context: &Context,
         directive: ExtensionDirective<'ctx>,
         directive_arguments: impl Anything<'ctx>,
         field: F,
@@ -53,6 +54,7 @@ pub trait ResolverExtension: Send + Sync + 'static {
 
     fn resolve<'ctx, 'resp, 'f>(
         &'ctx self,
+        context: &Context,
         directive: ExtensionDirective<'ctx>,
         prepared_data: &'ctx [u8],
         subgraph_headers: http::HeaderMap,
@@ -63,6 +65,7 @@ pub trait ResolverExtension: Send + Sync + 'static {
 
     fn resolve_subscription<'ctx, 'resp, 'f>(
         &'ctx self,
+        context: &Context,
         directive: ExtensionDirective<'ctx>,
         prepared_data: &'ctx [u8],
         subgraph_headers: http::HeaderMap,

--- a/crates/runtime/src/hooks.rs
+++ b/crates/runtime/src/hooks.rs
@@ -46,7 +46,7 @@ pub struct SubgraphRequest {
 
 #[allow(unused)]
 pub trait Hooks: Send + Sync + 'static {
-    type Context: Clone + Send + Sync + 'static;
+    type Context: Default + Clone + Send + Sync + 'static;
     type OnSubgraphResponseOutput: Send + Sync + 'static;
     type OnOperationResponseOutput: Send + Sync + 'static;
 

--- a/crates/wasi-component-loader/src/extension/api/since_0_10_0/instance/authentication.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_10_0/instance/authentication.rs
@@ -2,7 +2,7 @@ use futures::future::BoxFuture;
 use runtime::extension::Token;
 
 use crate::{
-    ErrorResponse,
+    ErrorResponse, SharedContext,
     extension::AuthenticationExtensionInstance,
     resources::{Headers, Lease},
 };
@@ -10,6 +10,7 @@ use crate::{
 impl AuthenticationExtensionInstance for super::ExtensionInstanceSince0_10_0 {
     fn authenticate(
         &mut self,
+        _: SharedContext,
         headers: Lease<http::HeaderMap>,
     ) -> BoxFuture<'_, Result<(Lease<http::HeaderMap>, Token), ErrorResponse>> {
         Box::pin(async move {

--- a/crates/wasi-component-loader/src/extension/api/since_0_10_0/instance/authorization.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_10_0/instance/authorization.rs
@@ -2,7 +2,7 @@ use futures::future::BoxFuture;
 use runtime::extension::{AuthorizationDecisions, TokenRef};
 
 use crate::{
-    Error,
+    Error, SharedContext,
     extension::{
         AuthorizationExtensionInstance, QueryAuthorizationResult,
         api::wit::{Headers, QueryElements, ResponseElements, TokenParam},
@@ -13,6 +13,7 @@ use crate::{
 impl AuthorizationExtensionInstance for super::ExtensionInstanceSince0_10_0 {
     fn authorize_query<'a>(
         &'a mut self,
+        _: SharedContext,
         headers: Lease<http::HeaderMap>,
         token: TokenRef<'a>,
         elements: QueryElements<'a>,
@@ -48,6 +49,7 @@ impl AuthorizationExtensionInstance for super::ExtensionInstanceSince0_10_0 {
 
     fn authorize_response<'a>(
         &'a mut self,
+        _: SharedContext,
         state: &'a [u8],
         elements: ResponseElements<'a>,
     ) -> BoxFuture<'a, Result<AuthorizationDecisions, Error>> {

--- a/crates/wasi-component-loader/src/extension/api/since_0_14_0/instance/authentication.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_14_0/instance/authentication.rs
@@ -2,7 +2,7 @@ use futures::future::BoxFuture;
 use runtime::extension::Token;
 
 use crate::{
-    ErrorResponse,
+    ErrorResponse, SharedContext,
     extension::AuthenticationExtensionInstance,
     resources::{Headers, Lease},
 };
@@ -10,6 +10,7 @@ use crate::{
 impl AuthenticationExtensionInstance for super::ExtensionInstanceSince0_14_0 {
     fn authenticate(
         &mut self,
+        _: SharedContext,
         headers: Lease<http::HeaderMap>,
     ) -> BoxFuture<'_, Result<(Lease<http::HeaderMap>, Token), ErrorResponse>> {
         Box::pin(async move {

--- a/crates/wasi-component-loader/src/extension/api/since_0_14_0/instance/authorization.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_14_0/instance/authorization.rs
@@ -2,7 +2,7 @@ use futures::future::BoxFuture;
 use runtime::extension::{AuthorizationDecisions, TokenRef};
 
 use crate::{
-    Error,
+    Error, SharedContext,
     extension::{
         AuthorizationExtensionInstance, QueryAuthorizationResult,
         api::wit::{Headers, QueryElements, ResponseElements, TokenParam},
@@ -13,6 +13,7 @@ use crate::{
 impl AuthorizationExtensionInstance for super::ExtensionInstanceSince0_14_0 {
     fn authorize_query<'a>(
         &'a mut self,
+        _: SharedContext,
         headers: Lease<http::HeaderMap>,
         token: TokenRef<'a>,
         elements: QueryElements<'a>,
@@ -48,6 +49,7 @@ impl AuthorizationExtensionInstance for super::ExtensionInstanceSince0_14_0 {
 
     fn authorize_response<'a>(
         &'a mut self,
+        _: SharedContext,
         state: &'a [u8],
         elements: ResponseElements<'a>,
     ) -> BoxFuture<'a, Result<AuthorizationDecisions, Error>> {

--- a/crates/wasi-component-loader/src/extension/api/since_0_15_0/instance/authentication.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_15_0/instance/authentication.rs
@@ -2,7 +2,7 @@ use futures::future::BoxFuture;
 use runtime::extension::Token;
 
 use crate::{
-    ErrorResponse,
+    ErrorResponse, SharedContext,
     extension::AuthenticationExtensionInstance,
     resources::{Headers, Lease},
 };
@@ -10,6 +10,7 @@ use crate::{
 impl AuthenticationExtensionInstance for super::ExtensionInstanceSince0_15_0 {
     fn authenticate(
         &mut self,
+        _: SharedContext,
         headers: Lease<http::HeaderMap>,
     ) -> BoxFuture<'_, Result<(Lease<http::HeaderMap>, Token), ErrorResponse>> {
         Box::pin(async move {

--- a/crates/wasi-component-loader/src/extension/api/since_0_15_0/instance/authorization.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_15_0/instance/authorization.rs
@@ -2,7 +2,7 @@ use futures::future::BoxFuture;
 use runtime::extension::{AuthorizationDecisions, TokenRef};
 
 use crate::{
-    Error,
+    Error, SharedContext,
     extension::{
         AuthorizationExtensionInstance, QueryAuthorizationResult,
         api::wit::{Headers, QueryElements, ResponseElements, TokenParam},
@@ -13,6 +13,7 @@ use crate::{
 impl AuthorizationExtensionInstance for super::ExtensionInstanceSince0_15_0 {
     fn authorize_query<'a>(
         &'a mut self,
+        _: SharedContext,
         headers: Lease<http::HeaderMap>,
         token: TokenRef<'a>,
         elements: QueryElements<'a>,
@@ -48,6 +49,7 @@ impl AuthorizationExtensionInstance for super::ExtensionInstanceSince0_15_0 {
 
     fn authorize_response<'a>(
         &'a mut self,
+        _: SharedContext,
         state: &'a [u8],
         elements: ResponseElements<'a>,
     ) -> BoxFuture<'a, Result<AuthorizationDecisions, Error>> {

--- a/crates/wasi-component-loader/src/extension/api/since_0_16_0/instance/authentication.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_16_0/instance/authentication.rs
@@ -2,7 +2,7 @@ use futures::future::BoxFuture;
 use runtime::extension::Token;
 
 use crate::{
-    ErrorResponse,
+    ErrorResponse, SharedContext,
     extension::AuthenticationExtensionInstance,
     resources::{Headers, Lease},
 };
@@ -10,6 +10,7 @@ use crate::{
 impl AuthenticationExtensionInstance for super::ExtensionInstanceSince0_16_0 {
     fn authenticate(
         &mut self,
+        _: SharedContext,
         headers: Lease<http::HeaderMap>,
     ) -> BoxFuture<'_, Result<(Lease<http::HeaderMap>, Token), ErrorResponse>> {
         Box::pin(async move {

--- a/crates/wasi-component-loader/src/extension/api/since_0_16_0/instance/authorization.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_16_0/instance/authorization.rs
@@ -2,7 +2,7 @@ use futures::future::BoxFuture;
 use runtime::extension::{AuthorizationDecisions, TokenRef};
 
 use crate::{
-    Error,
+    Error, SharedContext,
     extension::{
         AuthorizationExtensionInstance, QueryAuthorizationResult,
         api::wit::{Headers, QueryElements, ResponseElements, TokenParam},
@@ -13,6 +13,7 @@ use crate::{
 impl AuthorizationExtensionInstance for super::ExtensionInstanceSince0_16_0 {
     fn authorize_query<'a>(
         &'a mut self,
+        _: SharedContext,
         headers: Lease<http::HeaderMap>,
         token: TokenRef<'a>,
         elements: QueryElements<'a>,
@@ -48,6 +49,7 @@ impl AuthorizationExtensionInstance for super::ExtensionInstanceSince0_16_0 {
 
     fn authorize_response<'a>(
         &'a mut self,
+        _: SharedContext,
         state: &'a [u8],
         elements: ResponseElements<'a>,
     ) -> BoxFuture<'a, Result<AuthorizationDecisions, Error>> {

--- a/crates/wasi-component-loader/src/extension/api/since_0_17_0/instance/resolver.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_17_0/instance/resolver.rs
@@ -2,7 +2,7 @@ use engine_error::{ErrorCode, GraphqlError};
 use futures::future::BoxFuture;
 
 use crate::{
-    Error,
+    Error, SharedContext,
     extension::{
         ResolverExtensionInstance,
         api::wit::{ArgumentsId, Directive, Field, FieldId, Response, SubscriptionItem},
@@ -13,6 +13,7 @@ use crate::{
 impl ResolverExtensionInstance for super::ExtensionInstanceSince0_17_0 {
     fn prepare<'a>(
         &'a mut self,
+        context: SharedContext,
         subgraph_name: &'a str,
         directive: Directive<'a>,
         field_id: FieldId,
@@ -22,10 +23,13 @@ impl ResolverExtensionInstance for super::ExtensionInstanceSince0_17_0 {
             // Futures may be canceled, so we pro-actively mark the instance as poisoned until proven
             // otherwise.
             self.poisoned = true;
+
+            let context = self.store.data_mut().push_resource(context)?;
+
             let result = self
                 .inner
                 .grafbase_sdk_resolver()
-                .call_prepare(&mut self.store, subgraph_name, directive, field_id, fields)
+                .call_prepare(&mut self.store, context, subgraph_name, directive, field_id, fields)
                 .await?;
 
             self.poisoned = false;
@@ -35,6 +39,7 @@ impl ResolverExtensionInstance for super::ExtensionInstanceSince0_17_0 {
 
     fn resolve<'a>(
         &'a mut self,
+        context: SharedContext,
         headers: http::HeaderMap,
         prepared: &'a [u8],
         arguments: &'a [(ArgumentsId, &'a [u8])],
@@ -43,11 +48,14 @@ impl ResolverExtensionInstance for super::ExtensionInstanceSince0_17_0 {
             // Futures may be canceled, so we pro-actively mark the instance as poisoned until proven
             // otherwise.
             self.poisoned = true;
+
             let headers = self.store.data_mut().push_resource(Headers::from(headers))?;
+            let context = self.store.data_mut().push_resource(context)?;
+
             let response = self
                 .inner
                 .grafbase_sdk_resolver()
-                .call_resolve(&mut self.store, prepared, headers, arguments)
+                .call_resolve(&mut self.store, context, prepared, headers, arguments)
                 .await?;
 
             self.poisoned = false;
@@ -57,6 +65,7 @@ impl ResolverExtensionInstance for super::ExtensionInstanceSince0_17_0 {
 
     fn create_subscription<'a>(
         &'a mut self,
+        context: SharedContext,
         headers: http::HeaderMap,
         prepared: &'a [u8],
         arguments: &'a [(ArgumentsId, &'a [u8])],
@@ -65,24 +74,31 @@ impl ResolverExtensionInstance for super::ExtensionInstanceSince0_17_0 {
             // Futures may be canceled, so we pro-actively mark the instance as poisoned until proven
             // otherwise.
             self.poisoned = true;
+
             let headers = self.store.data_mut().push_resource(Headers::from(headers))?;
+            let context = self.store.data_mut().push_resource(context)?;
+
             let result = self
                 .inner
                 .grafbase_sdk_resolver()
-                .call_create_subscription(&mut self.store, prepared, headers, arguments)
+                .call_create_subscription(&mut self.store, context, prepared, headers, arguments)
                 .await?;
+
             // We don't remove poison flag here, as the subscription will be dropped later.
             Ok(result.map_err(|err| err.into_graphql_error(ErrorCode::ExtensionError)))
         })
     }
 
-    fn drop_subscription<'a>(&'a mut self) -> BoxFuture<'a, Result<(), Error>> {
+    fn drop_subscription<'a>(&'a mut self, context: SharedContext) -> BoxFuture<'a, Result<(), Error>> {
         // We don't need to poison here, as it's already poisoned by create_subscription
         Box::pin(async move {
+            let context = self.store.data_mut().push_resource(context)?;
+
             self.inner
                 .grafbase_sdk_resolver()
-                .call_drop_subscription(&mut self.store)
+                .call_drop_subscription(&mut self.store, context)
                 .await?;
+
             self.poisoned = false;
             Ok(())
         })
@@ -90,14 +106,18 @@ impl ResolverExtensionInstance for super::ExtensionInstanceSince0_17_0 {
 
     fn resolve_next_subscription_item(
         &mut self,
+        context: SharedContext,
     ) -> BoxFuture<'_, Result<Result<Option<SubscriptionItem>, GraphqlError>, Error>> {
         // We don't need to poison here, as it's already poisoned until we drop the subscription.
         Box::pin(async move {
+            let context = self.store.data_mut().push_resource(context)?;
+
             let result = self
                 .inner
                 .grafbase_sdk_resolver()
-                .call_resolve_next_subscription_item(&mut self.store)
+                .call_resolve_next_subscription_item(&mut self.store, context)
                 .await?;
+
             Ok(result.map_err(|err| err.into_graphql_error(ErrorCode::ExtensionError)))
         })
     }

--- a/crates/wasi-component-loader/src/extension/api/since_0_9_0/instance/authentication.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_9_0/instance/authentication.rs
@@ -2,7 +2,7 @@ use futures::future::BoxFuture;
 use runtime::extension::Token;
 
 use crate::{
-    ErrorResponse,
+    ErrorResponse, SharedContext,
     extension::AuthenticationExtensionInstance,
     resources::{Headers, Lease},
 };
@@ -10,6 +10,7 @@ use crate::{
 impl AuthenticationExtensionInstance for super::ExtensionInstanceSince090 {
     fn authenticate(
         &mut self,
+        _: SharedContext,
         headers: Lease<http::HeaderMap>,
     ) -> BoxFuture<'_, Result<(Lease<http::HeaderMap>, Token), ErrorResponse>> {
         Box::pin(async move {

--- a/crates/wasi-component-loader/src/extension/api/since_0_9_0/instance/authorization.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_9_0/instance/authorization.rs
@@ -3,7 +3,7 @@ use futures::future::BoxFuture;
 use runtime::extension::{AuthorizationDecisions, TokenRef};
 
 use crate::{
-    Error,
+    Error, SharedContext,
     extension::{
         AuthorizationExtensionInstance, QueryAuthorizationResult,
         api::wit::{QueryElements, ResponseElements},
@@ -14,6 +14,7 @@ use crate::{
 impl AuthorizationExtensionInstance for super::ExtensionInstanceSince090 {
     fn authorize_query<'a>(
         &'a mut self,
+        _: SharedContext,
         headers: Lease<http::HeaderMap>,
         token: TokenRef<'a>,
         elements: QueryElements<'a>,
@@ -48,6 +49,7 @@ impl AuthorizationExtensionInstance for super::ExtensionInstanceSince090 {
 
     fn authorize_response<'a>(
         &'a mut self,
+        _: SharedContext,
         _: &'a [u8],
         _: ResponseElements<'a>,
     ) -> BoxFuture<'a, Result<AuthorizationDecisions, Error>> {

--- a/crates/wasi-component-loader/src/extension/manager/instance/authentication.rs
+++ b/crates/wasi-component-loader/src/extension/manager/instance/authentication.rs
@@ -1,11 +1,12 @@
 use futures::future::BoxFuture;
 use runtime::extension::Token;
 
-use crate::{ErrorResponse, resources::Lease};
+use crate::{ErrorResponse, SharedContext, resources::Lease};
 
 pub(crate) trait AuthenticationExtensionInstance {
     fn authenticate(
         &mut self,
+        context: SharedContext,
         headers: Lease<http::HeaderMap>,
     ) -> BoxFuture<'_, Result<(Lease<http::HeaderMap>, Token), ErrorResponse>>;
 }

--- a/crates/wasi-component-loader/src/extension/manager/instance/authorization.rs
+++ b/crates/wasi-component-loader/src/extension/manager/instance/authorization.rs
@@ -2,7 +2,7 @@ use futures::future::BoxFuture;
 use runtime::extension::{AuthorizationDecisions, TokenRef};
 
 use crate::{
-    Error, ErrorResponse,
+    Error, ErrorResponse, SharedContext,
     extension::api::wit::{QueryElements, ResponseElements},
     resources::Lease,
 };
@@ -13,6 +13,7 @@ pub(crate) type QueryAuthorizationResult =
 pub(crate) trait AuthorizationExtensionInstance {
     fn authorize_query<'a>(
         &'a mut self,
+        context: SharedContext,
         headers: Lease<http::HeaderMap>,
         token: TokenRef<'a>,
         elements: QueryElements<'a>,
@@ -20,6 +21,7 @@ pub(crate) trait AuthorizationExtensionInstance {
 
     fn authorize_response<'a>(
         &'a mut self,
+        context: SharedContext,
         state: &'a [u8],
         elements: ResponseElements<'a>,
     ) -> BoxFuture<'a, Result<AuthorizationDecisions, Error>>;

--- a/crates/wasi-component-loader/src/extension/manager/instance/resolver.rs
+++ b/crates/wasi-component-loader/src/extension/manager/instance/resolver.rs
@@ -2,7 +2,7 @@ use engine_error::GraphqlError;
 use futures::future::BoxFuture;
 
 use crate::{
-    Error,
+    Error, SharedContext,
     extension::api::wit::{ArgumentsId, Directive, Field, FieldId, Response, SubscriptionItem},
 };
 
@@ -10,6 +10,7 @@ use crate::{
 pub(crate) trait ResolverExtensionInstance {
     fn prepare<'a>(
         &'a mut self,
+        context: SharedContext,
         subgraph_name: &'a str,
         directive: Directive<'a>,
         field_id: FieldId,
@@ -20,6 +21,7 @@ pub(crate) trait ResolverExtensionInstance {
 
     fn resolve<'a>(
         &'a mut self,
+        context: SharedContext,
         headers: http::HeaderMap,
         prepared: &'a [u8],
         arguments: &'a [(ArgumentsId, &'a [u8])],
@@ -30,6 +32,7 @@ pub(crate) trait ResolverExtensionInstance {
     #[allow(clippy::type_complexity)]
     fn create_subscription<'a>(
         &'a mut self,
+        context: SharedContext,
         headers: http::HeaderMap,
         prepared: &'a [u8],
         arguments: &'a [(ArgumentsId, &'a [u8])],
@@ -37,12 +40,13 @@ pub(crate) trait ResolverExtensionInstance {
         Box::pin(async { unreachable!("Not supported by this SDK") })
     }
 
-    fn drop_subscription<'a>(&'a mut self) -> BoxFuture<'a, Result<(), Error>> {
+    fn drop_subscription<'a>(&'a mut self, context: SharedContext) -> BoxFuture<'a, Result<(), Error>> {
         Box::pin(async { unreachable!("Not supported by this SDK") })
     }
 
     fn resolve_next_subscription_item(
         &mut self,
+        context: SharedContext,
     ) -> BoxFuture<'_, Result<Result<Option<SubscriptionItem>, GraphqlError>, Error>> {
         Box::pin(async { unreachable!("Not supported by this SDK") })
     }

--- a/crates/wasi-component-loader/src/extension/runtime/authentication.rs
+++ b/crates/wasi-component-loader/src/extension/runtime/authentication.rs
@@ -9,6 +9,7 @@ use runtime::extension::{AuthenticationExtension, Token};
 impl AuthenticationExtension<SharedContext> for WasmExtensions {
     async fn authenticate(
         &self,
+        context: &SharedContext,
         extension_ids: &[ExtensionId],
         gateway_headers: http::HeaderMap,
     ) -> (http::HeaderMap, Result<Token, ErrorResponse>) {
@@ -22,7 +23,7 @@ impl AuthenticationExtension<SharedContext> for WasmExtensions {
                 let mut instance = self.get(*id).await?;
 
                 instance
-                    .authenticate(Lease::Shared(headers.clone()))
+                    .authenticate(context.clone(), Lease::Shared(headers.clone()))
                     .await
                     .map(|(_, token)| token)
                     .map_err(|err| match err {

--- a/crates/wasi-component-loader/src/extension/runtime/resolver/subscription/unique.rs
+++ b/crates/wasi-component-loader/src/extension/runtime/resolver/subscription/unique.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use super::SubscriptionStream;
 use crate::{
-    Error,
+    Error, SharedContext,
     extension::{ExtensionGuard, api::wit::SubscriptionItem},
 };
 use engine_error::{ErrorCode, GraphqlError};
@@ -17,56 +17,63 @@ pub struct UniqueSubscription {
 }
 
 impl UniqueSubscription {
-    pub async fn resolve(self) -> SubscriptionStream<'static> {
+    pub async fn resolve(self, context: SharedContext) -> SubscriptionStream<'static> {
         let UniqueSubscription { instance } = self;
 
         stream::unfold(
-            (Some(instance), VecDeque::<Response>::new()),
-            async move |(instance, mut queue)| {
+            (Some(instance), VecDeque::<Response>::new(), context),
+            async move |(instance, mut queue, context)| {
                 let mut instance = instance?;
+
                 if let Some(response) = queue.pop_front() {
-                    return Some((response, (Some(instance), queue)));
+                    return Some((response, (Some(instance), queue, context)));
                 }
 
                 loop {
-                    let next = instance
-                        .resolve_next_subscription_item()
-                        .await
-                        .map_err(|err| match err {
-                            Error::Internal(err) => {
-                                tracing::error!("Wasm error: {err}");
-                                GraphqlError::new("Internal error", ErrorCode::ExtensionError)
-                            }
-                            Error::Guest(err) => err.into_graphql_error(ErrorCode::ExtensionError),
-                        });
+                    let next =
+                        instance
+                            .resolve_next_subscription_item(context.clone())
+                            .await
+                            .map_err(|err| match err {
+                                Error::Internal(err) => {
+                                    tracing::error!("Wasm error: {err}");
+                                    GraphqlError::new("Internal error", ErrorCode::ExtensionError)
+                                }
+                                Error::Guest(err) => err.into_graphql_error(ErrorCode::ExtensionError),
+                            });
 
                     match next {
                         Ok(Ok(Some(item))) => match item {
-                            SubscriptionItem::Single(resp) => return Some((resp.into(), (Some(instance), queue))),
+                            SubscriptionItem::Single(resp) => {
+                                return Some((resp.into(), (Some(instance), queue, context)));
+                            }
                             SubscriptionItem::Multiple(items) if items.is_empty() => continue,
                             SubscriptionItem::Multiple(items) => {
                                 queue.extend(items.into_iter().map(Into::into));
-                                return queue.pop_front().map(|resp| (resp, (Some(instance), queue)));
+                                return queue.pop_front().map(|resp| (resp, (Some(instance), queue, context)));
                             }
                         },
                         Ok(Ok(None)) => {
-                            if let Err(err) = instance.drop_subscription().await {
+                            if let Err(err) = instance.drop_subscription(context.clone()).await {
                                 tracing::error!("Error dropping subscription: {err}");
                             }
                             return None;
                         }
                         Ok(Err(err)) => {
-                            if let Err(err) = instance.drop_subscription().await {
+                            if let Err(err) = instance.drop_subscription(context.clone()).await {
                                 tracing::error!("Error dropping subscription: {err}");
                             }
-                            return Some((Response::error(err), (None, queue)));
+                            return Some((Response::error(err), (None, queue, context)));
                         }
                         Err(err) => {
                             tracing::error!("Error resolving subscription item: {err}");
-                            if let Err(err) = instance.drop_subscription().await {
+                            if let Err(err) = instance.drop_subscription(context.clone()).await {
                                 tracing::error!("Error dropping subscription: {err}");
                             }
-                            return Some((Response::error(GraphqlError::internal_extension_error()), (None, queue)));
+                            return Some((
+                                Response::error(GraphqlError::internal_extension_error()),
+                                (None, queue, context),
+                            ));
                         }
                     }
                 }


### PR DESCRIPTION
Next step: trickle the shared context object everywhere in extensions through the engine. We are still using the old hooks context, this should change in the next PR.