### PR TITLE
sdk: add headers to ErrorResponse

### DIFF
--- a/crates/engine/error/src/lib.rs
+++ b/crates/engine/error/src/lib.rs
@@ -10,6 +10,7 @@ use std::borrow::Cow;
 pub struct ErrorResponse {
     pub status: http::StatusCode,
     pub errors: Vec<GraphqlError>,
+    pub headers: http::HeaderMap,
 }
 
 impl ErrorResponse {
@@ -17,6 +18,7 @@ impl ErrorResponse {
         ErrorResponse {
             status,
             errors: Vec::new(),
+            headers: Default::default(),
         }
     }
 
@@ -31,6 +33,7 @@ impl From<GraphqlError> for ErrorResponse {
         ErrorResponse {
             status: error.code.into(),
             errors: vec![error],
+            headers: Default::default(),
         }
     }
 }

--- a/crates/engine/src/execution/request/errors.rs
+++ b/crates/engine/src/execution/request/errors.rs
@@ -52,7 +52,11 @@ pub(crate) fn not_well_formed_graphql_over_http_request(message: impl std::fmt::
 }
 
 pub(crate) fn refuse_request_with(status_code: http::StatusCode, message: impl Into<Cow<'static, str>>) -> Response {
-    Response::refuse_request_with(status_code, [GraphqlError::new(message, ErrorCode::BadRequest)])
+    Response::refuse_request_with(
+        status_code,
+        [GraphqlError::new(message, ErrorCode::BadRequest)],
+        Default::default(),
+    )
 }
 
 pub(crate) mod response {
@@ -65,6 +69,7 @@ pub(crate) mod response {
         Response::refuse_request_with(
             http::StatusCode::TOO_MANY_REQUESTS,
             [GraphqlError::new("Rate limited", ErrorCode::RateLimited)],
+            Default::default(),
         )
     }
 

--- a/crates/engine/src/execution/request/mod.rs
+++ b/crates/engine/src/execution/request/mod.rs
@@ -97,7 +97,7 @@ impl<R: Runtime> Engine<R> {
         {
             Ok((headers, token)) => (headers, token),
             Err(resp) => {
-                let response = Response::refuse_request_with(resp.status, resp.errors);
+                let response = Response::refuse_request_with(resp.status, resp.errors, resp.headers);
                 return Err(response);
             }
         };

--- a/crates/engine/src/prepare/mod.rs
+++ b/crates/engine/src/prepare/mod.rs
@@ -65,7 +65,11 @@ impl<R: Runtime> PrepareContext<'_, R> {
                 // If we have an error a this stage, it means we couldn't determine what document
                 // to load, so we don't consider it a well-formed GraphQL-over-HTTP request.
                 Err(err) => {
-                    return Err(Response::refuse_request_with(http::StatusCode::BAD_REQUEST, [err]));
+                    return Err(Response::refuse_request_with(
+                        http::StatusCode::BAD_REQUEST,
+                        [err],
+                        Default::default(),
+                    ));
                 }
             };
 
@@ -138,5 +142,6 @@ fn mutation_not_allowed_with_safe_method() -> Response {
             "Mutation is not allowed with a safe method like GET",
             ErrorCode::BadRequest,
         )],
+        Default::default(),
     )
 }

--- a/crates/engine/src/prepare/operation_plan/error.rs
+++ b/crates/engine/src/prepare/operation_plan/error.rs
@@ -8,7 +8,7 @@ pub(crate) type PlanResult<T> = std::result::Result<T, PlanError>;
 pub(crate) enum PlanError {
     Internal,
     GraphqlError(GraphqlError),
-    ErrorResponse(ErrorResponse),
+    ErrorResponse(Box<ErrorResponse>),
 }
 
 impl From<GraphqlError> for PlanError {
@@ -19,6 +19,6 @@ impl From<GraphqlError> for PlanError {
 
 impl From<ErrorResponse> for PlanError {
     fn from(err: ErrorResponse) -> Self {
-        PlanError::ErrorResponse(err)
+        PlanError::ErrorResponse(Box::new(err))
     }
 }

--- a/crates/engine/src/prepare/operation_plan/mod.rs
+++ b/crates/engine/src/prepare/operation_plan/mod.rs
@@ -32,6 +32,13 @@ pub async fn plan(
             ErrorCode::OperationPlanningError,
         )]),
         PlanError::GraphqlError(error) => Response::request_error([error]),
