### PR TITLE
rmcp: use released version instead of git dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8218,8 +8218,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.1.5"
-source = "git+https://github.com/modelcontextprotocol/rust-sdk#d1884fe598cd4c524ff6e0101859a60d4b4c8b8f"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37f2048a81a7ff7e8ef6bc5abced70c3d9114c8f03d85d7aaaafd9fd04f12e9e"
 dependencies = [
  "axum 0.8.3",
  "base64 0.22.1",
@@ -8249,9 +8250,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.1.5"
-source = "git+https://github.com/modelcontextprotocol/rust-sdk#d1884fe598cd4c524ff6e0101859a60d4b4c8b8f"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72398e694b9f6dbb5de960cf158c8699e6a1854cb5bbaac7de0646b2005763c4"
 dependencies = [
+ "darling",
  "proc-macro2",
  "quote",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,7 @@ redis = { version = "0.30.0", features = [
 regex = "1.11.1"
 reqwest = { version = "0.12.15", default-features = false, features = ["http2", "rustls-tls"] }
 reqwest-eventsource = "0.6"
-rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", features = [
+rmcp = { version = "0.2.1", features = [
     "transport-sse-server",
     "transport-streamable-http-server",
     "client",

--- a/crates/integration-tests/tests/gateway/mcp/basic.rs
+++ b/crates/integration-tests/tests/gateway/mcp/basic.rs
@@ -39,7 +39,7 @@ fn server_info() {
         },
         "serverInfo": {
           "name": "rmcp",
-          "version": "0.1.5"
+          "version": "0.2.1"
         },
         "instructions": null
       }


### PR DESCRIPTION
2.0 and 2.1 were just released last week.