### PR TITLE
chore(sdk): Bring back HttpHeaders from SDK 17

### DIFF
--- a/crates/grafbase-sdk/src/extension/contracts.rs
+++ b/crates/grafbase-sdk/src/extension/contracts.rs
@@ -17,17 +17,12 @@ use crate::{
 /// Or dynamically provided by the `on_request` hook:
 ///
 /// ```rust
-/// # use grafbase_sdk::{host_io::http::Method, types::{ErrorResponse, GatewayHeaders,OnRequestOutput, HttpHeaders as _}};
+/// # use grafbase_sdk::{host_io::http::Method, types::{ErrorResponse, GatewayHeaders,OnRequestOutput}};
 /// # struct MyContract;
 /// # impl MyContract {
 /// #[allow(refining_impl_trait)]
 /// fn on_request(&mut self, _: &str, _: Method, headers: &mut GatewayHeaders) -> Result<OnRequestOutput, ErrorResponse> {
-///     let mut output = OnRequestOutput::new();
-///     if let Some(value) = headers.get("contract-key") {
-///         output.contract_key(value.to_str().unwrap().to_owned());
-///     }
-///
-///     Ok(output)
+///     Ok(OnRequestOutput::new().contract_key("my-contract-key".to_owned()))
 /// }
 /// # }
 /// ```

--- a/crates/grafbase-sdk/src/host_io/http.rs
+++ b/crates/grafbase-sdk/src/host_io/http.rs
@@ -2,13 +2,16 @@
 
 use std::{string::FromUtf8Error, time::Duration};
 
-use crate::wit::{HttpError, HttpMethod};
+use crate::{
+    types::HttpHeaders,
+    wit::{HttpError, HttpMethod},
+};
 pub use http::{HeaderName, HeaderValue, Method, StatusCode};
 pub use serde_json::Error as JsonDeserializeError;
 pub use url::Url;
 
 use crate::{
-    types::{AsHeaderName, AsHeaderValue, OwnedHttpHeaders},
+    types::{AsHeaderName, AsHeaderValue},
     wit::{self, HttpClient},
 };
 use serde::Serialize;
@@ -245,7 +248,7 @@ impl HttpRequest {
 pub struct HttpRequestBuilder {
     url: Url,
     method: http::Method,
-    headers: OwnedHttpHeaders,
+    headers: HttpHeaders,
     body: Vec<u8>,
     timeout: Option<Duration>,
 }
@@ -257,7 +260,7 @@ impl HttpRequestBuilder {
     }
 
     /// Mutable access to the HTTP headers of the request.
-    pub fn headers(&mut self) -> &mut OwnedHttpHeaders {
+    pub fn headers(&mut self) -> &mut HttpHeaders {
         &mut self.headers
     }
 
@@ -388,7 +391,7 @@ impl Default for BatchHttpRequest {
 /// A struct that represents an HTTP response.
 pub struct HttpResponse {
     status_code: http::StatusCode,
-    headers: OwnedHttpHeaders,
+    headers: HttpHeaders,
     body: Vec<u8>,
 }
 
@@ -409,7 +412,7 @@ impl HttpResponse {
     }
 
     /// Returns the headers of the HTTP response.
-    pub fn headers(&self) -> &OwnedHttpHeaders {
+    pub fn headers(&self) -> &HttpHeaders {
         &self.headers
     }
 

--- a/crates/grafbase-sdk/src/types/authentication.rs
+++ b/crates/grafbase-sdk/src/types/authentication.rs
@@ -1,6 +1,4 @@
-use crate::wit;
-
-use super::OwnedHttpHeaders;
+use crate::{types::HttpHeaders, wit};
 
 /// An HTTP endpoint exposed publicly on the Gateway. This is typically used to return metadata for authentication purposes, for example with the [OAuth 2.0 Protected Resource Metadata](https://datatracker.ietf.org/doc/html/rfc9728) spec.
 #[non_exhaustive]
@@ -10,7 +8,7 @@ pub struct PublicMetadataEndpoint {
     /// The contents of the response body that the endpoint will return. Example: '{"resource": "https://secure.example.com" }'.
     response_body: Vec<u8>,
     /// The headers sent from with the response by the public endpoint. Example: ["Content-Type: application/json"].
-    response_headers: OwnedHttpHeaders,
+    response_headers: HttpHeaders,
 }
 
 impl PublicMetadataEndpoint {
@@ -24,13 +22,13 @@ impl PublicMetadataEndpoint {
     }
 
     /// Set the response headers
-    pub fn with_headers(mut self, response_headers: OwnedHttpHeaders) -> Self {
+    pub fn with_headers(mut self, response_headers: HttpHeaders) -> Self {
         self.response_headers = response_headers;
         self
     }
 
     /// Access the response headers
-    pub fn response_headers_mut(&mut self) -> &mut OwnedHttpHeaders {
+    pub fn response_headers_mut(&mut self) -> &mut HttpHeaders {
         &mut self.response_headers
     }
 }

--- a/crates/grafbase-sdk/src/types/hooks.rs
+++ b/crates/grafbase-sdk/src/types/hooks.rs
@@ -16,7 +16,7 @@ impl OnRequestOutput {
     }
 
     /// Sets the contract key for the request.
-    pub fn contract_key(&mut self, contract_key: String) -> &mut Self {
+    pub fn contract_key(mut self, contract_key: String) -> Self {
         self.0.contract_key = Some(contract_key);
         self
     }

--- a/crates/grafbase-sdk/src/wit/mod.rs
+++ b/crates/grafbase-sdk/src/wit/mod.rs
@@ -12,7 +12,7 @@ wit_bindgen::generate!({
     world: "sdk",
     with: {
         "grafbase:sdk/resolver-types": resolver_types,
-    }
+    },
 });
 
 pub(crate) use exports::grafbase::sdk::authentication::{Guest as AuthenticationGuest, PublicMetadataEndpoint};

--- a/crates/integration-tests/data/extensions/Cargo.lock
+++ b/crates/integration-tests/data/extensions/Cargo.lock
@@ -554,7 +554,7 @@ dependencies = [
 name = "auth-017"
 version = "0.1.0"
 dependencies = [
- "grafbase-sdk 0.19.0",
+ "grafbase-sdk 0.17.5",
  "serde",
  "serde_json",
 ]

--- a/crates/integration-tests/data/extensions/crates/auth-017/Cargo.toml
+++ b/crates/integration-tests/data/extensions/crates/auth-017/Cargo.toml
@@ -14,6 +14,6 @@ lto = true
 codegen-units = 1
 
 [dependencies]
-grafbase-sdk.workspace = true
+grafbase-sdk = "0.17"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/integration-tests/data/extensions/crates/auth-017/src/lib.rs
+++ b/crates/integration-tests/data/extensions/crates/auth-017/src/lib.rs
@@ -83,7 +83,7 @@ impl AuthenticationExtension for CachingProvider {
             return Ok(vec![]);
         };
 
-        let mut response_headers = grafbase_sdk::types::OwnedHttpHeaders::new();
+        let mut response_headers = HttpHeaders::new();
         response_headers.append("x-test", "works");
 
         Ok(vec![

--- a/crates/integration-tests/data/extensions/crates/hooks-19/src/lib.rs
+++ b/crates/integration-tests/data/extensions/crates/hooks-19/src/lib.rs
@@ -1,18 +1,38 @@
+use base64::Engine;
 use grafbase_sdk::{
     HooksExtension,
     host_io::{
-        event_queue::EventQueue,
-        http::{Method, StatusCode},
+        event_queue::{CacheStatus, Event, EventQueue, GraphqlResponseStatus, RequestExecution},
+        http::{HeaderValue, Method, StatusCode},
     },
-    types::{Configuration, Error, ErrorResponse, GatewayHeaders, HttpHeaders as _, OnRequestOutput},
+    types::{Configuration, Error, ErrorResponse, GatewayHeaders, OnRequestOutput},
 };
+use serde_json::json;
 
 #[derive(HooksExtension)]
-struct Hooks;
+struct Hooks {
+    config: TestConfig,
+}
+
+#[derive(Default, serde::Deserialize)]
+#[serde(default)]
+struct TestConfig {
+    incoming_header: Option<HeaderTest>,
+    outgoing_header: Option<HeaderTest>,
+    events_header_name: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct HeaderTest {
+    key: String,
+    value: String,
+}
 
 impl HooksExtension for Hooks {
-    fn new(_config: Configuration) -> Result<Self, Error> {
-        Ok(Self)
+    fn new(config: Configuration) -> Result<Self, Error> {
+        let config = config.deserialize::<TestConfig>()?;
+
+        Ok(Self { config })
     }
 
     #[allow(refining_impl_trait)]
@@ -22,15 +42,121 @@ impl HooksExtension for Hooks {
         _: Method,
         headers: &mut GatewayHeaders,
     ) -> Result<OnRequestOutput, ErrorResponse> {
+        if let Some(ref header_test) = self.config.incoming_header {
+            headers.append(
+                header_test.key.as_str(),
+                HeaderValue::from_str(&header_test.value).unwrap(),
+            );
+        }
+
         let mut output = OnRequestOutput::new();
         if let Some(value) = headers.get("contract-key") {
-            output.contract_key(value.to_str().unwrap().to_owned());
+            output = output.contract_key(value.to_str().unwrap().to_owned());
         }
 
         Ok(output)
     }
 
-    fn on_response(&mut self, _: StatusCode, _headers: &mut GatewayHeaders, _queue: EventQueue) -> Result<(), Error> {
+    fn on_response(&mut self, _: StatusCode, headers: &mut GatewayHeaders, queue: EventQueue) -> Result<(), Error> {
+        if let Some(ref header_test) = self.config.outgoing_header {
+            headers.append(
+                header_test.key.as_str(),
+                HeaderValue::from_str(&header_test.value).unwrap(),
+            );
+        }
+
+        if let Some(ref name) = self.config.events_header_name {
+            let mut events_json = Vec::new();
+
+            while let Some(event) = queue.pop() {
+                let event_json = match event {
+                    Event::Operation(op) => {
+                        json!({
+                            "type": "operation",
+                            "name": op.name,
+                            "document": op.document,
+                            "prepare_duration_ms": op.prepare_duration.as_millis(),
+                            "duration_ms": op.duration.as_millis(),
+                            "cached_plan": op.cached_plan,
+                            "status": match op.status {
+                                GraphqlResponseStatus::Success => json!({"type": "success"}),
+                                GraphqlResponseStatus::FieldError(ref err) => {
+                                    json!({
+                                        "type": "field_error",
+                                        "count": err.count,
+                                        "data_is_null": err.data_is_null
+                                    })
+                                },
+                                GraphqlResponseStatus::RequestError(ref err) => {
+                                    json!({
+                                        "type": "request_error",
+                                        "count": err.count
+                                    })
+                                },
+                                GraphqlResponseStatus::RefusedRequest => json!({"type": "refused_request"}),
+                            }
+                        })
+                    }
+                    Event::Subgraph(subgraph) => {
+                        json!({
+                            "type": "subgraph",
+                            "subgraph_name": subgraph.subgraph_name,
+                            "method": subgraph.method.as_str(),
+                            "url": subgraph.url,
+                            "cache_status": match subgraph.cache_status {
+                                CacheStatus::Hit => "hit",
+                                CacheStatus::PartialHit => "partial_hit",
+                                CacheStatus::Miss => "miss",
+                            },
+                            "total_duration_ms": subgraph.total_duration.as_millis(),
+                            "has_errors": subgraph.has_errors,
+                            "executions": subgraph.into_executions().map(|exec| {
+                                match exec {
+                                    RequestExecution::InternalServerError => json!({"type": "internal_server_error"}),
+                                    RequestExecution::RequestError => json!({"type": "request_error"}),
+                                    RequestExecution::RateLimited => json!({"type": "rate_limited"}),
+                                    RequestExecution::Response(resp) => {
+                                        json!({
+                                            "type": "response",
+                                            "connection_time_ms": resp.connection_time.as_millis(),
+                                            "response_time_ms": resp.response_time.as_millis(),
+                                            "status_code": resp.status_code.as_u16()
+                                        })
+                                    }
+                                    _ => json!({"type": "Unknown event"})
+                                }
+                            }).collect::<Vec<_>>()
+                        })
+                    }
+                    Event::Http(http) => {
+                        json!({
+                            "type": "http",
+                            "method": http.method.as_str(),
+                            "url": http.url,
+                            "status_code": http.status_code.as_u16()
+                        })
+                    }
+                    Event::Extension(ext) => {
+                        json!({
+                            "type": "extension",
+                            "event_name": ext.event_name,
+                            "extension_name": ext.extension_name
+                        })
+                    }
+                    _ => json!({"type": "Unknown event"}),
+                };
+
+                events_json.push(event_json);
+            }
+
+            let events_json_string = base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .encode(serde_json::to_string(&events_json).unwrap_or_else(|_| "[]".to_string()));
+            headers.append(
+                name,
+                HeaderValue::from_str(&events_json_string).unwrap_or_else(|_| HeaderValue::from_static("[]")),
+            );
+        }
+
         Ok(())
     }
 }

--- a/crates/integration-tests/tests/gateway/extensions/hooks/backwards_compatibility/events_sdk18.rs
+++ b/crates/integration-tests/tests/gateway/extensions/hooks/backwards_compatibility/events_sdk18.rs
@@ -10,7 +10,7 @@ fn receive_events() {
         let engine = Gateway::builder()
             .with_toml_config(
                 r#"
-                [extensions.hooks-19]
+                [extensions.hooks-17]
                 path = "./data/extensions/crates/hooks/build"
                 stdout = true
                 stderr = true
@@ -19,11 +19,11 @@ fn receive_events() {
                 rule = "forward"
                 name = "x-incoming-header"
 
-                [extensions.hooks-19.config]
+                [extensions.hooks-17.config]
                 events_header_name = "x-events"
             "#,
             )
-            .with_extension("hooks-19")
+            .with_extension("hooks-17")
             .with_subgraph(EchoSchema)
             .build()
             .await;

--- a/crates/integration-tests/tests/gateway/extensions/hooks/backwards_compatibility/mod.rs
+++ b/crates/integration-tests/tests/gateway/extensions/hooks/backwards_compatibility/mod.rs
@@ -1,0 +1,1 @@
+mod events_sdk18;

--- a/crates/integration-tests/tests/gateway/extensions/hooks/mod.rs
+++ b/crates/integration-tests/tests/gateway/extensions/hooks/mod.rs
@@ -1,2 +1,3 @@
+mod backwards_compatibility;
 mod events;
 mod headers;


### PR DESCRIPTION
The `HttpHeaders` were split into `OwnedHttpHeade`, `SharedHttpHeaders` and a `HttpHeaders` trait which really makes way too complex imho. The reason for this was how the events of the event queue were structured. Changed them to struct with `#[non_exhaustive]` and with a function that takes ownership of the headers rather than using references everywhere. In pure Rust you would receive owned variant of the events.