### PR TITLE
feat(contracts): Initial contract handling in the engine.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2834,6 +2834,7 @@ dependencies = [
  "multipart-stream",
  "percent-encoding",
  "pretty_assertions",
+ "quick_cache",
  "ramhorns",
  "rand 0.9.1",
  "runtime",
@@ -3362,6 +3363,7 @@ dependencies = [
  "indoc",
  "insta",
  "lambda_http",
+ "mini-moka",
  "minicbor-serde",
  "notify",
  "rand 0.9.1",
@@ -4079,6 +4081,7 @@ dependencies = [
  "minicbor-serde",
  "ordered-float 5.0.0",
  "priority-queue",
+ "quick_cache",
  "rmcp",
  "schemars",
  "serde",
@@ -7554,6 +7557,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quick_cache"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b450dad8382b1b95061d5ca1eb792081fb082adf48c678791fe917509596d5f"
+dependencies = [
+ "ahash 0.8.11",
+ "equivalent",
+ "hashbrown 0.15.2",
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,6 +173,7 @@ priority-queue = "2"
 proc-macro2 = "1"
 prost = { version = "0.13.5", default-features = false }
 prost-types = { version = "0.13.5", default-features = false }
+quick_cache = "0.6"
 quote = "1"
 ramhorns = { git = "https://github.com/grafbase/ramhorns", branch = "grafbase", default-features = false, features = [
     "indexes",

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -85,7 +85,7 @@ pub(crate) async fn run(args: McpCommand) -> anyhow::Result<()> {
         authentication,
     };
 
-    let engine = engine::Engine::new(Arc::new(schema), runtime).await;
+    let engine = engine::ContractAwareEngine::new(Arc::new(schema), runtime);
     let (_, rx) = tokio::sync::watch::channel(Arc::new(engine));
 
     let mcp_config = gateway_config::ModelControlProtocolConfig {

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -44,6 +44,7 @@ multipart-stream.workspace = true
 operation = { path = "./operation", package = "engine-operation" }
 percent-encoding.workspace = true
 query-solver = { path = "./query-solver", package = "engine-query-solver" }
+quick_cache.workspace = true
 ramhorns.workspace = true
 rand.workspace = true
 runtime.workspace = true

--- a/crates/engine/operation/src/validation/after_binding.rs
+++ b/crates/engine/operation/src/validation/after_binding.rs
@@ -35,7 +35,7 @@ pub(crate) fn validate(schema: &Schema, operation: &Operation) -> Result<(), Vec
 }
 
 fn ensure_introspection_is_accepted(ctx: OperationContext<'_>) -> Result<(), ValidationError> {
-    if ctx.operation.attributes.ty.is_query() && ctx.schema.settings.disable_introspection {
+    if ctx.operation.attributes.ty.is_query() && ctx.schema.config.disable_introspection {
         for field in ctx.root_selection_set().fields() {
             if let Some(field) = field.as_data() {
                 if ctx
@@ -57,7 +57,7 @@ fn ensure_introspection_is_accepted(ctx: OperationContext<'_>) -> Result<(), Val
 }
 
 fn enforce_operation_limits(ctx: OperationContext<'_>) -> Result<(), ValidationError> {
-    let operation_limits = &ctx.schema.settings.operation_limits;
+    let operation_limits = &ctx.schema.config.operation_limits;
     let selection_set = ctx.root_selection_set();
 
     // All other limits are verified before the binding step.

--- a/crates/engine/operation/src/validation/after_parsing.rs
+++ b/crates/engine/operation/src/validation/after_parsing.rs
@@ -39,7 +39,7 @@ impl ValidationError {
 }
 
 pub(crate) fn validate(schema: &Schema, operation: &ParsedOperation) -> Result<(), Vec<ValidationError>> {
-    let limits = &schema.settings.operation_limits;
+    let limits = &schema.config.operation_limits;
     let operation = operation.operation();
 
     let result = Visitor {

--- a/crates/engine/operation/src/validation/complexity.rs
+++ b/crates/engine/operation/src/validation/complexity.rs
@@ -16,7 +16,7 @@ pub fn compute_and_validate_complexity(
     ctx: OperationContext<'_>,
     variables: &Variables,
 ) -> Result<Option<ComplexityCost>, ComplexityError> {
-    match ctx.schema.settings.complexity_control {
+    match ctx.schema.config.complexity_control {
         ComplexityControl::Disabled => Ok(None),
         ComplexityControl::Enforce { limit, .. } => {
             let complexity = calculate_complexity(ctx, variables)?;
@@ -43,7 +43,7 @@ pub fn calculate_complexity(
     let context = ComplexityContext {
         default_list_size: ctx
             .schema
-            .settings
+            .config
             .complexity_control
             .list_size()
             .expect("should be some unless disabled"),

--- a/crates/engine/schema/src/builder/mod.rs
+++ b/crates/engine/schema/src/builder/mod.rs
@@ -163,7 +163,7 @@ impl BuildContext<'_> {
             strings,
             regexps: regexps.into(),
             urls: urls.into(),
-            settings,
+            config: settings,
         })
     }
 }

--- a/crates/engine/schema/src/lib.rs
+++ b/crates/engine/schema/src/lib.rs
@@ -81,7 +81,7 @@ pub struct Schema {
     #[indexed_by(UrlId)]
     urls: Vec<url::Url>,
 
-    pub settings: PartialConfig,
+    pub config: PartialConfig,
 }
 
 impl Schema {

--- a/crates/engine/src/engine/mcp.rs
+++ b/crates/engine/src/engine/mcp.rs
@@ -1,4 +1,6 @@
-use schema::DirectiveSiteId;
+use std::sync::Arc;
+
+use schema::{DirectiveSiteId, Schema};
 
 #[derive(Clone, Debug)]
 pub struct McpRequestContext {
@@ -7,5 +9,6 @@ pub struct McpRequestContext {
 
 #[derive(Clone, Debug)]
 pub struct McpResponseExtension {
+    pub schema: Arc<Schema>,
     pub site_ids: Vec<DirectiveSiteId>,
 }

--- a/crates/engine/src/engine/retry_budget.rs
+++ b/crates/engine/src/engine/retry_budget.rs
@@ -15,7 +15,7 @@ impl RetryBudgets {
             by_graphql_endpoints: schema
                 .graphql_endpoints()
                 .map(|endpoint| {
-                    let retry_config = endpoint.config.retry.as_ref().or(schema.settings.retry.as_ref())?;
+                    let retry_config = endpoint.config.retry.as_ref().or(schema.config.retry.as_ref())?;
 
                     // Defaults: https://docs.rs/tower/0.4.13/src/tower/retry/budget.rs.html#137-139
                     let ttl = retry_config.ttl.unwrap_or(std::time::Duration::from_secs(10));

--- a/crates/engine/src/execution/request/well_formed_graphql_request.rs
+++ b/crates/engine/src/execution/request/well_formed_graphql_request.rs
@@ -43,14 +43,14 @@ impl<R: Runtime> Engine<R> {
                     );
                 };
 
-                if !self.schema.settings.batching.enabled {
+                if !self.schema.config.batching.enabled {
                     return self.bad_request_but_well_formed_graphql_over_http_request(
                         &request_context,
                         "batching is not enabled for this service",
                     );
                 }
 
-                if let Some(limit) = self.schema.settings.batching.limit {
+                if let Some(limit) = self.schema.config.batching.limit {
                     if requests.len() > (limit as usize) {
                         return self.bad_request_but_well_formed_graphql_over_http_request(
                             &request_context,

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -11,7 +11,7 @@ mod response;
 mod utils;
 pub mod websocket;
 
-pub use engine::{Engine, Runtime, WebsocketSession, mcp};
+pub use engine::{ContractAwareEngine, Engine, Runtime, WebsocketSession, mcp};
 pub use error::{ErrorCode, ErrorResponse, GraphqlError};
 pub use graphql_over_http::{Body, ResponseFormat, TelemetryExtension};
 pub use prepare::cached::CachedOperation;

--- a/crates/engine/src/prepare/without_cache.rs
+++ b/crates/engine/src/prepare/without_cache.rs
@@ -18,7 +18,7 @@ impl<R: Runtime> PrepareContext<'_, R> {
         document: OperationDocument<'_>,
         variables: RawVariables,
     ) -> Result<PreparedOperation, Response> {
-        if document.content.len() >= self.schema().settings.executable_document_limit_bytes {
+        if document.content.len() >= self.schema().config.executable_document_limit_bytes {
             let error = GraphqlError::new(
                 "Executable document exceeded the maximum configured size",
                 ErrorCode::OperationValidationError,
@@ -33,7 +33,10 @@ impl<R: Runtime> PrepareContext<'_, R> {
                     let site_ids = items.iter().filter_map(|error| error.site_id).collect::<Vec<_>>();
                     Response::request_error(items.into_iter().map(operation_error_into_graphql_error)).with_extensions(
                         ResponseExtensions {
-                            mcp: Some(McpResponseExtension { site_ids }),
+                            mcp: Some(McpResponseExtension {
+                                schema: self.engine.schema.clone(),
+                                site_ids,
+                            }),
                             ..Default::default()
                         },
                     )

--- a/crates/engine/src/resolver/graphql/subscription.rs
+++ b/crates/engine/src/resolver/graphql/subscription.rs
@@ -87,7 +87,7 @@ impl GraphqlResolver {
                 .request_context
                 .websocket_init_payload
                 .as_ref()
-                .filter(|_| ctx.schema().settings.websocket_forward_connection_init_payload)
+                .filter(|_| ctx.schema().config.websocket_forward_connection_init_payload)
                 .cloned(),
             method: http::Method::POST,
             headers,

--- a/crates/federated-server/Cargo.toml
+++ b/crates/federated-server/Cargo.toml
@@ -41,6 +41,7 @@ http-body-util.workspace = true
 hyper.workspace = true
 indoc.workspace = true
 lambda_http = { workspace = true, optional = true }
+mini-moka.workspace = true
 minicbor-serde = { workspace = true, features = ["alloc"] }
 notify.workspace = true
 rand.workspace = true

--- a/crates/federated-server/src/router/graphql/ws/accepter.rs
+++ b/crates/federated-server/src/router/graphql/ws/accepter.rs
@@ -1,14 +1,14 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use ::axum::extract::ws::{self, WebSocket};
-use engine::{Engine, Runtime, WebsocketSession};
+use engine::{Runtime, WebsocketSession};
 use futures_util::{SinkExt, Stream, StreamExt, pin_mut, stream::SplitStream};
-use tokio::sync::{mpsc, watch};
+use tokio::sync::mpsc;
+
+use crate::router::EngineWatcher;
 
 use super::{WebsocketReceiver, WebsocketRequest, service::MessageConvert};
 use engine::websocket::{Event, Message};
-
-pub type EngineWatcher<R> = watch::Receiver<Arc<Engine<R>>>;
 
 const CONNECTION_INIT_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 

--- a/crates/federated-server/src/router/state.rs
+++ b/crates/federated-server/src/router/state.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::engine::EngineWatcher;
+use crate::router::EngineWatcher;
 
 pub struct ServerStateInner<R: engine::Runtime, SR> {
     /// The gateway responsible for handling engine communication.

--- a/crates/federated-server/src/serve/mod.rs
+++ b/crates/federated-server/src/serve/mod.rs
@@ -55,7 +55,7 @@ pub async fn serve(
         config_receiver,
         config_path,
         config_hot_reload,
-        graph_loader: fetch_method,
+        graph_loader,
         grafbase_access_token,
         logging_filter,
     }: ServeConfig,
@@ -71,7 +71,7 @@ pub async fn serve(
     let (update_sender, update_receiver) = mpsc::channel::<UpdateEvent>(16);
 
     // Start the graph producer
-    fetch_method.start_producer(update_sender.clone()).await?;
+    graph_loader.start_producer(update_sender.clone()).await?;
 
     // Bridge config updates to the central channel if hot reload is enabled
     if config_hot_reload {

--- a/crates/integration-tests/src/gateway/builder/engine.rs
+++ b/crates/integration-tests/src/gateway/builder/engine.rs
@@ -3,7 +3,7 @@ use std::{path::Path, str::FromStr, sync::Arc};
 use crate::gateway::{TestRuntimeBuilder, subgraph::Subgraphs};
 use gateway_config::Config;
 
-use engine::Engine;
+use engine::ContractAwareEngine;
 
 use super::{TestConfig, TestRuntime};
 
@@ -13,7 +13,7 @@ pub(super) async fn build(
     mut config: TestConfig,
     runtime: TestRuntimeBuilder,
     subgraphs: &Subgraphs,
-) -> Result<Arc<Engine<TestRuntime>>, String> {
+) -> Result<Arc<ContractAwareEngine<TestRuntime>>, String> {
     let federated_sdl = {
         let mut federated_graph = match federated_sdl {
             Some(sdl) => graphql_composition::FederatedGraph::from_sdl(&sdl).unwrap(),
@@ -98,7 +98,7 @@ pub(super) async fn build(
 
     println!("=== CONFIG ===\n{config:#?}\n");
 
-    let engine = engine::Engine::new(schema, runtime).await;
+    let engine = engine::ContractAwareEngine::new(schema, runtime);
 
     Ok(Arc::new(engine))
 }

--- a/crates/integration-tests/src/gateway/builder/router.rs
+++ b/crates/integration-tests/src/gateway/builder/router.rs
@@ -1,20 +1,20 @@
 use std::sync::Arc;
 
 use axum::Router;
-use engine::Engine;
+use engine::ContractAwareEngine;
 use federated_server::router::RouterConfig;
 use gateway_config::Config;
 
 use super::TestRuntime;
 
-pub(super) async fn build(engine: Arc<Engine<TestRuntime>>, config: Config) -> Router {
+pub(super) async fn build(engine: Arc<ContractAwareEngine<TestRuntime>>, config: Config) -> Router {
     let (_, engine_watcher) = tokio::sync::watch::channel(engine.clone());
 
     let router_config = RouterConfig {
         config,
         engine: engine_watcher,
         server_runtime: (),
-        extensions: engine.runtime.gateway_extensions.clone(),
+        extensions: engine.no_contract.runtime.gateway_extensions.clone(),
         inject_layers_before_cors: |r| r,
     };
 

--- a/crates/integration-tests/src/gateway/mod.rs
+++ b/crates/integration-tests/src/gateway/mod.rs
@@ -23,7 +23,7 @@ pub struct Gateway {
     tmpdir: Arc<tempfile::TempDir>,
     router: axum::Router,
     #[allow(unused)]
-    engine: Arc<engine::Engine<TestRuntime>>,
+    engine: Arc<engine::ContractAwareEngine<TestRuntime>>,
     subgraphs: subgraph::Subgraphs,
 }
 

--- a/crates/integration-tests/src/gateway/runtime/context.rs
+++ b/crates/integration-tests/src/gateway/runtime/context.rs
@@ -16,6 +16,10 @@ impl ExtensionContext for ExtContext {
     fn event_queue(&self) -> &EventQueue {
         self.wasm.event_queue()
     }
+
+    fn contract_key(&self) -> Option<&str> {
+        self.wasm.contract_key()
+    }
 }
 
 impl ExtContext {

--- a/crates/integration-tests/src/gateway/runtime/hooks.rs
+++ b/crates/integration-tests/src/gateway/runtime/hooks.rs
@@ -1,4 +1,4 @@
-use runtime::extension::HooksExtension;
+use runtime::extension::{GatewayExtensions, HooksExtension};
 use wasi_component_loader::extension::GatewayWasmExtensions;
 
 use crate::gateway::ExtContext;
@@ -8,27 +8,26 @@ pub struct GatewayTestExtensions {
     pub wasm: GatewayWasmExtensions,
 }
 
-impl HooksExtension for GatewayTestExtensions {
+impl GatewayExtensions for GatewayTestExtensions {
     type Context = ExtContext;
+}
 
-    fn new_context(&self) -> Self::Context {
-        ExtContext {
-            wasm: self.wasm.new_context(),
-            ..Default::default()
-        }
-    }
-
+impl HooksExtension<ExtContext> for GatewayTestExtensions {
     async fn on_request(
         &self,
-        context: &Self::Context,
         parts: http::request::Parts,
-    ) -> Result<http::request::Parts, engine::ErrorResponse> {
-        self.wasm.on_request(&context.wasm, parts).await
+    ) -> Result<(ExtContext, http::request::Parts), engine::ErrorResponse> {
+        let (ctx, parts) = self.wasm.on_request(parts).await?;
+        let ctx = ExtContext {
+            wasm: ctx,
+            ..Default::default()
+        };
+        Ok((ctx, parts))
     }
 
     async fn on_response(
         &self,
-        context: &Self::Context,
+        context: &ExtContext,
         parts: http::response::Parts,
     ) -> Result<http::response::Parts, String> {
         self.wasm.on_response(&context.wasm, parts).await

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -26,6 +26,7 @@ itertools.workspace = true
 minicbor-serde.workspace = true
 ordered-float.workspace = true
 priority-queue.workspace = true
+quick_cache.workspace = true
 rmcp.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use axum::Router;
-use engine::{Engine, Runtime};
+use engine::{ContractAwareEngine, Runtime};
 use gateway_config::ModelControlProtocolConfig;
 use rmcp::transport::{
     sse_server::{SseServer, SseServerConfig},
@@ -20,7 +20,7 @@ use rmcp::transport::{
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
-type EngineWatcher<R> = watch::Receiver<Arc<Engine<R>>>;
+type EngineWatcher<R> = watch::Receiver<Arc<ContractAwareEngine<R>>>;
 
 pub fn router<R: Runtime>(
     engine: &EngineWatcher<R>,

--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -65,10 +65,10 @@ impl ServerHandler for McpServer {
     async fn call_tool(
         &self,
         CallToolRequestParam { name, arguments }: CallToolRequestParam,
-        context: RequestContext<RoleServer>,
+        ctx: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
         if let Some(tool) = self.tools.iter().find(|tool| tool.name() == name) {
-            return tool.call(arguments, context).await;
+            return tool.call(ctx, arguments).await;
         }
 
         Err(ErrorData::new(

--- a/crates/runtime/src/extension/hooks.rs
+++ b/crates/runtime/src/extension/hooks.rs
@@ -3,22 +3,15 @@ use std::future::Future;
 use error::ErrorResponse;
 use http::{request, response};
 
-use super::ExtensionContext;
-
-pub trait HooksExtension: Clone + Send + Sync + 'static {
-    type Context: ExtensionContext + Clone + Send + Sync + 'static;
-
-    fn new_context(&self) -> Self::Context;
-
+pub trait HooksExtension<Context>: Clone + Send + Sync + 'static {
     fn on_request(
         &self,
-        context: &Self::Context,
         parts: request::Parts,
-    ) -> impl Future<Output = Result<request::Parts, ErrorResponse>> + Send;
+    ) -> impl Future<Output = Result<(Context, request::Parts), ErrorResponse>> + Send;
 
     fn on_response(
         &self,
-        context: &Self::Context,
+        context: &Context,
         parts: response::Parts,
     ) -> impl Future<Output = Result<response::Parts, String>> + Send;
 }

--- a/crates/runtime/src/extension/mod.rs
+++ b/crates/runtime/src/extension/mod.rs
@@ -3,6 +3,7 @@ mod authorization;
 mod field_resolver;
 mod hooks;
 mod resolver;
+mod schema_contract;
 mod selection_set_resolver;
 
 pub use authentication::*;
@@ -13,6 +14,7 @@ use event_queue::EventQueue;
 pub use field_resolver::*;
 pub use hooks::*;
 pub use resolver::*;
+pub use schema_contract::*;
 pub use selection_set_resolver::*;
 
 pub trait Anything<'a>: serde::Serialize + Send + 'a {}
@@ -31,8 +33,13 @@ pub trait EngineExtensions:
     type Context: ExtensionContext;
 }
 
-pub trait ExtensionContext: Default + Send + Sync + 'static {
+pub trait GatewayExtensions: HooksExtension<Self::Context> + Send + Sync + 'static {
+    type Context: ExtensionContext;
+}
+
+pub trait ExtensionContext: Default + Clone + Send + Sync + 'static {
     fn event_queue(&self) -> &EventQueue;
+    fn contract_key(&self) -> Option<&str>;
 }
 
 #[derive(Debug, Clone)]

--- a/crates/runtime/src/extension/schema_contract.rs
+++ b/crates/runtime/src/extension/schema_contract.rs
@@ -1,0 +1,13 @@
+use std::future::Future;
+
+use engine_schema::Schema;
+use error::ErrorResponse;
+
+pub trait SchemaContractExtension<Context>: Clone + Send + Sync + 'static {
+    fn apply(
+        &self,
+        context: &Context,
+        key: String,
+        schema: Schema,
+    ) -> impl Future<Output = Result<Schema, ErrorResponse>> + Send;
+}

--- a/crates/wasi-component-loader/src/context.rs
+++ b/crates/wasi-component-loader/src/context.rs
@@ -26,11 +26,16 @@ pub struct SharedContextInner {
     // FIXME: legacy kv for sdk 0.9
     pub(crate) kv: HashMap<String, String>,
     pub(crate) event_queue: EventQueue,
+    pub(crate) contract_key: Option<String>,
 }
 
 impl ExtensionContext for SharedContext {
     fn event_queue(&self) -> &EventQueue {
         &self.event_queue
+    }
+
+    fn contract_key(&self) -> Option<&str> {
+        self.contract_key.as_deref()
     }
 }
 
@@ -40,17 +45,19 @@ impl Default for SharedContext {
             kv: Default::default(),
             authorization_states: Default::default(),
             event_queue: Default::default(),
+            contract_key: None,
         }))
     }
 }
 
 impl SharedContext {
     /// Creates a new shared context.
-    pub fn new(event_queue: EventQueue) -> Self {
+    pub fn new(event_queue: EventQueue, contract_key: Option<String>) -> Self {
         Self(Arc::new(SharedContextInner {
             event_queue,
             kv: Default::default(),
             authorization_states: Default::default(),
+            contract_key,
         }))
     }
 }

--- a/crates/wasi-component-loader/src/extension/runtime/mod.rs
+++ b/crates/wasi-component-loader/src/extension/runtime/mod.rs
@@ -6,12 +6,16 @@ mod resolver;
 mod selection_set_resolver;
 mod subscription;
 
-use crate::resources::SharedContext;
+use crate::{extension::GatewayWasmExtensions, resources::SharedContext};
 
-use runtime::extension::EngineExtensions;
+use runtime::extension::{EngineExtensions, GatewayExtensions};
 
 use super::EngineWasmExtensions;
 
 impl EngineExtensions for EngineWasmExtensions {
+    type Context = SharedContext;
+}
+
+impl GatewayExtensions for GatewayWasmExtensions {
     type Context = SharedContext;
 }


### PR DESCRIPTION
Initially intended to add the contract handling in the `federated-server`. But it's just way too complex with the reloading and the multiple ways the engine is used (http, websocket, mcp, etc.). So instead created a `ContractAwareEngine` and everything uses this instead of `Engine`. Ideally would find better names, but good enough.

This PR adds the contract cache in the engine and adds support for it everywhere on top. but it doesn't do anything with it yet.