-        PlanError::ErrorResponse(ErrorResponse { status, errors }) => Response::refuse_request_with(status, errors),
+        PlanError::ErrorResponse(error_response) => {
+            let ErrorResponse {
+                status,
+                errors,
+                headers,
+            } = *error_response;
+            Response::refuse_request_with(status, errors, headers)
+        }
     })
 }

--- a/crates/engine/src/response/mod.rs
+++ b/crates/engine/src/response/mod.rs
@@ -77,6 +77,7 @@ pub(crate) struct RefusedRequestResponse {
     errors: Vec<GraphqlError>,
     error_code_counter: ErrorCodeCounter,
     extensions: ResponseExtensions,
+    pub(crate) headers: http::HeaderMap,
 }
 
 impl RefusedRequestResponse {
@@ -89,6 +90,7 @@ impl Response {
     pub(crate) fn refuse_request_with(
         status: http::StatusCode,
         errors: impl IntoIterator<Item = impl Into<GraphqlError>>,
+        headers: http::HeaderMap,
     ) -> Self {
         let mut error_code_counter = ErrorCodeCounter::default();
 
@@ -107,6 +109,7 @@ impl Response {
             errors,
             error_code_counter,
             extensions: Default::default(),
+            headers,
         })
     }
 

--- a/crates/grafbase-sdk/src/types/error_response.rs
+++ b/crates/grafbase-sdk/src/types/error_response.rs
@@ -56,6 +56,24 @@ impl ErrorResponse {
     pub fn push_error(&mut self, error: impl Into<Error>) {
         self.0.errors.push(Into::<Error>::into(error).into());
     }
+
+    /// Add a header to the error response.
+    pub fn push_header(&mut self, name: &str, value: &[u8]) -> Result<(), wit::HeaderError> {
+        let headers = if let Some(headers) = self.0.headers.take() {
+            headers
+        } else {
+            wit::Headers::new()
+        };
+        headers.append(name, value)?;
+        self.0.headers = Some(headers);
+        Ok(())
+    }
+
+    /// Add a header to the error response.
+    pub fn with_header(mut self, name: &str, value: &[u8]) -> Result<Self, wit::HeaderError> {
+        self.push_header(name, value)?;
+        Ok(self)
+    }
 }
 
 impl From<Error> for ErrorResponse {

--- a/crates/integration-tests/data/extensions/Cargo.lock
+++ b/crates/integration-tests/data/extensions/Cargo.lock
@@ -541,6 +541,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "auth-017"
+version = "0.1.0"
+dependencies = [
+ "grafbase-sdk 0.17.3",
+ "serde",
+]
+
+[[package]]
 name = "auth-09"
 version = "0.1.0"
 dependencies = [

--- a/crates/integration-tests/data/extensions/crates/auth-017/.gitignore
+++ b/crates/integration-tests/data/extensions/crates/auth-017/.gitignore
@@ -1,0 +1,3 @@
+target
+build
+.build.lock

--- a/crates/integration-tests/data/extensions/crates/auth-017/Cargo.toml
+++ b/crates/integration-tests/data/extensions/crates/auth-017/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "auth-017"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0"
+
+[lib]
+crate-type = ["cdylib"]
+
+[profile.release]
+opt-level = "z"
+strip = true
+lto = true
+codegen-units = 1
+
+[dependencies]
+grafbase-sdk.workspace = true
+serde = { version = "1", features = ["derive"] }

--- a/crates/integration-tests/data/extensions/crates/auth-017/extension.toml
+++ b/crates/integration-tests/data/extensions/crates/auth-017/extension.toml
@@ -1,0 +1,17 @@
+[extension]
+name = "auth-017"
+version = "0.1.0"
+type = "authentication"
+description = "A new extension"
+# homepage_url = "https://example.com/my-extension"
+# repository_url = "https://github.com/my-username/my-extension"
+# license = "MIT"
+
+# These are the default permissions for the extension.
+# The user can enable or disable them as needed in the gateway
+# configuration file.
+[permissions]
+network = false
+stdout = false
+stderr = false
+environment_variables = false

--- a/crates/integration-tests/data/extensions/crates/auth-017/src/lib.rs
+++ b/crates/integration-tests/data/extensions/crates/auth-017/src/lib.rs
@@ -1,0 +1,72 @@
+use grafbase_sdk::{
+    AuthenticationExtension,
+    host_io::{
+        cache::{self, CachedItem},
+        http::StatusCode,
+    },
+    types::{Configuration, Error, ErrorResponse, GatewayHeaders, Token},
+};
+
+#[derive(AuthenticationExtension)]
+struct CachingProvider {
+    config: ProviderConfig,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(default)]
+struct ProviderConfig {
+    header_name: String,
+    cache_key_prefix: String,
+}
+
+impl Default for ProviderConfig {
+    fn default() -> Self {
+        Self {
+            header_name: "Authorization".to_owned(),
+            cache_key_prefix: "test".to_owned(),
+        }
+    }
+}
+
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+struct Jwks {
+    key: String,
+}
+
+impl AuthenticationExtension for CachingProvider {
+    fn new(config: Configuration) -> Result<Self, Error> {
+        let config: Option<ProviderConfig> = config.deserialize()?;
+
+        Ok(Self {
+            config: config.unwrap_or_default(),
+        })
+    }
+
+    fn authenticate(&mut self, headers: &GatewayHeaders) -> Result<Token, ErrorResponse> {
+        let auth = headers.get(&self.config.header_name).ok_or_else(|| {
+            ErrorResponse::new(StatusCode::UNAUTHORIZED)
+                .with_error(Error::new("Not passing through on my watch! SDK-017"))
+                .with_header("Www-Authenticate", b"Bearer test_author=grafbase")
+                .unwrap()
+        })?;
+
+        let auth = auth.to_str().unwrap();
+
+        let value = headers
+            .get("value")
+            .map(|value| value.to_str().unwrap().to_owned())
+            .unwrap_or_else(|| String::from("default"));
+
+        let cache_key = format!("{}:{auth}", self.config.cache_key_prefix);
+
+        let jwks: Jwks = cache::get(&cache_key, || {
+            let jwks = Jwks { key: value };
+            let item = CachedItem::new(jwks, None);
+
+            Ok(item)
+        })
+        .unwrap();
+
+        Ok(Token::from_bytes(format!("sdk017:{auth}:{}", jwks.key).into()))
+    }
+}

--- a/crates/integration-tests/tests/gateway/extensions/authentication/headers.rs
+++ b/crates/integration-tests/tests/gateway/extensions/authentication/headers.rs
@@ -1,0 +1,72 @@
+use graphql_mocks::{EchoSchema, Schema as _};
+use integration_tests::{
+    gateway::{AuthorizationExt, Gateway},
+    runtime,
+};
+
+use crate::gateway::extensions::authorization::InsertTokenAsHeader;
+
+#[test]
+fn authorization_failure_with_response_header_from_extension() {
+    runtime().block_on(async move {
+        let engine = Gateway::builder()
+            .with_subgraph(EchoSchema.with_sdl(
+                r#"
+                extend schema @link(url: "authorization-1.0.0", import: ["@auth"])
+
+                type Query {
+                    header(name: String): String @auth
+                }
+                "#,
+            ))
+            .with_extension(AuthorizationExt::new(InsertTokenAsHeader))
+            .with_extension("auth-017")
+            .with_toml_config(
+                r#"
+                [extensions.auth-017.config]
+                header_name = "auth017"
+                "#,
+            )
+            .build()
+            .await;
+
+        let response = engine.post(r#"query { header(name: "token") }"#).await;
+
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "errors": [
+            {
+              "message": "Not passing through on my watch! SDK-017",
+              "extensions": {
+                "code": "UNAUTHENTICATED"
+              }
+            }
+          ]
+        }
+        "#);
+
+        insta::assert_debug_snapshot!(response.headers, @r#"
+        {
+            "content-type": "application/json",
+            "www-authenticate": "Bearer test_author=grafbase",
+            "content-length": "107",
+            "vary": "accept-encoding",
+            "vary": "origin, access-control-request-method, access-control-request-headers",
+            "access-control-allow-origin": "*",
+            "access-control-expose-headers": "*",
+        }
+        "#);
+
+        let response = engine
+            .post(r#"query { header(name: "token") }"#)
+            .header("auth017", "valid")
+            .await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "header": "sdk017:valid:default"
+          }
+        }
+        "#);
+    });
+}

--- a/crates/integration-tests/tests/gateway/extensions/authentication/mod.rs
+++ b/crates/integration-tests/tests/gateway/extensions/authentication/mod.rs
@@ -1,4 +1,5 @@
 mod backwards_compatibility;
 mod default;
+mod headers;
 mod multiple;
 pub mod static_token;

--- a/crates/integration-tests/tests/gateway/extensions/authorization/error_response.rs
+++ b/crates/integration-tests/tests/gateway/extensions/authorization/error_response.rs
@@ -22,6 +22,7 @@ impl AuthorizationTestExtension for Failure {
         Err(ErrorResponse {
             status: http::StatusCode::UNAUTHORIZED,
             errors: vec![GraphqlError::unauthorized()],
+            headers: Default::default(),
         })
     }
 }

--- a/crates/wasi-component-loader/src/error.rs
+++ b/crates/wasi-component-loader/src/error.rs
@@ -1,4 +1,5 @@
 use engine_error::ErrorCode;
+use wasmtime::Store;
 
 use crate::extension::api::wit;
 
@@ -9,32 +10,67 @@ pub enum ErrorResponse {
     #[error("{0}")]
     Internal(#[from] anyhow::Error),
     /// Error defined by the guest.
-    #[error("{0}")]
-    Guest(#[from] wit::ErrorResponse),
+    #[error("status code: {status_code:?}, errors: {errors:?}, headers: {headers:?}")]
+    Guest {
+        status_code: http::StatusCode,
+        errors: Vec<wit::Error>,
+        headers: http::HeaderMap,
+    },
+}
+
+impl ErrorResponse {
+    pub(crate) fn from_wit(store: &mut Store<crate::state::WasiState>, error: wit::ErrorResponse) -> Self {
+        let headers = if let Some(resource) = error.headers {
+            match store
+                .data_mut()
+                .take_resource::<crate::resources::WasmOwnedOrLease<http::HeaderMap>>(resource.rep())
+            {
+                Ok(headers) => headers.into_inner().unwrap(),
+                Err(err) => return Self::Internal(err.into()),
+            }
+        } else {
+            Default::default()
+        };
+
+        ErrorResponse::Guest {
+            status_code: http::StatusCode::from_u16(error.status_code)
+                .unwrap_or(http::StatusCode::INTERNAL_SERVER_ERROR),
+            errors: error.errors,
+            headers,
+        }
+    }
+
+    pub(crate) fn into_graphql_error_response(self, code: ErrorCode) -> engine_error::ErrorResponse {
+        match self {
+            ErrorResponse::Internal(error) => {
+                tracing::error!("Wasm error: {error}");
+                engine_error::ErrorResponse::from(engine_error::GraphqlError::new(
+                    "Internal error",
+                    ErrorCode::ExtensionError,
+                ))
+            }
+            ErrorResponse::Guest {
+                status_code,
+                errors,
+                headers,
+            } => engine_error::ErrorResponse {
+                status: status_code,
+                errors: errors.into_iter().map(|err| err.into_graphql_error(code)).collect(),
+                headers,
+            },
+        }
+    }
 }
 
 impl From<Error> for ErrorResponse {
     fn from(value: Error) -> Self {
         match value {
             Error::Internal(error) => ErrorResponse::Internal(error),
-            Error::Guest(error) => ErrorResponse::Guest(wit::ErrorResponse {
-                status_code: 500,
+            Error::Guest(error) => ErrorResponse::Guest {
+                status_code: http::StatusCode::INTERNAL_SERVER_ERROR,
                 errors: vec![error],
-                headers: None,
-            }),
-        }
-    }
-}
-
-impl wit::ErrorResponse {
-    pub(crate) fn into_graphql_error_response(self, code: ErrorCode) -> engine_error::ErrorResponse {
-        engine_error::ErrorResponse {
-            status: http::StatusCode::from_u16(self.status_code).unwrap_or(http::StatusCode::INTERNAL_SERVER_ERROR),
-            errors: self
-                .errors
-                .into_iter()
-                .map(|err| err.into_graphql_error(code))
-                .collect(),
+                headers: Default::default(),
+            },
         }
     }
 }

--- a/crates/wasi-component-loader/src/extension/api/since_0_17_0/instance/authentication.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_17_0/instance/authentication.rs
@@ -38,7 +38,7 @@ impl AuthenticationExtensionInstance for super::ExtensionInstanceSince0_17_0 {
 
             self.poisoned = false;
 
-            let token = result?;
+            let token = result.map_err(|err| ErrorResponse::from_wit(&mut self.store, err))?;
             Ok((headers, token.into()))
         })
     }

--- a/crates/wasi-component-loader/src/extension/api/since_0_17_0/instance/authorization.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_17_0/instance/authorization.rs
@@ -2,7 +2,7 @@ use futures::future::BoxFuture;
 use runtime::extension::{AuthorizationDecisions, TokenRef};
 
 use crate::{
-    Error, SharedContext,
+    Error, ErrorResponse, SharedContext,
     extension::{
         AuthorizationExtensionInstance, QueryAuthorizationResult,
         api::wit::{Headers, QueryElements, ResponseElements, TokenParam},
@@ -46,7 +46,7 @@ impl AuthorizationExtensionInstance for super::ExtensionInstanceSince0_17_0 {
 
             result
                 .map(|(decisions, state)| (headers, decisions.into(), state))
-                .map_err(Into::into)
+                .map_err(|err| ErrorResponse::from_wit(&mut self.store, err))
         })
     }
 

--- a/crates/wasi-component-loader/src/extension/api/since_0_17_0/instance/hooks.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_17_0/instance/hooks.rs
@@ -57,7 +57,7 @@ impl HooksInstance for super::ExtensionInstanceSince0_17_0 {
 
             self.poisoned = false;
 
-            result?;
+            result.map_err(|err| ErrorResponse::from_wit(&mut self.store, err))?;
 
             Ok(parts)
         })

--- a/crates/wasi-component-loader/src/extension/api/since_0_17_0/wit/error.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_17_0/wit/error.rs
@@ -1,6 +1,5 @@
-use engine_error::{ErrorCode, GraphqlError};
-
 use crate::{cbor, state::WasiState};
+use engine_error::{ErrorCode, GraphqlError};
 
 pub use super::grafbase::sdk::error::*;
 
@@ -38,11 +37,5 @@ impl From<crate::extension::api::since_0_9_0::wit::error::ErrorResponse> for Err
 impl From<crate::extension::api::since_0_9_0::wit::error::Error> for crate::Error {
     fn from(value: crate::extension::api::since_0_9_0::wit::error::Error) -> Self {
         Error::from(value).into()
-    }
-}
-
-impl From<crate::extension::api::since_0_9_0::wit::error::ErrorResponse> for crate::ErrorResponse {
-    fn from(value: crate::extension::api::since_0_9_0::wit::error::ErrorResponse) -> Self {
-        ErrorResponse::from(value).into()
     }
 }

--- a/crates/wasi-component-loader/src/extension/api/since_0_9_0/wit/error.rs
+++ b/crates/wasi-component-loader/src/extension/api/since_0_9_0/wit/error.rs
@@ -14,3 +14,14 @@ impl Error {
         }))
     }
 }
