### PR TITLE
chore: Consistent inaccessible

### DIFF
--- a/crates/engine/schema/src/builder/graph/directives/common/mod.rs
+++ b/crates/engine/schema/src/builder/graph/directives/common/mod.rs
@@ -3,8 +3,12 @@ mod deprecated;
 mod list_size;
 mod requires_scopes;
 
+use id_newtypes::IdToMany;
+
 use crate::{
-    Graph, TypeDefinitionId, TypeSystemDirectiveId, UnionDefinitionId,
+    CompositeTypeId, EntityDefinitionId, EnumDefinitionId, FieldDefinitionId, Graph, InputObjectDefinitionId,
+    InputValueDefinitionId, InputValueParentDefinitionId, InterfaceDefinitionId, ObjectDefinitionId, TypeDefinitionId,
+    TypeSystemDirectiveId, UnionDefinitionId,
     builder::{Error, sdl},
 };
 
@@ -114,7 +118,239 @@ impl<'sdl> DirectivesIngester<'_, 'sdl> {
     }
 }
 
+// We don't always have full control over the schema, when coming from a file or schema contract, so we ensure that inaccessibility use is
+// consistent and ends up in a usable schema.
 pub(in crate::builder) fn finalize_inaccessible(graph: &mut Graph) {
+    // If a field argument/input field is inaccessible AND required then the parent field/input object must also
+    // be inaccessible as there is no way for a client to provide the necessary inputs to avoid a
+    // validation failure.
+    let mut output_to_input_value = Vec::with_capacity(graph.input_value_definitions.len() >> 2);
+    for (ix, input_value) in graph.input_value_definitions.iter().enumerate() {
+        let id = InputValueDefinitionId::from(ix);
+        let is_output_inaccessible = match input_value.ty_record.definition_id {
+            TypeDefinitionId::Scalar(id) => graph.inaccessible.scalar_definitions[id],
+            TypeDefinitionId::Object(id) => graph.inaccessible.object_definitions[id],
+            TypeDefinitionId::Interface(id) => graph.inaccessible.interface_definitions[id],
+            TypeDefinitionId::Union(id) => graph.inaccessible.union_definitions[id],
+            TypeDefinitionId::Enum(id) => graph.inaccessible.enum_definitions[id],
+            TypeDefinitionId::InputObject(input_object_id) => {
+                output_to_input_value.push((input_object_id, id));
+                graph.inaccessible.input_object_definitions[input_object_id]
+            }
+        };
+
+        let is_inaccessible = if is_output_inaccessible || input_value.is_internal_in_id.is_some() {
+            graph.inaccessible.input_value_definitions.set(id, true);
+            true
+        } else {
+            graph.inaccessible.input_value_definitions[id]
+        };
+        // We don't propagate inaccessible input values if they're internal and thus not part
+        // of the schema.
+        if is_inaccessible && input_value.ty_record.is_required() && input_value.is_internal_in_id.is_none() {
+            match input_value.parent_id {
+                InputValueParentDefinitionId::Field(field_id) => {
+                    graph.inaccessible.field_definitions.set(field_id, true);
+                }
+                InputValueParentDefinitionId::InputObject(input_object_id) => {
+                    graph.inaccessible.input_object_definitions.set(input_object_id, true)
+                }
+            }
+        }
+    }
+
+    // Propagating upwards inaccessibility if an input_value is required.
+    let mut inaccessible_input_objects = graph.inaccessible.input_object_definitions.ones().collect::<Vec<_>>();
+    let output_to_input_value = IdToMany::from(output_to_input_value);
+    while let Some(id) = inaccessible_input_objects.pop() {
+        for &id in output_to_input_value.find_all(id) {
+            if !graph.inaccessible.input_value_definitions.put(id) {
+                let input_value = &graph.input_value_definitions[usize::from(id)];
+                if input_value.ty_record.is_required() && input_value.is_internal_in_id.is_none() {
+                    match input_value.parent_id {
+                        InputValueParentDefinitionId::Field(field_id) => {
+                            graph.inaccessible.field_definitions.set(field_id, true);
+                        }
+                        InputValueParentDefinitionId::InputObject(input_object_id) => {
+                            if !graph.inaccessible.input_object_definitions.put(input_object_id) {
+                                inaccessible_input_objects.push(input_object_id);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Interfaces, unions, enums and input objects must have at least one field/member.
+    for ix in 0..graph.object_definitions.len() {
+        let id = ObjectDefinitionId::from(ix);
+        if graph.inaccessible.object_definitions[id] {
+            continue;
+        }
+
+        if graph[id]
+            .field_ids
+            .into_iter()
+            .all(|id| graph.inaccessible.field_definitions[id])
+        {
+            graph.inaccessible.object_definitions.set(id, true);
+        }
+    }
+
+    for ix in 0..graph.interface_definitions.len() {
+        let id = InterfaceDefinitionId::from(ix);
+        if graph.inaccessible.interface_definitions[id] {
+            continue;
+        }
+
+        if graph[id]
+            .field_ids
+            .into_iter()
+            .all(|id| graph.inaccessible.field_definitions[id])
+        {
+            graph.inaccessible.interface_definitions.set(id, true);
+        }
+    }
+
+    let mut object_to_union = Vec::new();
+    for ix in 0..graph.union_definitions.len() {
+        let id = UnionDefinitionId::from(ix);
+        if graph.inaccessible.union_definitions[id] {
+            continue;
+        }
+        if graph[id]
+            .possible_type_ids
+            .iter()
+            .all(|id| graph.inaccessible.object_definitions[*id])
+        {
+            graph.inaccessible.union_definitions.set(id, true);
+        } else {
+            object_to_union.extend(graph[id].possible_type_ids.iter().map(|object_id| (*object_id, id)));
+        }
+    }
+    let object_to_unions = IdToMany::from(object_to_union);
+
+    for ix in 0..graph.enum_definitions.len() {
+        let id = EnumDefinitionId::from(ix);
+        if graph.inaccessible.enum_definitions[id] {
+            continue;
+        }
+        if graph[id]
+            .value_ids
+            .into_iter()
+            .all(|id| graph.inaccessible.enum_values[id])
+        {
+            graph.inaccessible.enum_definitions.set(id, true);
+        }
+    }
+
+    for ix in 0..graph.input_object_definitions.len() {
+        let id = InputObjectDefinitionId::from(ix);
+        if graph.inaccessible.input_object_definitions[id] {
+            continue;
+        }
+        if graph[id]
+            .input_field_ids
+            .into_iter()
+            .all(|id| graph.inaccessible.input_value_definitions[id])
+        {
+            graph.inaccessible.input_object_definitions.set(id, true);
+        }
+    }
+
+    // Any field or input_value having an inaccessible type is marked as inaccessible.
+    let mut newly_inaccessible_types = Vec::<CompositeTypeId>::new();
+    let mut composite_type_to_fields = Vec::<(CompositeTypeId, FieldDefinitionId)>::new();
+    for (ix, field) in graph.field_definitions.iter().enumerate() {
+        let id = FieldDefinitionId::from(ix);
+        let is_output_inaccessible = match field.ty_record.definition_id {
+            TypeDefinitionId::Scalar(id) => graph.inaccessible.scalar_definitions[id],
+            TypeDefinitionId::Object(object_id) => {
+                composite_type_to_fields.push((object_id.into(), id));
+                graph.inaccessible.object_definitions[object_id]
+            }
+            TypeDefinitionId::Interface(interface_id) => {
+                composite_type_to_fields.push((interface_id.into(), id));
+                graph.inaccessible.interface_definitions[interface_id]
+            }
+            TypeDefinitionId::Union(union_id) => {
+                composite_type_to_fields.push((union_id.into(), id));
+                graph.inaccessible.union_definitions[union_id]
+            }
+            TypeDefinitionId::Enum(id) => graph.inaccessible.enum_definitions[id],
+            TypeDefinitionId::InputObject(_) => unreachable!(),
+        };
+        if is_output_inaccessible && !graph.inaccessible.field_definitions.put(id) {
+            match graph[id].parent_entity_id {
+                EntityDefinitionId::Interface(id) => {
+                    if graph[id]
+                        .field_ids
+                        .into_iter()
+                        .all(|id| graph.inaccessible.field_definitions[id])
+                        && !graph.inaccessible.interface_definitions.put(id)
+                    {
+                        newly_inaccessible_types.push(id.into());
+                    }
+                }
+                EntityDefinitionId::Object(id) => {
+                    if graph[id]
+                        .field_ids
+                        .into_iter()
+                        .all(|id| graph.inaccessible.field_definitions[id])
+                        && !graph.inaccessible.object_definitions.put(id)
+                    {
+                        newly_inaccessible_types.push(id.into());
+                    }
+                }
+            }
+        }
+    }
+
+    // Propagating upwards inaccessibility if all fields of an entity are inaccessible or if an
+    // union has no accessible members.
+    let composite_type_to_fields = IdToMany::from(composite_type_to_fields);
+    while let Some(id) = newly_inaccessible_types.pop() {
+        if let Some(id) = id.as_object() {
+            for &union_id in object_to_unions.find_all(id) {
+                if graph[union_id]
+                    .possible_type_ids
+                    .iter()
+                    .all(|id| graph.inaccessible.object_definitions[*id])
+                    && !graph.inaccessible.union_definitions.put(union_id)
+                {
+                    newly_inaccessible_types.push(union_id.into());
+                }
+            }
+        }
+        for &field_id in composite_type_to_fields.find_all(id) {
+            if !graph.inaccessible.field_definitions.put(field_id) {
+                match graph[field_id].parent_entity_id {
+                    EntityDefinitionId::Interface(id) => {
+                        if graph[id]
+                            .field_ids
+                            .into_iter()
+                            .all(|id| graph.inaccessible.field_definitions[id])
+                            && !graph.inaccessible.interface_definitions.put(id)
+                        {
+                            newly_inaccessible_types.push(id.into());
+                        }
+                    }
+                    EntityDefinitionId::Object(id) => {
+                        if graph[id]
+                            .field_ids
+                            .into_iter()
+                            .all(|id| graph.inaccessible.field_definitions[id])
+                            && !graph.inaccessible.object_definitions.put(id)
+                        {
+                            newly_inaccessible_types.push(id.into());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     graph.union_has_inaccessible_member.set_all(false);
     graph.interface_has_inaccessible_implementor.set_all(false);
 
@@ -136,33 +372,6 @@ pub(in crate::builder) fn finalize_inaccessible(graph: &mut Graph) {
                 graph.interface_has_inaccessible_implementor.set(id, true);
                 break;
             }
-        }
-    }
-
-    // Any field or input_value having an inaccessible type is marked as inaccessible.
-    // Composition should ensure all of this is consistent, but we ensure it.
-    fn is_definition_inaccessible(graph: &Graph, definition_id: TypeDefinitionId) -> bool {
-        match definition_id {
-            TypeDefinitionId::Scalar(id) => graph.inaccessible.scalar_definitions[id],
-            TypeDefinitionId::Object(id) => graph.inaccessible.object_definitions[id],
-            TypeDefinitionId::Interface(id) => graph.inaccessible.interface_definitions[id],
-            TypeDefinitionId::Union(id) => graph.inaccessible.union_definitions[id],
-            TypeDefinitionId::Enum(id) => graph.inaccessible.enum_definitions[id],
-            TypeDefinitionId::InputObject(id) => graph.inaccessible.input_object_definitions[id],
-        }
-    }
-
-    for (ix, field) in graph.field_definitions.iter().enumerate() {
-        if is_definition_inaccessible(graph, field.ty_record.definition_id) {
-            graph.inaccessible.field_definitions.set(ix.into(), true);
-        }
-    }
-
-    for (ix, input_value) in graph.input_value_definitions.iter().enumerate() {
-        if is_definition_inaccessible(graph, input_value.ty_record.definition_id)
-            || input_value.is_internal_in_id.is_some()
-        {
-            graph.inaccessible.input_value_definitions.set(ix.into(), true);
         }
     }
 }

--- a/crates/engine/schema/src/builder/mod.rs
+++ b/crates/engine/schema/src/builder/mod.rs
@@ -155,7 +155,7 @@ impl BuildContext<'_> {
         let extensions = catalog.iter().map(|ext| ext.manifest.id.clone()).collect();
         let hash = hash::compute(sdl, catalog);
 
-        Ok(Schema {
+        let mut schema = Schema {
             subgraphs,
             graph,
             hash,
@@ -165,7 +165,10 @@ impl BuildContext<'_> {
             regexps: regexps.into(),
             urls: urls.into(),
             config: settings,
-        })
+        };
+        mutable::mark_builtins_and_introspection_as_accessible(&mut schema);
+
+        Ok(schema)
     }
 }
 

--- a/crates/integration-tests/data/extensions/crates/authenticated-19/Cargo.toml
+++ b/crates/integration-tests/data/extensions/crates/authenticated-19/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "authenticated-19"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+repository.workspace = true
+
+[dependencies]
+grafbase-sdk.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+grafbase-sdk = { workspace = true, features = ["test-utils"] }
+indoc = "2"
+insta = { version = "1", features = ["json"] }
+openidconnect = "4"
+ory-client = "1.9"
+reqwest = "0.12"
+serde_json.workspace = true
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "test-util"] }
+
+[lib]
+crate-type = ["cdylib"]

--- a/crates/integration-tests/data/extensions/crates/authenticated-19/definitions.graphql
+++ b/crates/integration-tests/data/extensions/crates/authenticated-19/definitions.graphql
@@ -1,0 +1,1 @@
+directive @authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | ENUM | SCALAR

--- a/crates/integration-tests/data/extensions/crates/authenticated-19/extension.toml
+++ b/crates/integration-tests/data/extensions/crates/authenticated-19/extension.toml
@@ -1,0 +1,6 @@
+[extension]
+name = "authenticated"
+version = "1.0.0"
+kind = "authorization"
+description = ""
+

--- a/crates/integration-tests/data/extensions/crates/authenticated-19/src/lib.rs
+++ b/crates/integration-tests/data/extensions/crates/authenticated-19/src/lib.rs
@@ -1,0 +1,26 @@
+use grafbase_sdk::{
+    AuthorizationExtension, IntoQueryAuthorization,
+    types::{AuthorizationDecisions, Configuration, Error, ErrorResponse, QueryElements, SubgraphHeaders, Token},
+};
+
+#[derive(AuthorizationExtension)]
+struct Authenticated;
+
+impl AuthorizationExtension for Authenticated {
+    fn new(_: Configuration) -> Result<Self, Error> {
+        Ok(Self)
+    }
+
+    fn authorize_query(
+        &mut self,
+        _headers: &mut SubgraphHeaders,
+        token: Token,
+        _elements: QueryElements<'_>,
+    ) -> Result<impl IntoQueryAuthorization, ErrorResponse> {
+        Ok(if token.is_anonymous() {
+            AuthorizationDecisions::deny_all("Not authenticated")
+        } else {
+            AuthorizationDecisions::grant_all()
+        })
+    }
+}

--- a/crates/integration-tests/data/extensions/crates/authenticated-19/tests/hydra.rs
+++ b/crates/integration-tests/data/extensions/crates/authenticated-19/tests/hydra.rs
@@ -1,0 +1,150 @@
+use openidconnect::{
+    ClientId, ClientSecret, EndpointMaybeSet, EndpointNotSet, EndpointSet, IssuerUrl,
+    core::{CoreClient, CoreProviderMetadata},
+};
+use ory_client::apis::configuration::Configuration;
+
+// Defined in compose.yaml
+pub const ISSUER: &str = "http://127.0.0.1:4444";
+pub const JWKS_URI: &str = "http://127.0.0.1:4444/.well-known/jwks.json";
+pub const AUDIENCE: &str = "integration-tests";
+pub const OTHER_AUDIENCE: &str = "other-audience";
+const HYDRA_ADMIN_URL: &str = "http://127.0.0.1:4445";
+// Second provider
+pub const READ_SCOPE: &str = "read";
+pub const WRITE_SCOPE: &str = "write";
+
+pub struct OryHydraOpenIDProvider {
+    issuer: IssuerUrl,
+    ory_config: Configuration,
+}
+
+impl Default for OryHydraOpenIDProvider {
+    fn default() -> Self {
+        Self {
+            issuer: IssuerUrl::new(ISSUER.to_string()).unwrap(),
+            ory_config: Configuration {
+                base_path: HYDRA_ADMIN_URL.to_string(),
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl OryHydraOpenIDProvider {
+    pub async fn create_client(
+        &self,
+    ) -> CoreClient<EndpointSet, EndpointNotSet, EndpointNotSet, EndpointNotSet, EndpointSet, EndpointMaybeSet> {
+        let resp = ory_client::apis::o_auth2_api::create_o_auth2_client(
+            &self.ory_config,
+            ory_client::models::OAuth2Client {
+                access_token_strategy: Some("jwt".into()),
+                grant_types: Some(vec!["client_credentials".into()]),
+                // Allowed audiences
+                audience: Some(vec![AUDIENCE.into(), OTHER_AUDIENCE.into()]),
+                // Allowed scopes
+                scope: Some(format!("{READ_SCOPE} {WRITE_SCOPE}")),
+                ..ory_client::models::OAuth2Client::new()
+            },
+        )
+        .await
+        .unwrap();
+
+        let reqwest_client = reqwest::Client::new();
+        let provider_metadata = CoreProviderMetadata::discover_async(self.issuer.clone(), &reqwest_client)
+            .await
+            .unwrap();
+        let token_uri = provider_metadata.token_endpoint().expect("must be defined").clone();
+
+        CoreClient::from_provider_metadata(
+            provider_metadata,
+            ClientId::new(resp.client_id.unwrap()),
+            Some(ClientSecret::new(resp.client_secret.unwrap())),
+        )
+        .set_token_uri(token_uri)
+        // It is silly that we need to explicitly pass in the token URL, but that's the only way to ensure the returned
+        // client type's has `HasTokenUrl` set to `EndpointSet`, as `from_provider_metadata()` assumes the metadata passed in
+        // may be missing it.
+    }
+}
+
+#[allow(async_fn_in_trait)]
+pub trait CoreClientExt {
+    async fn get_access_token_with_client_credentials(&self, extra_params: &[(&str, &str)]) -> String;
+}
+
+/// Methods requiring a token endpoint. To anybody who ever reads this, I'm sorry. I'm so sorry.
+impl<
+    AC,
+    AD,
+    GC,
+    JE,
+    JS,
+    K,
+    P,
+    TE,
+    TR,
+    TIR,
+    RT,
+    TRE,
+    HasAuthUrl,
+    HasDeviceAuthUrl,
+    HasIntrospectionUrl,
+    HasRevocationUrl,
+    HasUserInfoUrl,
+> CoreClientExt
+    for openidconnect::Client<
+        AC,
+        AD,
+        GC,
+        JE,
+        K,
+        P,
+        TE,
+        TR,
+        TIR,
+        RT,
+        TRE,
+        HasAuthUrl,
+        HasDeviceAuthUrl,
+        HasIntrospectionUrl,
+        HasRevocationUrl,
+        EndpointSet,
+        HasUserInfoUrl,
+    >
+where
+    AC: openidconnect::AdditionalClaims,
+    AD: openidconnect::AuthDisplay,
+    GC: openidconnect::GenderClaim,
+    JS: openidconnect::JwsSigningAlgorithm,
+    JE: openidconnect::JweContentEncryptionAlgorithm<KeyType = JS::KeyType>,
+    K: openidconnect::JsonWebKey<SigningAlgorithm = JS>,
+    P: openidconnect::AuthPrompt,
+    TE: openidconnect::ErrorResponse + 'static,
+    TR: openidconnect::TokenResponse<AC, GC, JE, JS>,
+    TIR: openidconnect::TokenIntrospectionResponse,
+    RT: openidconnect::RevocableToken,
+    TRE: openidconnect::ErrorResponse + 'static,
+    HasAuthUrl: openidconnect::EndpointState,
+    HasDeviceAuthUrl: openidconnect::EndpointState,
+    HasIntrospectionUrl: openidconnect::EndpointState,
+    HasRevocationUrl: openidconnect::EndpointState,
+    HasUserInfoUrl: openidconnect::EndpointState,
+{
+    async fn get_access_token_with_client_credentials(&self, extra_params: &[(&str, &str)]) -> String {
+        let reqwest_client = reqwest::Client::new();
+        let mut request = self.exchange_client_credentials();
+
+        for (key, value) in extra_params {
+            request = request.add_extra_param(*key, *value);
+        }
+
+        request
+            .request_async(&reqwest_client)
+            .await
+            .unwrap()
+            .access_token()
+            .secret()
+            .clone()
+    }
+}

--- a/crates/integration-tests/data/extensions/crates/authenticated-19/tests/integration_tests.rs
+++ b/crates/integration-tests/data/extensions/crates/authenticated-19/tests/integration_tests.rs
@@ -1,0 +1,94 @@
+mod hydra;
+
+use grafbase_sdk::test::{GraphqlSubgraph, TestGateway};
+use hydra::{CoreClientExt as _, JWKS_URI, OryHydraOpenIDProvider};
+use indoc::formatdoc;
+
+#[tokio::test]
+async fn test_authenticated() {
+    let gateway = TestGateway::builder()
+        .toml_config(formatdoc!(
+            r#"
+            [graph]
+            introspection = true
+
+            [authentication]
+            default = "anonymous"
+
+            [extensions.jwt]
+            version = "1.3"
+
+            [extensions.jwt.config]
+            url = "{JWKS_URI}"
+            "#,
+        ))
+        .subgraph(
+            GraphqlSubgraph::with_schema(
+                r#"
+            extend schema
+                @link(url: "<self>", import: ["@authenticated"])
+
+            type Query {
+                public: String
+                private: String @authenticated
+            }
+            "#,
+            )
+            .with_resolver("Query", "public", "public")
+            .with_resolver("Query", "private", "private"),
+        )
+        .build()
+        .await
+        .unwrap();
+
+    let token = OryHydraOpenIDProvider::default()
+        .create_client()
+        .await
+        .get_access_token_with_client_credentials(&[])
+        .await;
+
+    println!("{}", gateway.introspect().send().await);
+
+    let response = gateway.query(r#"query { public private }"#).send().await;
+
+    insta::assert_json_snapshot!(response, @r#"
+    {
+      "data": {
+        "public": "public",
+        "private": null
+      },
+      "errors": [
+        {
+          "message": "Not authenticated",
+          "locations": [
+            {
+              "line": 1,
+              "column": 16
+            }
+          ],
+          "path": [
+            "private"
+          ],
+          "extensions": {
+            "code": "UNAUTHORIZED"
+          }
+        }
+      ]
+    }
+    "#);
+
+    let response = gateway
+        .query(r#"query { public private }"#)
+        .header("Authorization", &format!("Bearer {token}"))
+        .send()
+        .await;
+
+    insta::assert_json_snapshot!(response, @r#"
+    {
+      "data": {
+        "public": "public",
+        "private": "private"
+      }
+    }
+    "#);
+}

--- a/crates/integration-tests/tests/gateway/extensions/contracts/sdk19/unreachable_types.rs
+++ b/crates/integration-tests/tests/gateway/extensions/contracts/sdk19/unreachable_types.rs
@@ -148,6 +148,10 @@ fn interface_types() {
 
     let contract = super::run(sdl, key);
     insta::assert_snapshot!(contract, @r#"
+    interface Entity {
+      name: String!
+    }
+
     interface HiddenInterface {
       data: String!
     }
@@ -514,6 +518,10 @@ fn complex_unreachable_scenario() {
 
     input UnreachableInput {
       field: String
+    }
+
+    interface UnreachableInterface {
+      id: ID!
     }
 
     scalar UnreachableScalar

--- a/crates/integration-tests/tests/gateway/inaccessible/consistency.rs
+++ b/crates/integration-tests/tests/gateway/inaccessible/consistency.rs
@@ -1,0 +1,687 @@
+use integration_tests::{gateway::Gateway, runtime};
+
+#[test]
+fn inaccessible_required_input_value() {
+    runtime().block_on(async {
+        let gateway = Gateway::builder()
+            .with_federated_sdl(
+                r#"
+                directive @core(feature: String!) repeatable on SCHEMA
+
+                directive @join__owner(graph: join__Graph!) on OBJECT
+
+                directive @join__type(
+                    graph: join__Graph!
+                    key: String!
+                    resolvable: Boolean = true
+                ) repeatable on OBJECT | INTERFACE
+
+                directive @join__field(
+                    graph: join__Graph
+                    requires: String
+                    provides: String
+                ) on FIELD_DEFINITION
+
+                directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+                enum join__Graph {
+                    FST @join__graph(name: "fst", url: "http://does.not.exist")
+                }
+
+                type User
+                    @join__type(graph: FST, key: "id")
+                {
+                    id: ID!
+                    name: String @join__field(graph: FST) @deprecated(reason: "we have no name")
+                }
+
+                type Query {
+                    dummy: String @join__field(graph: FST)
+                    user_with_opt(id: ID @inaccessible, x: Int!): User @join__field(graph: FST)
+                    user_with_req(id: ID! @inaccessible): User @join__field(graph: FST)
+                    user_with_nested_opt(input: UserInput, x: Int!): User @join__field(graph: FST)
+                    user_with_nested_req(input: UserInput!): User @join__field(graph: FST)
+                }
+
+                input UserInput @join__field(graph: FST) {
+                    id: ID! @inaccessible
+                }
+                "#,
+            )
+            .with_toml_config(
+                r#"
+                [graph]
+                introspection = true
+                "#,
+            )
+            .build()
+            .await;
+
+        let sdl = gateway.introspect().await;
+        insta::assert_snapshot!(sdl, @r#"
+        type Query {
+          dummy: String
+          user_with_opt(x: Int!): User
+          user_with_nested_opt(x: Int!): User
+        }
+
+        type User {
+          id: ID!
+          name: String @deprecated(reason: "we have no name")
+        }
+        "#);
+    })
+}
+
+#[test]
+fn inaccessible_required_input_value_should_not_impact_composite_require() {
+    runtime().block_on(async {
+        let gateway = Gateway::builder()
+            .with_federated_sdl(
+                r#"
+                directive @core(feature: String!) repeatable on SCHEMA
+
+                directive @join__owner(graph: join__Graph!) on OBJECT
+
+                directive @join__type(
+                    graph: join__Graph!
+                    key: String!
+                    resolvable: Boolean = true
+                ) repeatable on OBJECT | INTERFACE
+
+                directive @join__field(
+                    graph: join__Graph
+                    requires: String
+                    provides: String
+                ) on FIELD_DEFINITION
+
+                directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+                enum join__Graph {
+                    FST @join__graph(name: "fst", url: "http://does.not.exist")
+                }
+
+                type User
+                    @join__type(graph: FST, key: "id")
+                {
+                    id: ID!
+                    friends(userId: ID! @composite__require(graph: FST, field: "id")): [User!]!
+                }
+
+                type Query {
+                    dummy: String @join__field(graph: FST)
+                    user: User
+                }
+                "#,
+            )
+            .with_toml_config(
+                r#"
+                [graph]
+                introspection = true
+                "#,
+            )
+            .build()
+            .await;
+
+        let sdl = gateway.introspect().await;
+        insta::assert_snapshot!(sdl, @r#"
+        type Query {
+          dummy: String
+          user: User
+        }
+
+        type User {
+          id: ID!
+          friends: [User!]!
+        }
+        "#);
+    })
+}
+
+#[test]
+fn inaccessible_interface_with_no_fields() {
+    runtime().block_on(async {
+        let gateway = Gateway::builder()
+            .with_federated_sdl(
+                r#"
+                directive @core(feature: String!) repeatable on SCHEMA
+
+                directive @join__owner(graph: join__Graph!) on OBJECT
+
+                directive @join__type(
+                    graph: join__Graph!
+                    key: String!
+                    resolvable: Boolean = true
+                ) repeatable on OBJECT | INTERFACE
+
+                directive @join__field(
+                    graph: join__Graph
+                    requires: String
+                    provides: String
+                ) on FIELD_DEFINITION
+
+                directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+                enum join__Graph {
+                    FST @join__graph(name: "fst", url: "http://does.not.exist")
+                }
+
+                type User implements Node
+                    @join__type(graph: FST, key: "id")
+                {
+                    id: ID!
+                    name: String @join__field(graph: FST) @deprecated(reason: "we have no name")
+                }
+
+                interface Node @join__type(graph: FST) {
+                    id: ID! @inaccessible
+                }
+
+                type Query @join__type(graph: FST) {
+                    dummy: String
+                    node: Node
+                }
+                "#,
+            )
+            .with_toml_config(
+                r#"
+                [graph]
+                introspection = true
+                "#,
+            )
+            .build()
+            .await;
+
+        let sdl = gateway.introspect().await;
+        insta::assert_snapshot!(sdl, @r#"
+        type Query {
+          dummy: String
+        }
+
+        type User {
+          id: ID!
+          name: String @deprecated(reason: "we have no name")
+        }
+        "#);
+    })
+}
+
+#[test]
+fn inaccessible_object_with_no_fields() {
+    runtime().block_on(async {
+        let gateway = Gateway::builder()
+            .with_federated_sdl(
+                r#"
+                directive @core(feature: String!) repeatable on SCHEMA
+
+                directive @join__owner(graph: join__Graph!) on OBJECT
+
+                directive @join__type(
+                    graph: join__Graph!
+                    key: String!
+                    resolvable: Boolean = true
+                ) repeatable on OBJECT | INTERFACE
+
+                directive @join__field(
+                    graph: join__Graph
+                    requires: String
+                    provides: String
+                ) on FIELD_DEFINITION
+
+                directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+                enum join__Graph {
+                    FST @join__graph(name: "fst", url: "http://does.not.exist")
+                }
+
+                type User
+                    @join__type(graph: FST, key: "id")
+                {
+                    id: ID! @inaccessible
+                }
+
+                type Query @join__type(graph: FST) {
+                    dummy: String
+                    user: User
+                }
+                "#,
+            )
+            .with_toml_config(
+                r#"
+                [graph]
+                introspection = true
+                "#,
+            )
+            .build()
+            .await;
+
+        let sdl = gateway.introspect().await;
+        insta::assert_snapshot!(sdl, @r#"
+        type Query {
+          dummy: String
+        }
+        "#);
+    })
+}
+
+#[test]
+fn inaccessible_input_object_with_no_fields() {
+    runtime().block_on(async {
+        let gateway = Gateway::builder()
+            .with_federated_sdl(
+                r#"
+                directive @core(feature: String!) repeatable on SCHEMA
+
+                directive @join__owner(graph: join__Graph!) on OBJECT
+
+                directive @join__type(
+                    graph: join__Graph!
+                    key: String!
+                    resolvable: Boolean = true
+                ) repeatable on OBJECT | INTERFACE
+
+                directive @join__field(
+                    graph: join__Graph
+                    requires: String
+                    provides: String
+                ) on FIELD_DEFINITION
+
+                directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+                enum join__Graph {
+                    FST @join__graph(name: "fst", url: "http://does.not.exist")
+                }
+
+                type User
+                    @join__type(graph: FST, key: "id")
+                {
+                    id: ID!
+                }
+
+                input UserInput @join__type(graph: FST)  {
+                    id: ID! @inaccessible
+
+                }
+
+                type Query @join__type(graph: FST) {
+                    dummy: String
+                    user(input: UserInput): User
+                }
+                "#,
+            )
+            .with_toml_config(
+                r#"
+                [graph]
+                introspection = true
+                "#,
+            )
+            .build()
+            .await;
+
+        let sdl = gateway.introspect().await;
+        insta::assert_snapshot!(sdl, @r#"
+        type Query {
+          dummy: String
+          user: User
+        }
+
+        type User {
+          id: ID!
+        }
+        "#);
+    })
+}
+
+#[test]
+fn inaccessible_union_with_no_members() {
+    runtime().block_on(async {
+        let gateway = Gateway::builder()
+            .with_federated_sdl(
+                r#"
+                directive @core(feature: String!) repeatable on SCHEMA
+
+                directive @join__owner(graph: join__Graph!) on OBJECT
+
+                directive @join__type(
+                    graph: join__Graph!
+                    key: String!
+                    resolvable: Boolean = true
+                ) repeatable on OBJECT | INTERFACE
+
+                directive @join__field(
+                    graph: join__Graph
+                    requires: String
+                    provides: String
+                ) on FIELD_DEFINITION
+
+                directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+                enum join__Graph {
+                    FST @join__graph(name: "fst", url: "http://does.not.exist")
+                }
+
+                type User
+                    @join__type(graph: FST, key: "id")
+                    @inaccessible
+                {
+                    id: ID!
+                }
+
+                type Account 
+                    @join__type(graph: FST, key: "id")
+                    @inaccessible
+                {
+                    id: ID!
+                }
+
+                union Any = User | Account
+
+                type Query @join__type(graph: FST) {
+                    dummy: String
+                    any: Any
+                }
+                "#,
+            )
+            .with_toml_config(
+                r#"
+                [graph]
+                introspection = true
+                "#,
+            )
+            .build()
+            .await;
+
+        let sdl = gateway.introspect().await;
+        insta::assert_snapshot!(sdl, @r#"
+        type Query {
+          dummy: String
+        }
+        "#);
+    })
+}
+
+#[test]
+fn inaccessible_interface_with_no_fields_propagation() {
+    runtime().block_on(async {
+        let gateway = Gateway::builder()
+            .with_federated_sdl(
+                r#"
+                directive @core(feature: String!) repeatable on SCHEMA
+
+                directive @join__owner(graph: join__Graph!) on OBJECT
+
+                directive @join__type(
+                    graph: join__Graph!
+                    key: String!
+                    resolvable: Boolean = true
+                ) repeatable on OBJECT | INTERFACE
+
+                directive @join__field(
+                    graph: join__Graph
+                    requires: String
+                    provides: String
+                ) on FIELD_DEFINITION
+
+                directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+                enum join__Graph {
+                    FST @join__graph(name: "fst", url: "http://does.not.exist")
+                }
+
+                type User implements Node & SuperNode
+                    @join__type(graph: FST, key: "id")
+                {
+                    id: ID!
+                    name: String @join__field(graph: FST) @deprecated(reason: "we have no name")
+                    node: Node
+                }
+
+                interface SuperNode @join__type(graph: FST) {
+                    node: Node
+                }
+
+                interface Node @join__type(graph: FST) {
+                    id: ID! @inaccessible
+                }
+
+                type Query @join__type(graph: FST) {
+                    dummy: String
+                    node: SuperNode 
+                }
+                "#,
+            )
+            .with_toml_config(
+                r#"
+                [graph]
+                introspection = true
+                "#,
+            )
+            .build()
+            .await;
+
+        let sdl = gateway.introspect().await;
+        insta::assert_snapshot!(sdl, @r#"
+        type Query {
+          dummy: String
+        }
+
+        type User {
+          id: ID!
+          name: String @deprecated(reason: "we have no name")
+        }
+        "#);
+    })
+}
+
+#[test]
+fn inaccessible_object_with_no_fields_propagation() {
+    runtime().block_on(async {
+        let gateway = Gateway::builder()
+            .with_federated_sdl(
+                r#"
+                directive @core(feature: String!) repeatable on SCHEMA
+
+                directive @join__owner(graph: join__Graph!) on OBJECT
+
+                directive @join__type(
+                    graph: join__Graph!
+                    key: String!
+                    resolvable: Boolean = true
+                ) repeatable on OBJECT | INTERFACE
+
+                directive @join__field(
+                    graph: join__Graph
+                    requires: String
+                    provides: String
+                ) on FIELD_DEFINITION
+
+                directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+                enum join__Graph {
+                    FST @join__graph(name: "fst", url: "http://does.not.exist")
+                }
+
+                type User
+                    @join__type(graph: FST, key: "id")
+                {
+                    id: ID! @inaccessible
+                    nested: Nested
+                }
+
+                type Nested @join__type(graph: FST) {
+                    id: ID! @inaccessible
+                }
+
+
+                type Query @join__type(graph: FST) {
+                    dummy: String
+                    user: User
+                }
+                "#,
+            )
+            .with_toml_config(
+                r#"
+                [graph]
+                introspection = true
+                "#,
+            )
+            .build()
+            .await;
+
+        let sdl = gateway.introspect().await;
+        insta::assert_snapshot!(sdl, @r#"
+        type Query {
+          dummy: String
+        }
+        "#);
+    })
+}
+
+#[test]
+fn inaccessible_input_object_no_fields_propagation() {
+    runtime().block_on(async {
+        let gateway = Gateway::builder()
+            .with_federated_sdl(
+                r#"
+                directive @core(feature: String!) repeatable on SCHEMA
+
+                directive @join__owner(graph: join__Graph!) on OBJECT
+
+                directive @join__type(
+                    graph: join__Graph!
+                    key: String!
+                    resolvable: Boolean = true
+                ) repeatable on OBJECT | INTERFACE
+
+                directive @join__field(
+                    graph: join__Graph
+                    requires: String
+                    provides: String
+                ) on FIELD_DEFINITION
+
+                directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+                enum join__Graph {
+                    FST @join__graph(name: "fst", url: "http://does.not.exist")
+                }
+
+                type User
+                    @join__type(graph: FST, key: "id")
+                {
+                    id: ID!
+                }
+
+                input UserInput @join__type(graph: FST) {
+                    id: ID! @inaccessible
+                    nested: NestedInput
+                }
+
+                input NestedInput @join__type(graph: FST) {
+                    id: ID! @inaccessible
+                }
+
+                type Query @join__type(graph: FST) {
+                    dummy: String
+                    user(input: UserInput): User
+                }
+                "#,
+            )
+            .with_toml_config(
+                r#"
+                [graph]
+                introspection = true
+                "#,
+            )
+            .build()
+            .await;
+
+        let sdl = gateway.introspect().await;
+        insta::assert_snapshot!(sdl, @r#"
+        type Query {
+          dummy: String
+          user: User
+        }
+
+        type User {
+          id: ID!
+        }
+        "#);
+    })
+}
+
+#[test]
+fn inaccessible_complex_output_propagation() {
+    runtime().block_on(async {
+        let gateway = Gateway::builder()
+            .with_federated_sdl(
+                r#"
+                directive @core(feature: String!) repeatable on SCHEMA
+
+                directive @join__owner(graph: join__Graph!) on OBJECT
+
+                directive @join__type(
+                    graph: join__Graph!
+                    key: String!
+                    resolvable: Boolean = true
+                ) repeatable on OBJECT | INTERFACE
+
+                directive @join__field(
+                    graph: join__Graph
+                    requires: String
+                    provides: String
+                ) on FIELD_DEFINITION
+
+                directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+                enum join__Graph {
+                    FST @join__graph(name: "fst", url: "http://does.not.exist")
+                }
+
+                type User
+                    @join__type(graph: FST, key: "id")
+                {
+                    id: ID! @inaccessible
+
+                }
+
+                type Account 
+                    @join__type(graph: FST)
+                {
+                    user: User
+                }
+
+                union Any = User | Account
+
+                interface Super @join__type(graph: FST) {
+                    any: Any
+                }
+
+                type Random @join__type(graph: FST) {
+                    super: Super
+                }
+
+                union Any2 = Random
+
+                type Query @join__type(graph: FST) {
+                    dummy: String
+                    any: Any2
+                }
+                "#,
+            )
+            .with_toml_config(
+                r#"
+                [graph]
+                introspection = true
+                "#,
+            )
+            .build()
+            .await;
+
+        let sdl = gateway.introspect().await;
+        insta::assert_snapshot!(sdl, @r#"
+        type Query {
+          dummy: String
+        }
+        "#);
+    })
+}

--- a/crates/integration-tests/tests/gateway/inaccessible/mod.rs
+++ b/crates/integration-tests/tests/gateway/inaccessible/mod.rs
@@ -1,3 +1,4 @@
+mod consistency;
 mod object_behind_interface;
 mod object_behind_union;
 

--- a/gateway/changelog/0.44.0.md
+++ b/gateway/changelog/0.44.0.md
@@ -1,3 +1,7 @@
+## Breaking changes
+
+- It shouldn't any production impact, but now `@inaccessible` consistency is enforced by the gateway. If an required argument has an inaccessible type, the parent field/input object will be inaccessible as a client it's not possible to construct a valid operation with it. Object, interfaces and input objects without fields, and unions without members will also be marked as inaccessible.
+
 ## Fixes
 
 - When authentication extensions are active, the Gateway would previously return 401 responses instead of 404 on unauthenticated requests to routes that do not exist. It now returns 404 responses. (https://github.com/grafbase/grafbase/pull/3296)

--- a/gateway/changelog/0.44.0.md
+++ b/gateway/changelog/0.44.0.md
@@ -1,6 +1,6 @@
 ## Breaking changes
 
-- It shouldn't any production impact, but now `@inaccessible` consistency is enforced by the gateway. If an required argument has an inaccessible type, the parent field/input object will be inaccessible as a client it's not possible to construct a valid operation with it. Object, interfaces and input objects without fields, and unions without members will also be marked as inaccessible.
+- It shouldn't any production impact, but now `@inaccessible` consistency is enforced by the gateway. If an required argument has an inaccessible type, the parent field/input object will be inaccessible, because as a client it's not possible to construct a valid operation with it. Object, interfaces and input objects without fields, and unions without members will also be marked as inaccessible.
 
 ## Fixes
 


### PR DESCRIPTION
If an required argument has an inaccessible type, the parent field/input object will be inaccessible as a client it's not possible to construct a valid operation with it. 

Object, interfaces and input objects without fields, and unions without members will also be marked as inaccessible. Those can't be present in a valid GraphQL schema.

Marked as a breaking change of `0.44` just in case.
