### PR TITLE
fix(engine): Handle nested resolvers within a subgraph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2816,6 +2816,7 @@ dependencies = [
  "futures",
  "futures-lite 2.6.0",
  "futures-util",
+ "fxhash",
  "grafbase-telemetry",
  "grafbase-workspace-hack",
  "headers",

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -26,6 +26,7 @@ fixedbitset.workspace = true
 futures.workspace = true
 futures-lite.workspace = true
 futures-util.workspace = true
+fxhash.workspace = true
 grafbase-telemetry.workspace = true
 grafbase-workspace-hack.workspace = true
 headers.workspace = true

--- a/crates/engine/codegen/domain/query_plan.graphql
+++ b/crates/engine/codegen/domain/query_plan.graphql
@@ -29,6 +29,7 @@ type QueryPartition @indexed(id_size: "u16") @meta(module: "query_partition") {
 
 type ResponseObjectSetDefinition @meta(module: "response_object_set") @indexed(id_size: "u16", deduplicated: true) {
   ty: CompositeType!
+  query_partition: [QueryPartition!]! @vec
 }
 
 # ----------------

--- a/crates/engine/schema/src/generated/resolver/lookup.rs
+++ b/crates/engine/schema/src/generated/resolver/lookup.rs
@@ -21,7 +21,7 @@ use walker::{Iter, Walk};
 ///   key: FieldSet!
 ///   field_definition: FieldDefinition!
 ///   resolver: ResolverDefinition!
-///   batch: Boolean!
+///   guest_batch: Boolean!
 ///   injections: [ArgumentInjection!]!
 /// }
 /// ```

--- a/crates/engine/src/prepare/cached/query_plan/generated/response_object_set.rs
+++ b/crates/engine/src/prepare/cached/query_plan/generated/response_object_set.rs
@@ -3,7 +3,10 @@
 //! ===================
 //! Generated with: `cargo run -p engine-codegen`
 //! Source file: <engine-codegen dir>/domain/query_plan.graphql
-use crate::prepare::cached::query_plan::prelude::*;
+use crate::prepare::cached::query_plan::{
+    generated::{QueryPartition, QueryPartitionId},
+    prelude::*,
+};
 use schema::{CompositeType, CompositeTypeId};
 #[allow(unused_imports)]
 use walker::{Iter, Walk};
@@ -13,11 +16,13 @@ use walker::{Iter, Walk};
 /// ```custom,{.language-graphql}
 /// type ResponseObjectSetDefinition @meta(module: "response_object_set") @indexed(id_size: "u16", deduplicated: true) {
 ///   ty: CompositeType!
+///   query_partition: [QueryPartition!]! @vec
 /// }
 /// ```
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct ResponseObjectSetDefinitionRecord {
     pub ty_id: CompositeTypeId,
+    pub query_partition_ids: Vec<QueryPartitionId>,
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, serde::Serialize, serde::Deserialize, id_derives::Id)]
@@ -46,6 +51,9 @@ impl<'a> ResponseObjectSetDefinition<'a> {
     pub(crate) fn ty(&self) -> CompositeType<'a> {
         self.ty_id.walk(self.ctx)
     }
+    pub(crate) fn query_partition(&self) -> impl Iter<Item = QueryPartition<'a>> + 'a {
+        self.as_ref().query_partition_ids.walk(self.ctx)
+    }
 }
 
 impl<'a> Walk<CachedOperationContext<'a>> for ResponseObjectSetDefinitionId {
@@ -69,6 +77,7 @@ impl std::fmt::Debug for ResponseObjectSetDefinition<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ResponseObjectSetDefinition")
             .field("ty", &self.ty())
+            .field("query_partition", &self.query_partition())
             .finish()
     }
 }

--- a/crates/integration-tests/src/gateway/runtime/extension/impls/resolver.rs
+++ b/crates/integration-tests/src/gateway/runtime/extension/impls/resolver.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use engine::GraphqlError;
+use engine::{ErrorCode, GraphqlError};
 use engine_schema::ExtensionDirective;
 use futures::{FutureExt as _, stream::BoxStream};
 use runtime::{
@@ -173,7 +173,12 @@ pub trait ResolverTestExtension: Send + Sync + 'static {
         directive_arguments: serde_json::Value,
         field: Box<dyn DynField<'ctx>>,
     ) -> Result<Vec<u8>, GraphqlError> {
-        Ok(Vec::new())
+        serde_json::to_vec(&directive_arguments).map_err(|e| {
+            GraphqlError::new(
+                format!("Failed to serialize directive arguments: {}", e),
+                ErrorCode::ExtensionError,
+            )
+        })
     }
 
     async fn resolve(

--- a/crates/integration-tests/tests/gateway/extensions/resolver/nested.rs
+++ b/crates/integration-tests/tests/gateway/extensions/resolver/nested.rs
@@ -1,0 +1,97 @@
+use integration_tests::{gateway::Gateway, runtime};
+
+#[test]
+fn nested_static_resolver() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl(
+                "a",
+                r#"
+                extend schema
+                    @link(url: "resolver-1.0.0", import: ["@resolve"])
+
+                scalar JSON
+
+                type Query {
+                    me: User @resolve(data: { id: "1", name: "Josh" })
+                }
+
+                type User {
+                    id: ID!
+                    name: String!
+                    friends: [User!]! @resolve(data: [{ id: "2", name: "Alice"}])
+                }
+                "#,
+            )
+            .with_extension(super::ResolverExt::echo_data())
+            .build()
+            .await;
+
+        let response = engine.post("query { me { id name friends { id name } } }").await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "me": {
+              "id": "1",
+              "name": "Josh",
+              "friends": [
+                {
+                  "id": "2",
+                  "name": "Alice"
+                }
+              ]
+            }
+          }
+        }
+        "#);
+    })
+}
+
+#[test]
+fn lookup_shouldnt_count_as_nested_resolver() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph_sdl(
+                "a",
+                r#"
+                extend schema
+                    @link(url: "resolver-1.0.0", import: ["@resolve"])
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key"])
+
+                scalar JSON
+
+                type Query {
+                    user(id: ID!): User @resolve(data: {}) @lookup
+                    me: User @resolve(data: { id: "1", name: "Josh" })
+                }
+
+                type User @key(fields: "id") {
+                    id: ID!
+                    name: String!
+                    friends: [User!]! @resolve(data: [{ id: "2", name: "Alice"}])
+                }
+                "#,
+            )
+            .with_extension(super::ResolverExt::echo_data())
+            .build()
+            .await;
+
+        let response = engine.post("query { me { id name friends { id name } } }").await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "me": {
+              "id": "1",
+              "name": "Josh",
+              "friends": [
+                {
+                  "id": "2",
+                  "name": "Alice"
+                }
+              ]
+            }
+          }
+        }
+        "#);
+    })
+}


### PR DESCRIPTION
Previously we wouldn't handle correctly the following:

```graphql
extend schema
    @link(url: "resolver-1.0.0", import: ["@resolve"])
scalar JSON
type Query {
    me: User @resolve(data: { id: "1", name: "Josh" })
}
type User {
    id: ID!
    name: String!
    friends: [User!]! @resolve(data: [{ id: "2", name: "Alice"}])
}
```

for two reasons:
- we would treat it like a graphql subgraph, meanings `friends` is part of the subgraph, so provideable by the resolver providing `Query.me` which obviously doesn't work here.
- We wouldn't correctly keep track of the dependency from `User.friends` on `Query.me` because there are no field dependencies involved here. We still need the `User` object to be present though.