+
+impl From<ErrorResponse> for crate::ErrorResponse {
+    fn from(value: crate::extension::api::since_0_9_0::wit::error::ErrorResponse) -> Self {
+        crate::ErrorResponse::Guest {
+            status_code: http::StatusCode::from_u16(value.status_code)
+                .unwrap_or(http::StatusCode::INTERNAL_SERVER_ERROR),
+            errors: value.errors.into_iter().map(From::from).collect(),
+            headers: Default::default(),
+        }
+    }
+}

--- a/crates/wasi-component-loader/src/extension/runtime/authorization.rs
+++ b/crates/wasi-component-loader/src/extension/runtime/authorization.rs
@@ -106,15 +106,7 @@ impl AuthorizationExtension<SharedContext> for WasmExtensions {
                                 },
                                 (extension_id, state),
                             )),
-                            Err(err) => Err(match err {
-                                crate::ErrorResponse::Internal(err) => {
-                                    tracing::error!("Wasm error: {err}");
-                                    ErrorResponse::from(GraphqlError::new("Internal error", ErrorCode::ExtensionError))
-                                }
-                                crate::ErrorResponse::Guest(err) => {
-                                    err.into_graphql_error_response(ErrorCode::Unauthorized)
-                                }
-                            }),
+                            Err(err) => Err(err.into_graphql_error_response(ErrorCode::Unauthorized)),
                         }
                     },
                 )

