### PR TITLE
gateway/helm: make readiness probe timeouts configurable

### DIFF
--- a/gateway/helm/templates/deployment.yaml
+++ b/gateway/helm/templates/deployment.yaml
@@ -73,6 +73,8 @@ spec:
             httpGet:
               path: /health
               port: http
+              initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+              timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/gateway/helm/values.yaml
+++ b/gateway/helm/values.yaml
@@ -186,6 +186,10 @@ gateway:
     [telemetry.tracing.exporters.stdout]
     enabled = true
 
+readinessProbe:
+  initialDelaySeconds: 5
+  timeoutSeconds: 30
+
 # Secrets to be mounted as env vars
 # https://kubernetes.io/docs/concepts/configuration/secret/
 secrets:


### PR DESCRIPTION
And increase the defaults. The gateway can take longer to start because of extensions compilation.

We should work on precompilation.