### PR TITLE
release 0.97.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3893,7 +3893,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.97.0"
+version = "0.97.1"
 dependencies = [
  "anyhow",
  "askama",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.97.0"
+version = "0.97.1"
 name = "grafbase"
 description = "The Grafbase command line interface"
 categories = ["command-line-utilities"]

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.97.0",
+  "version": "0.97.1",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.97.0",
+  "version": "0.97.1",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.97.0",
+  "version": "0.97.1",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.97.0",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.97.0",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.97.0",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.97.0",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.97.0"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.97.1",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.97.1",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.97.1",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.97.1",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.97.1"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.97.0",
+  "version": "0.97.1",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.97.0",
+  "version": "0.97.1",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.97.0",
+  "version": "0.97.1",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
Dummy release as I yanked 0.97.0, but didn't know it would break the cli
install script...

I've yanked 0.97.0 because I'm changing the Grafbase SDK wit for the
rest example