--- a/crates/wasi-component-loader/src/extension/runtime/hooks.rs
+++ b/crates/wasi-component-loader/src/extension/runtime/hooks.rs
@@ -27,20 +27,13 @@ impl HooksExtension for WasmHooks {
                 e.to_string(),
                 engine_error::ErrorCode::ExtensionError,
             )],
+            headers: Default::default(),
         })?;
 
-        instance.on_request(context.clone(), parts).await.map_err(|e| match e {
-            crate::ErrorResponse::Internal(err) => ErrorResponse {
-                status: http::StatusCode::INTERNAL_SERVER_ERROR,
-                errors: vec![engine_error::GraphqlError::new(
-                    err.to_string(),
-                    engine_error::ErrorCode::ExtensionError,
-                )],
-            },
-            crate::ErrorResponse::Guest(err) => {
-                err.into_graphql_error_response(engine_error::ErrorCode::ExtensionError)
-            }
-        })
+        instance
+            .on_request(context.clone(), parts)
+            .await
+            .map_err(|e| e.into_graphql_error_response(engine_error::ErrorCode::ExtensionError))
     }
 
     async fn on_response(&self, context: &Self::Context, parts: response::Parts) -> Result<response::Parts, String> {

--- a/crates/wasi-component-loader/src/tests/extensions.rs
+++ b/crates/wasi-component-loader/src/tests/extensions.rs
@@ -118,13 +118,11 @@ async fn single_call_caching_auth_invalid() {
 
     insta::assert_debug_snapshot!(err, @r#"
     Some(
-        Guest(
-            ErrorResponse {
-                status-code: 401,
-                errors: [],
-                headers: None,
-            },
-        ),
+        Guest {
+            status_code: 401,
+            errors: [],
+            headers: {},
+        },
     )
     "#);
 }

--- a/gateway/tests/hooks/mod.rs
+++ b/gateway/tests/hooks/mod.rs
@@ -82,6 +82,6 @@ fn extension_loads_and_passes_headers() {
         }
         "###);
 
-        dbg!(server.received_requests().await);
+        server.received_requests().await;
     });
 }


### PR DESCRIPTION
Allows e.g. authentication extensions to return error responses with headers like `WWW-Authenticate`.