### PR TITLE
fix(gb-9252): path issues with extension building

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.98.0"
+version = "0.98.1"
 dependencies = [
  "anyhow",
  "askama",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.98.0"
+version = "0.98.1"
 name = "grafbase"
 description = "The Grafbase command line interface"
 categories = ["command-line-utilities"]

--- a/cli/changelog/0.98.1.md
+++ b/cli/changelog/0.98.1.md
@@ -1,0 +1,3 @@
+### Fixes
+
+- Resolve path issues with extension build --source-dir flag

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.98.0",
+  "version": "0.98.1",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.98.0",
+  "version": "0.98.1",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.98.0",
+  "version": "0.98.1",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.98.0",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.98.0",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.98.0",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.98.0",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.98.0"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.98.1",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.98.1",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.98.1",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.98.1",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.98.1"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.98.0",
+  "version": "0.98.1",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.98.0",
+  "version": "0.98.1",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.98.0",
+  "version": "0.98.1",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/tests/extension/mod.rs
+++ b/cli/tests/extension/mod.rs
@@ -509,3 +509,120 @@ fn use_latest_grafbase_sdk_in_cargo_toml(project_path: &Path) {
 
     std::fs::write(project_path.join("Cargo.toml"), cargo_toml.as_ref()).unwrap();
 }
+
+#[test]
+fn build_with_source_dir() {
+    // FIXME: Make this test work on windows, linux arm64 and darwin x86.
+    if cfg!(windows)
+        || (cfg!(target_arch = "aarch64") && cfg!(target_os = "linux"))
+        || (cfg!(target_arch = "x86_64") && cfg!(target_os = "macos"))
+    {
+        return;
+    }
+
+    let temp_dir = tempdir().unwrap();
+    let extension_path = temp_dir.path().join("my_extension");
+    let extension_path_str = extension_path.to_string_lossy();
+
+    // Initialize extension in a subdirectory
+    let args = vec!["extension", "init", "--type", "resolver", &*extension_path_str];
+    let command = cmd(cargo_bin("grafbase"), &args).stdout_null().stderr_null();
+    command.run().unwrap();
+
+    use_latest_grafbase_sdk_in_cargo_toml(&extension_path);
+
+    // Build from parent directory using --source-dir
+    let args = vec!["extension", "build", "--source-dir", "my_extension"];
+
+    let result = cmd(cargo_bin("grafbase"), &args)
+        .env("RUSTFLAGS", "")
+        .dir(temp_dir.path())
+        .unchecked()
+        .stdout_capture()
+        .stderr_capture()
+        .run()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "{}\n{}",
+        String::from_utf8_lossy(&result.stdout),
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    // Verify the build artifacts exist in the default build directory
+    let build_path = temp_dir.path().join("build");
+    assert!(std::fs::exists(build_path.join("extension.wasm")).unwrap());
+    assert!(std::fs::exists(build_path.join("manifest.json")).unwrap());
+
+    // Verify that the target directory was created in the source directory, not nested
+    let target_path = extension_path.join("target");
+    assert!(target_path.exists());
+
+    // Verify that no nested directory structure was created
+    let nested_path = extension_path.join("my_extension").join("target");
+    assert!(!nested_path.exists());
+}
+
+#[test]
+fn build_with_source_dir_and_scratch_dir() {
+    // FIXME: Make this test work on windows, linux arm64 and darwin x86.
+    if cfg!(windows)
+        || (cfg!(target_arch = "aarch64") && cfg!(target_os = "linux"))
+        || (cfg!(target_arch = "x86_64") && cfg!(target_os = "macos"))
+    {
+        return;
+    }
+
+    let temp_dir = tempdir().unwrap();
+    let extension_path = temp_dir.path().join("my_extension");
+    let extension_path_str = extension_path.to_string_lossy();
+
+    // Initialize extension in a subdirectory
+    let args = vec!["extension", "init", "--type", "resolver", &*extension_path_str];
+    let command = cmd(cargo_bin("grafbase"), &args).stdout_null().stderr_null();
+    command.run().unwrap();
+
+    use_latest_grafbase_sdk_in_cargo_toml(&extension_path);
+
+    // Build from parent directory using both --source-dir and --scratch-dir
+    let args = vec![
+        "extension",
+        "build",
+        "--source-dir",
+        "my_extension",
+        "--scratch-dir",
+        "my_extension/custom_target",
+    ];
+
+    let result = cmd(cargo_bin("grafbase"), &args)
+        .env("RUSTFLAGS", "")
+        .dir(temp_dir.path())
+        .unchecked()
+        .stdout_capture()
+        .stderr_capture()
+        .run()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "{}\n{}",
+        String::from_utf8_lossy(&result.stdout),
+        String::from_utf8_lossy(&result.stderr)
+    );
+
+    // Verify the build artifacts exist in the default build directory
+    let build_path = temp_dir.path().join("build");
+    assert!(std::fs::exists(build_path.join("extension.wasm")).unwrap());
+    assert!(std::fs::exists(build_path.join("manifest.json")).unwrap());
+
+    // Verify that the custom target directory was created in the right place
+    let custom_target_path = extension_path.join("custom_target");
+    assert!(custom_target_path.exists());
+
+    // Verify that no nested directory structure was created
+    let nested_path = extension_path.join("my_extension").join("custom_target");
+    assert!(!nested_path.exists(), "Nested directory structure should not exist");
+
+    // Also verify no "my_extension/my_extension" directory was created
+    let double_nested = extension_path.join("my_extension");
+    assert!(!double_nested.exists(), "Double nested directory should not exist");
+}

