### PR TITLE
gateway(docker/helm): align UIDs between podSecurityContext and image

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -50,7 +50,7 @@ WORKDIR /grafbase
 # used curl to run a health check query against the server in a docker-compose file
 RUN apt update && apt upgrade -y && apt install -y curl && rm -rf /var/lib/apt/lists/*
 
-RUN adduser --home "/data" grafbase && mkdir -p /data && chown grafbase /data
+RUN adduser -u 1000 --home /data grafbase && mkdir -p /data && chown grafbase /data
 USER grafbase
 
 COPY --from=builder /grafbase/target/release/grafbase-gateway /bin/grafbase-gateway

--- a/gateway/helm/Chart.yaml
+++ b/gateway/helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: gateway
 description: A Helm chart for the Grafbase Gateway
 type: application
-version: 0.2.5
+version: 0.2.6

--- a/gateway/helm/values.yaml
+++ b/gateway/helm/values.yaml
@@ -18,10 +18,10 @@ image:
 imagePullSecrets: []
 
 # Override Helm release name for custom resource names.
-nameOverride: ""
+nameOverride: ''
 
 # Override the full Helm release name for custom resource names.
-fullnameOverride: ""
+fullnameOverride: ''
 
 serviceAccount:
   # Whether to create a new service account.
@@ -31,7 +31,7 @@ serviceAccount:
   annotations: {}
 
   # Specify a custom name for the service account if `create` is false.
-  name: ""
+  name: ''
 
 # Annotations for the Grafbase gateway pods.
 # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
@@ -41,7 +41,7 @@ podAnnotations: {}
 # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 podSecurityContext:
   runAsNonRoot: true
-  runAsUser: 1001
+  runAsUser: 1000
 
 # Security context for each container, defining privileges and access control.
 # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
@@ -75,7 +75,7 @@ ingress:
   enabled: false
 
   # Specify ingress class, e.g., nginx.
-  className: "nginx"
+  className: 'nginx'
 
   hosts:
     - # Hostname for the ingress route.
@@ -146,7 +146,7 @@ gateway:
   # Default GraphQL schema for the gateway.
   # Providing the schema through values does not require an explicit `--schema` flag to be passed in through `args: []`.
   # Alternatively one can leverage `volumes`, `volumeMounts` and `args` to make an external schema available.
-  schema: "type Query"
+  schema: 'type Query'
   # Opt-out of providing the federated schema through helm values
   externalSchema: false
 


### PR DESCRIPTION
Before this commit:

- The grafbase user inside the container is created without a hardcoded UID. In practice, it ends up being 1000
- The podSecurityContext in the helm chart makes the gateway run with user 1001

That leads to a mismatch, with the gateway running as a completely unpriviledged user, that doesn't have access to any files baked into the docker image in later steps.

This is in particular a problem when you install and bake gateway extensions into the docker image. The gateway doesn't have permissions to read them.

In this commit,

- the grafbase user gets UID 1000 assigned explicitly, so it shouldn't change in practice for existing deployments (less breaking)
- the helm chart runs containers as user 1000

So the gateway should run as the grafbase user and have access to the files created in dockerfiles building upon the base gateway dockerfile from now on.