### PR TITLE
feat(sdk): Add introspect() & support for other extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2866,7 +2866,7 @@ dependencies = [
  "itertools 0.14.0",
  "mediatype",
  "mime",
- "minicbor-serde",
+ "minicbor-serde 0.5.0",
  "multipart-stream",
  "percent-encoding",
  "pretty_assertions",
@@ -3400,7 +3400,7 @@ dependencies = [
  "insta",
  "lambda_http",
  "mini-moka",
- "minicbor-serde",
+ "minicbor-serde 0.5.0",
  "notify",
  "rand 0.9.2",
  "reqwest 0.12.22",
@@ -4116,7 +4116,7 @@ dependencies = [
  "grafbase-workspace-hack",
  "http 1.3.1",
  "itertools 0.14.0",
- "minicbor-serde",
+ "minicbor-serde 0.5.0",
  "ordered-float 5.0.0",
  "priority-queue",
  "quick_cache",
@@ -4140,6 +4140,7 @@ dependencies = [
  "async-tungstenite",
  "bytes",
  "chrono",
+ "cynic-introspection",
  "document-features",
  "duct",
  "env_filter",
@@ -4153,14 +4154,13 @@ dependencies = [
  "hashbrown 0.15.4",
  "http 1.3.1",
  "http-body-util",
- "indoc",
  "insta",
  "itertools 0.14.0",
  "jaq-core",
  "jaq-json",
  "jaq-std",
  "log",
- "minicbor-serde",
+ "minicbor-serde 0.6.0",
  "postcard",
  "regex",
  "reqwest 0.12.22",
@@ -4320,8 +4320,8 @@ dependencies = [
  "memchr",
  "miette",
  "mime_guess",
- "minicbor",
- "minicbor-serde",
+ "minicbor 1.1.0",
+ "minicbor-serde 0.5.0",
  "miniz_oxide",
  "mio 1.0.4",
  "num-bigint-dig",
@@ -5463,7 +5463,7 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "mimalloc",
- "minicbor-serde",
+ "minicbor-serde 0.5.0",
  "multipart-stream",
  "openidconnect",
  "ory-client",
@@ -6257,7 +6257,16 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "734daad4ff3b880f23dc2a675dd74553fa8e583367aa7523f96a16e96a516b62"
 dependencies = [
- "minicbor-derive",
+ "minicbor-derive 0.17.0",
+]
+
+[[package]]
+name = "minicbor"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d2aa21725f9442def0570f427df351961a79439f63fff51b7d022a5ca31304"
+dependencies = [
+ "minicbor-derive 0.18.0",
 ]
 
 [[package]]
@@ -6272,12 +6281,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicbor-derive"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efcc51e9571691dc36dd629a3e81447e6e7803ff3a209b0fb6a60d4274ba63c3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "minicbor-serde"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a05d783cc8c3cdbde9f7ee9eeeef417810278e81fb6289634fdbc952d462fc23"
 dependencies = [
- "minicbor",
+ "minicbor 1.1.0",
+ "serde",
+]
+
+[[package]]
+name = "minicbor-serde"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bbf243b8cc68a7a76473b14328d3546fb002ae3d069227794520e9181003de9"
+dependencies = [
+ "minicbor 2.0.0",
  "serde",
 ]
 
@@ -8399,7 +8429,7 @@ dependencies = [
  "grafbase-telemetry",
  "grafbase-workspace-hack",
  "http 1.3.1",
- "minicbor-serde",
+ "minicbor-serde 0.5.0",
  "reqwest 0.12.22",
  "semver 1.0.26",
  "serde",
@@ -8437,7 +8467,7 @@ dependencies = [
  "httpsig",
  "httpsig-hyper",
  "mini-moka",
- "minicbor-serde",
+ "minicbor-serde 0.5.0",
  "p256",
  "p384",
  "postcard",
@@ -11233,7 +11263,7 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "mini-moka",
- "minicbor-serde",
+ "minicbor-serde 0.5.0",
  "rapidhash",
  "reqwest 0.12.22",
  "rolling-logger",

--- a/crates/grafbase-sdk/Cargo.toml
+++ b/crates/grafbase-sdk/Cargo.toml
@@ -17,7 +17,6 @@ all-features = true
 test-utils = [
     "dep:duct",
     "dep:fslock",
-    "dep:indoc",
     "dep:reqwest",
     "dep:tempfile",
     "dep:toml",
@@ -33,6 +32,7 @@ test-utils = [
     "dep:itertools",
     "dep:http-body-util",
     "dep:bytes",
+    "dep:cynic-introspection",
 ]
 ## Utilities to use `jq`-like selection to process data in your extension like the [rest](https://grafbase.com/extensions/rest) extension.
 jq-selection = [
@@ -47,6 +47,7 @@ anyhow = { workspace = true, optional = true }
 async-tungstenite = { workspace = true, optional = true, features = ["tokio-runtime"] }
 bytes = { workspace = true, optional = true }
 chrono.workspace = true
+cynic-introspection = { workspace = true, optional = true }
 document-features = { version = "0.2" }
 duct = { workspace = true, optional = true }
 env_filter = "0.1.3"
@@ -62,13 +63,12 @@ graphql-ws-client = { workspace = true, optional = true }
 hashbrown = { workspace = true, optional = true }
 http = "1"
 http-body-util = { workspace = true, optional = true }
-indoc = { workspace = true, optional = true }
 itertools = { workspace = true, optional = true }
 jaq-core = { version = "2.1.1", optional = true }
 jaq-json = { version = "1.1.1", features = ["serde_json"], optional = true }
 jaq-std = { version = "2.1.0", optional = true }
 log = { workspace = true, features = ["kv_unstable_std"] }
-minicbor-serde = { version = "0.5.0", features = ["alloc"] }
+minicbor-serde = { version = "0.6.0", features = ["alloc"] }
 postcard = { version = "1", features = ["use-std"] }
 regex = { workspace = true, optional = true }
 reqwest = { workspace = true, features = ["json"], optional = true }

--- a/crates/integration-tests/data/extensions/Cargo.lock
+++ b/crates/integration-tests/data/extensions/Cargo.lock
@@ -585,6 +585,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "authenticated-19"
+version = "0.1.0"
+dependencies = [
+ "grafbase-sdk 0.19.0",
+ "indoc",
+ "insta",
+ "openidconnect",
+ "ory-client",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "authorization-10"
 version = "0.1.0"
 dependencies = [
@@ -747,6 +762,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -1204,6 +1225,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1431,6 +1462,18 @@ dependencies = [
  "quote",
  "strsim 0.10.0",
  "syn 2.0.104",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cynic-introspection"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84855a1f755acfcfa0a810aad7c85cc9fe4b093cbd5d5a39c023b1d9431e4f40"
+dependencies = [
+ "cynic",
+ "cynic-codegen",
+ "indenter",
  "thiserror 1.0.69",
 ]
 
@@ -1891,6 +1934,21 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2355,6 +2413,7 @@ dependencies = [
  "async-tungstenite",
  "bytes",
  "chrono",
+ "cynic-introspection",
  "document-features",
  "duct 1.0.0",
  "env_filter",
@@ -2367,10 +2426,9 @@ dependencies = [
  "graphql-ws-client",
  "http",
  "http-body-util",
- "indoc",
  "itertools 0.14.0",
  "log",
- "minicbor-serde 0.5.0",
+ "minicbor-serde 0.6.0",
  "postcard",
  "regex",
  "reqwest",
@@ -3181,6 +3239,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3199,9 +3273,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3346,6 +3422,12 @@ dependencies = [
  "icu_normalizer",
  "icu_properties",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -3760,6 +3842,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "minicbor"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d2aa21725f9442def0570f427df351961a79439f63fff51b7d022a5ca31304"
+dependencies = [
+ "minicbor-derive 0.18.0",
+]
+
+[[package]]
 name = "minicbor-derive"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3775,6 +3866,17 @@ name = "minicbor-derive"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512ce2c37128698ea15c99b3518936c78a8b112b92468e7b95b9fa045666ebd8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efcc51e9571691dc36dd629a3e81447e6e7803ff3a209b0fb6a60d4274ba63c3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3798,6 +3900,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a05d783cc8c3cdbde9f7ee9eeeef417810278e81fb6289634fdbc952d462fc23"
 dependencies = [
  "minicbor 1.0.0",
+ "serde",
+]
+
+[[package]]
+name = "minicbor-serde"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bbf243b8cc68a7a76473b14328d3546fb002ae3d069227794520e9181003de9"
+dependencies = [
+ "minicbor 2.0.0",
  "serde",
 ]
 
@@ -3863,6 +3975,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -3939,6 +4068,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.16",
+ "http",
+ "rand 0.8.5",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3975,10 +4124,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openidconnect"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c6709ba2ea764bbed26bce1adf3c10517113ddea6f2d4196e4851757ef2b2"
+dependencies = [
+ "base64 0.21.7",
+ "chrono",
+ "dyn-clone",
+ "ed25519-dalek",
+ "hmac 0.12.1",
+ "http",
+ "itertools 0.10.5",
+ "log",
+ "oauth2",
+ "p256",
+ "p384",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_plain",
+ "serde_with",
+ "sha2 0.10.9",
+ "subtle",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ory-client"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f59825c3783cb8ca4db53e42144b2bd5401268b1fa07d21a81d241a402f620c"
+dependencies = [
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+ "url",
+ "uuid",
+]
 
 [[package]]
 name = "os_pipe"
@@ -4771,6 +5013,7 @@ dependencies = [
  "async-compression",
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -4781,10 +5024,13 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "mime_guess",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -4797,6 +5043,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower 0.5.2",
@@ -5039,7 +5286,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -5135,12 +5382,25 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5202,6 +5462,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5245,6 +5515,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_qs"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5253,6 +5532,17 @@ dependencies = [
  "percent-encoding",
  "serde",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5827,6 +6117,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6045,6 +6356,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -6569,6 +6890,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6930,6 +7257,17 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"

--- a/crates/integration-tests/src/gateway/mod.rs
+++ b/crates/integration-tests/src/gateway/mod.rs
@@ -94,8 +94,9 @@ impl Gateway {
     }
 
     pub fn introspect(&self) -> IntrospectionRequest {
-        const PATHFINDER_INTROSPECTION_QUERY: &str = include_str!("../../data/introspection.graphql");
-        IntrospectionRequest::from(self.post(PATHFINDER_INTROSPECTION_QUERY))
+        IntrospectionRequest::from(self.post(cynic_introspection::IntrospectionQuery::with_capabilities(
+            cynic_introspection::SpecificationVersion::October2021.capabilities(),
+        )))
     }
 
     pub async fn mcp_sse(&self, path: &str) -> McpStream {

--- a/crates/integration-tests/src/gateway/request/introspection.rs
+++ b/crates/integration-tests/src/gateway/request/introspection.rs
@@ -25,20 +25,6 @@ impl IntrospectionRequest {
         self
     }
 
-    pub fn header_append<Name, Value>(mut self, name: Name, value: Value) -> Self
-    where
-        Name: TryInto<http::HeaderName, Error: std::fmt::Debug>,
-        Value: TryInto<http::HeaderValue, Error: std::fmt::Debug>,
-    {
-        self.0 = self.0.header_append(name, value);
-        self
-    }
-
-    pub fn variables(mut self, variables: impl serde::Serialize) -> Self {
-        self.0 = self.0.variables(variables);
-        self
-    }
-
     pub fn extensions(mut self, extensions: impl serde::Serialize) -> Self {
         self.0 = self.0.extensions(extensions);
         self


### PR DESCRIPTION
- Add support for `gateway.introspect().send().await` which returns a
  string of the introspected data.
- Add support for other extensions with an extra step that installs them
  with the cli if there is more than one.
- Removed the `enable_stdout()` etc. Instead users should just set them
  in the TOML config like any other extension.

A bit of cleanup in the SDK, removing the intermediate `TestConfig`.