--- a/cli/tests/integration/data/Cargo.lock
+++ b/cli/tests/integration/data/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "chrono",
  "document-features",

--- a/crates/integration-tests/data/extensions/Cargo.lock
+++ b/crates/integration-tests/data/extensions/Cargo.lock
@@ -544,7 +544,7 @@ dependencies = [
 name = "auth-017"
 version = "0.1.0"
 dependencies = [
- "grafbase-sdk 0.17.4",
+ "grafbase-sdk 0.17.5",
  "serde",
  "serde_json",
 ]
@@ -571,7 +571,7 @@ dependencies = [
 name = "authenticated"
 version = "0.1.0"
 dependencies = [
- "grafbase-sdk 0.17.4",
+ "grafbase-sdk 0.17.5",
  "serde",
  "serde_json",
 ]
@@ -2195,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-sdk"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "async-tungstenite",
@@ -2809,7 +2809,7 @@ name = "hooks"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
- "grafbase-sdk 0.17.4",
+ "grafbase-sdk 0.17.5",
  "indoc",
  "insta",
  "serde",
@@ -3988,7 +3988,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 name = "placeholder"
 version = "0.1.0"
 dependencies = [
- "grafbase-sdk 0.17.4",
+ "grafbase-sdk 0.17.5",
  "serde",
  "serde_json",
 ]
@@ -4586,7 +4586,7 @@ dependencies = [
 name = "resolver-17"
 version = "0.1.0"
 dependencies = [
- "grafbase-sdk 0.17.4",
+ "grafbase-sdk 0.17.5",
  "serde",
  "serde_json",
 ]

--- a/crates/integration-tests/data/extensions/Cargo.toml
+++ b/crates/integration-tests/data/extensions/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = ["crates/*"]
+exclude = ["crates/build"]
 
 [workspace.package]
 version = "0.1.0"


### PR DESCRIPTION
This commit fixes multiple path resolution issues when using the `grafbase extension build` command with the --source-dir flag:

1. **Fixed default scratch_dir path resolution**: When using --source-dir without --scratch-dir, the default "./target" directory is now correctly resolved relative to the source directory rather than the current working directory.

2. **Fixed nested directory creation**: When explicitly providing both --source-dir and --scratch-dir with relative paths, the CLI no longer creates nested directory structures (e.g., "extension/extension/target"). This is achieved by converting relative paths to absolute paths before passing them to cargo.

3. **Fixed workspace configuration**: Excluded the empty "crates/build" directory from the integration test workspace to prevent cargo manifest resolution errors.

The changes ensure that:
- `grafbase extension build --source-dir path/to/extension` works correctly
- Build artifacts are created in the expected locations
- No nested directory structures are created
- All existing functionality remains unchanged

Added comprehensive tests to verify the fix handles both default and explicit scratch directory scenarios.

Fixes customer-reported issue where wasm build artifacts were created in the wrong location when using --source-dir.