### PR TITLE
CLI: release 0.99.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3895,7 +3895,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.99.5"
+version = "0.99.6"
 dependencies = [
  "anyhow",
  "askama",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.99.6] - 2025-07-18
+
+[CHANGELOG](changelog/0.96.6.md)
+
 ## [0.93.3] - 2025-04-29
 
 [CHANGELOG](changelog/0.93.3.md)

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.99.5"
+version = "0.99.6"
 name = "grafbase"
 description = "The Grafbase command line interface"
 categories = ["command-line-utilities"]

--- a/cli/changelog/0.99.6.md
+++ b/cli/changelog/0.99.6.md
@@ -1,0 +1,3 @@
+## Fixes
+
+- Fixed a panic in composition with mismatched number of enum values when an enum is used both in input and output positions. This was order-dependent, so not always triggered (https://github.com/grafbase/grafbase/pull/3292).

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.99.5",
+  "version": "0.99.6",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.99.5",
+  "version": "0.99.6",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.99.5",
+  "version": "0.99.6",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "29.7.0"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.99.5",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.99.5",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.99.5",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.99.5",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.99.5"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.99.6",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.99.6",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.99.6",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.99.6",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.99.6"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.99.5",
+  "version": "0.99.6",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.99.5",
+  "version": "0.99.6",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.99.5",
+  "version": "0.99.6",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
## Fixes

- Fixed a panic in composition with mismatched number of enum values when an enum is used both in input and output positions. This was order-dependent, so not always triggered (https://github.com/grafbase/grafbase/pull/3292).