### PR TITLE
cli: error in extension commands when config is not found

### DIFF
--- a/cli/changelog/unreleased.md
+++ b/cli/changelog/unreleased.md
@@ -1,3 +1,4 @@
 # Improvements
 
 - The subgraph owners are now shown for subgraphs that are loaded from the schema registry in the `grafbase dev` app.
+- Previously, if the configuration file was not found, an empty configuration was assumed in all commands. This lead to commands like grafbase extension install returning with a successful exit status when no configuration is present. Since a failure would be expected in this case, the CLI should return with a non-zero exit status. This release makes extension commands fail on missing configuration. (https://github.com/grafbase/grafbase/pull/3269)

--- a/cli/src/cli_input/compose.rs
+++ b/cli/src/cli_input/compose.rs
@@ -18,7 +18,8 @@ pub(crate) struct ComposeCommand {
 impl ComposeCommand {
     pub fn config(&self) -> anyhow::Result<Config> {
         Config::loader()
-            .load_or_default(self.config_path.as_ref())
-            .map_err(|err| anyhow::anyhow!(err))
+            .load(self.config_path.as_ref())
+            .map_err(|err| anyhow::anyhow!(err))?
+            .ok_or_else(|| anyhow::anyhow!("Could not read the configuration file."))
     }
 }

--- a/cli/src/cli_input/dev.rs
+++ b/cli/src/cli_input/dev.rs
@@ -19,7 +19,8 @@ pub struct DevCommand {
 impl DevCommand {
     pub fn config(&self) -> anyhow::Result<Config> {
         Config::loader()
-            .load_or_default(self.config_path.as_ref())
+            .load(self.config_path.as_ref())
+            .map(Option::unwrap_or_default)
             .map_err(|err| anyhow::anyhow!(err))
     }
 }

--- a/cli/src/cli_input/extension.rs
+++ b/cli/src/cli_input/extension.rs
@@ -84,8 +84,9 @@ pub(crate) struct ExtensionUpdateCommand {
 impl ExtensionUpdateCommand {
     pub fn config(&self) -> anyhow::Result<Config> {
         Config::loader()
-            .load_or_default(self.config_path.as_ref())
-            .map_err(|err| anyhow::anyhow!(err))
+            .load(self.config_path.as_ref())
+            .map_err(|err| anyhow::anyhow!(err))?
+            .ok_or_else(|| anyhow::anyhow!("Could not read the configuration file."))
     }
 }
 
@@ -99,7 +100,8 @@ pub(crate) struct ExtensionInstallCommand {
 impl ExtensionInstallCommand {
     pub fn config(&self) -> anyhow::Result<Config> {
         Config::loader()
-            .load_or_default(self.config_path.as_ref())
-            .map_err(|err| anyhow::anyhow!(err))
+            .load(self.config_path.as_ref())
+            .map_err(|err| anyhow::anyhow!(err))?
+            .ok_or_else(|| anyhow::anyhow!("Could not read the configuration file."))
     }
 }

--- a/cli/src/dev/hot_reload.rs
+++ b/cli/src/dev/hot_reload.rs
@@ -105,10 +105,11 @@ pub(crate) async fn hot_reload(
         subgraph_watcher.stop();
 
         let config = match Config::load(&config_path) {
-            Ok(mut config) => {
+            Ok(Some(mut config)) => {
                 config.graph.introspection = Some(true);
                 config
             }
+            Ok(None) => Config::default(),
             Err(error) => {
                 tracing::error!("{}", error.to_string().trim());
                 continue;

--- a/cli/src/extension/install.rs
+++ b/cli/src/extension/install.rs
@@ -29,7 +29,7 @@ async fn download_extensions(lockfile: lockfile::Lockfile) -> anyhow::Result<()>
 
     fs::create_dir_all(extensions_directory).await.map_err(|err| {
         anyhow::anyhow!(
-            "Failed to create extensions directory at {}. Cause: {err}",
+            "Failed to create extensions directory at {}. Cause: {err}",
             extensions_directory.display()
         )
     })?;

--- a/crates/gateway-config/src/lib.rs
+++ b/crates/gateway-config/src/lib.rs
@@ -66,7 +66,7 @@ impl Loader {
         }
     }
 
-    pub fn load_or_default<P: AsRef<Path>>(self, path: Option<P>) -> Result<Config, String> {
+    pub fn load<P: AsRef<Path>>(self, path: Option<P>) -> Result<Option<Config>, String> {
         let path = match path {
             Some(path) => path.as_ref().to_path_buf(),
             None => {
@@ -80,7 +80,7 @@ impl Loader {
                 if path.exists() {
                     path
                 } else {
-                    return Ok(Default::default());
+                    return Ok(None);
                 }
             }
         };
@@ -154,9 +154,11 @@ impl Loader {
             path
         });
 
-        Ok(config
-            .with_absolute_paths()
-            .expect("config.parent_path exists and is absolute."))
+        Ok(Some(
+            config
+                .with_absolute_paths()
+                .expect("config.parent_path exists and is absolute."),
+        ))
     }
 }
 
@@ -223,8 +225,8 @@ impl Config {
         Loader::default()
     }
 
-    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, String> {
-        Self::loader().load_or_default(Some(path))
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<Option<Self>, String> {
+        Self::loader().load(Some(path))
     }
 
     pub fn with_absolute_paths(mut self) -> Option<Self> {

--- a/crates/integration-tests/src/gateway/builder/engine.rs
+++ b/crates/integration-tests/src/gateway/builder/engine.rs
@@ -83,7 +83,7 @@ pub(super) async fn build(
 
     let config_path = tmpdir.join("grafbase.toml");
     std::fs::write(tmpdir.join("grafbase.toml"), &config.toml).unwrap();
-    let mut config = Config::load(config_path).unwrap();
+    let mut config = Config::load(config_path).unwrap().unwrap();
 
     let schema = Arc::new(
         engine::Schema::builder(&federated_sdl)

--- a/gateway/src/args/std.rs
+++ b/gateway/src/args/std.rs
@@ -94,8 +94,9 @@ impl super::Args for Args {
 
     fn config(&self) -> anyhow::Result<Config> {
         let mut config = Config::loader()
-            .load_or_default(self.config.as_deref())
-            .map_err(|err| anyhow::anyhow!(err))?;
+            .load(self.config.as_deref())
+            .map_err(|err| anyhow::anyhow!(err))?
+            .unwrap_or_default();
 
         if let Some(otel_config) = self.grafbase_otel_config()? {
             config.telemetry.grafbase = Some(otel_config);


### PR DESCRIPTION
Currently, if the configuration is not found, an empty configuration is assumed. This leads to commands like `grafbase extension install` returning with a successful exit status when no configuration is present. Since the user would expect a failure in this case, the CLI should return with a non-zero exit status.

This commit makes it happen.

closes GB-9277