### PR TITLE
 cli: add subgraph owners to data.json for grafbase dev app

### DIFF
--- a/cli/changelog/unreleased.md
+++ b/cli/changelog/unreleased.md
@@ -1,0 +1,3 @@
+# Improvements
+
+- The subgraph owners are now shown for subgraphs that are loaded from the schema registry in the `grafbase dev` app.

--- a/cli/src/api/graphql/types/queries/subgraph_schemas_by_branch.rs
+++ b/cli/src/api/graphql/types/queries/subgraph_schemas_by_branch.rs
@@ -24,4 +24,10 @@ pub struct Subgraph {
     pub name: String,
     pub schema: String,
     pub url: Option<String>,
+    pub owners: Option<Vec<Team>>,
+}
+
+#[derive(cynic::QueryFragment, Debug, Clone)]
+pub struct Team {
+    pub name: String,
 }

--- a/cli/src/dev/data_json.rs
+++ b/cli/src/dev/data_json.rs
@@ -51,6 +51,7 @@ where
             let mut map = serializer.serialize_map(Some(2))?;
             map.serialize_entry("name", &self.0.name)?;
             map.serialize_entry("schema", &self.0.sdl)?;
+            map.serialize_entry("owners", &self.0.owners)?;
             map.end()
         }
     }

--- a/cli/src/dev/hot_reload/subgraph_watcher.rs
+++ b/cli/src/dev/hot_reload/subgraph_watcher.rs
@@ -115,6 +115,7 @@ impl SubgraphWatcher {
                                         sdl,
                                         name: cached_local_subgraph.subgraph.name.clone(),
                                         url: cached_local_subgraph.subgraph.url.clone(),
+                                        owners: None,
                                     }),
                                     ..(*cached_local_subgraph).clone()
                                 },

--- a/cli/src/dev/subgraphs.rs
+++ b/cli/src/dev/subgraphs.rs
@@ -41,6 +41,12 @@ pub(crate) struct CachedSubgraph {
     pub(crate) name: String,
     pub(crate) sdl: String,
     pub(crate) url: Option<String>,
+    pub(crate) owners: Option<Vec<SubgraphOwner>>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub(crate) struct SubgraphOwner {
+    pub(crate) name: String,
 }
 
 pub(crate) struct SubgraphCache {
@@ -97,6 +103,12 @@ impl SubgraphCache {
                         name: subgraph.name,
                         sdl: subgraph.schema,
                         url: subgraph.url,
+                        owners: subgraph.owners.map(|owners| {
+                            owners
+                                .into_iter()
+                                .map(|team| SubgraphOwner { name: team.name })
+                                .collect()
+                        }),
                     })
                 })
                 .collect::<Vec<_>>();
@@ -353,6 +365,7 @@ async fn handle_overridden_subgraph(
             name: name.to_owned(),
             sdl,
             url,
+            owners: None,
         }))
     } else if let Some(introspection_url) = subgraph.introspection_url.as_ref().or(parsed_url.as_ref()) {
         let headers: Vec<(&String, &String)> = subgraph
@@ -375,6 +388,7 @@ async fn handle_overridden_subgraph(
                 name: name.to_owned(),
                 sdl,
                 url: url.clone(),
+                owners: None,
             }),
         }))
     } else {


### PR DESCRIPTION
Only for subgraphs loaded from the schema registry.

closes GB-9274