### PR TITLE
graphql-composition: stop rendering composed directives in API SDL

### DIFF
--- a/crates/graphql-composition/CHANGELOG.md
+++ b/crates/graphql-composition/CHANGELOG.md
@@ -18,6 +18,7 @@
 ## Fixes
 
 - When an enum is used both in input and output positions, composition enforces that definitions of that enum in all subgraphs must have exactly the same values. In the case where one subgraph had more values than another, composition would do an out of bound access to test equality, and panic. It's order dependent, so it was not encountered in the existing tests. This commit fixes the out of bound errors, preserving the same logic, and improves the composition error message formulation. (https://github.com/grafbase/grafbase/pull/3292)
+- Directives composed with `@composeDirective` no longer appear in the API SDL, only the federated SDL. API SDL matches the introspection output of the running gateway, which can only return `@deprecated` directives' contents as per the October 2021 version of the GraphQL specification. (https://github.com/grafbase/grafbase/pull/3319)
 
 ## 0.8.0 - 2025-05-16
 

--- a/crates/graphql-composition/src/federated_graph/render_sdl/directive_definition.rs
+++ b/crates/graphql-composition/src/federated_graph/render_sdl/directive_definition.rs
@@ -6,7 +6,7 @@ pub(crate) fn display_directive_definitions(
     // filter the definitions themselves
     definitions_filter: fn(&DirectiveDefinition<'_>) -> bool,
     // filter the directives on the arguments of the definitions
-    directives_filter: fn(&Directive, &FederatedGraph) -> bool,
+    directives_filter: fn(&Directive) -> bool,
     graph: &FederatedGraph,
     f: &mut fmt::Formatter<'_>,
 ) -> fmt::Result {
@@ -45,7 +45,7 @@ pub(crate) fn display_directive_definitions(
 fn display_directive_definition(
     directive_definition: DirectiveDefinition<'_>,
     arguments: &[DirectiveDefinitionArgument],
-    directives_filter: fn(&Directive, graph: &FederatedGraph) -> bool,
+    directives_filter: fn(&Directive) -> bool,
     graph: &FederatedGraph,
     f: &mut fmt::Formatter<'_>,
 ) -> fmt::Result {

--- a/crates/graphql-composition/src/federated_graph/render_sdl/input_value_definition.rs
+++ b/crates/graphql-composition/src/federated_graph/render_sdl/input_value_definition.rs
@@ -8,7 +8,7 @@ use std::fmt;
 pub(crate) fn display_input_value_definition(
     input_value_definition: &InputValueDefinition,
     graph: &FederatedGraph,
-    directives_filter: fn(&Directive, graph: &FederatedGraph) -> bool,
+    directives_filter: fn(&Directive) -> bool,
     f: &mut fmt::Formatter<'_>,
 ) -> fmt::Result {
     write_description(f, input_value_definition.description, INDENT, graph)?;
@@ -24,7 +24,7 @@ pub(crate) fn display_input_value_definition(
     let mut filtered_directives = input_value_definition
         .directives
         .iter()
-        .filter(|directive| directives_filter(directive, graph))
+        .filter(|directive| directives_filter(directive))
         .peekable();
 
     if filtered_directives.peek().is_some() {

--- a/crates/graphql-composition/src/federated_graph/render_sdl/render_api_sdl.rs
+++ b/crates/graphql-composition/src/federated_graph/render_sdl/render_api_sdl.rs
@@ -236,7 +236,7 @@ impl fmt::Display for Renderer<'_> {
     }
 }
 
-fn public_directives_filter(directive: &Directive, graph: &FederatedGraph) -> bool {
+fn public_directives_filter(directive: &Directive) -> bool {
     match directive {
         Directive::Inaccessible
         | Directive::OneOf
@@ -256,10 +256,10 @@ fn public_directives_filter(directive: &Directive, graph: &FederatedGraph) -> bo
         | Directive::CompositeRequire { .. }
         | Directive::CompositeIs { .. }
         | Directive::ExtensionDirective { .. }
-        | Directive::CompositeInternal { .. } => false,
+        | Directive::CompositeInternal { .. }
+        | Directive::Other { .. } => false,
 
-        Directive::Other { name, .. } if graph[*name] == "tag" => false,
-        Directive::Deprecated { .. } | Directive::Other { .. } => true,
+        Directive::Deprecated { .. } => true,
     }
 }
 
@@ -270,7 +270,7 @@ fn write_public_directives<'a, 'b: 'a>(
 ) -> fmt::Result {
     for directive in directives
         .iter()
-        .filter(|directive| public_directives_filter(directive, graph))
+        .filter(|directive| public_directives_filter(directive))
     {
         f.write_str(" ")?;
         write_directive(f, directive, graph)?;

--- a/crates/graphql-composition/src/federated_graph/render_sdl/render_federated_sdl.rs
+++ b/crates/graphql-composition/src/federated_graph/render_sdl/render_federated_sdl.rs
@@ -489,7 +489,7 @@ impl std::fmt::Display for ListSizeRender<'_> {
     }
 }
 
-fn directives_filter(_: &Directive, _: &FederatedGraph) -> bool {
+fn directives_filter(_: &Directive) -> bool {
     true
 }
 

--- a/crates/graphql-composition/tests/composition/authorized_with_composeDirective/api.graphql.snap
+++ b/crates/graphql-composition/tests/composition/authorized_with_composeDirective/api.graphql.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/graphql-composition/tests/composition_tests.rs
-expression: actual_api_sdl
+expression: API SDL
 input_file: crates/graphql-composition/tests/composition/authorized_with_composeDirective/test.md
 ---
 directive @authorized(arguments: String, fields: String, node: String, metadata: _Any) on OBJECT | FIELD_DEFINITION
@@ -12,7 +12,7 @@ type Pet {
 }
 
 type User {
-  address: Address @authorized(fields: "id")
+  address: Address
   id: Int!
   name: String!
   pets: [Pet!]!
@@ -24,8 +24,8 @@ type Address {
 
 type Query {
   pets: [Pet]!
-  user(id: Int!): User @authorized(arguments: "id")
-  users: [User]! @authorized(node: "id", metadata: {role: "admin"})
+  user(id: Int!): User
+  users: [User]!
 }
 
 scalar _Any

--- a/crates/graphql-composition/tests/composition/composed_directives_basic/api.graphql.snap
+++ b/crates/graphql-composition/tests/composition/composed_directives_basic/api.graphql.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/graphql-composition/tests/composition_tests.rs
-expression: actual_api_sdl
+expression: API SDL
 input_file: crates/graphql-composition/tests/composition/composed_directives_basic/test.md
 ---
 enum ObserverType {
@@ -9,7 +9,7 @@ enum ObserverType {
   PROFESSIONAL
 }
 
-type Bird @fieldMarks(plumage: "juvenile") @fieldMarks(plumage: "adult") {
+type Bird {
   id: ID!
   location: String!
   name: String!
@@ -32,7 +32,7 @@ type ObserverDetails {
 }
 
 type BirdSighting @deprecated(reason: "we haven't seen any birds in a while :(") {
-  bird: Bird! @pelagic
+  bird: Bird!
   observer: String!
   sightingID: ID!
   weatherConditions: String

--- a/crates/graphql-composition/tests/composition_tests.rs
+++ b/crates/graphql-composition/tests/composition_tests.rs
@@ -71,13 +71,19 @@ fn run_test(test_path: &Path) -> anyhow::Result<()> {
         (String::new(), String::new())
     };
 
-    let test_description = Some(test_description.as_str().trim())
-        .filter(|desc| !desc.is_empty())
-        .unwrap_or("Federated SDL");
+    let test_description = Some(test_description.as_str().trim()).filter(|desc| !desc.is_empty());
 
-    insta::assert_snapshot!("diagnostics", rendered_diagnostics, test_description);
-    insta::assert_snapshot!("federated.graphql", federated_sdl, test_description);
-    insta::assert_snapshot!("api.graphql", api_sdl, test_description);
+    insta::assert_snapshot!(
+        "diagnostics",
+        rendered_diagnostics,
+        test_description.unwrap_or("Diagnostics")
+    );
+    insta::assert_snapshot!(
+        "federated.graphql",
+        federated_sdl,
+        test_description.unwrap_or("Federated SDL")
+    );
+    insta::assert_snapshot!("api.graphql", api_sdl, test_description.unwrap_or("API SDL"));
 
     check_federated_sdl(&federated_sdl, test_path)
 }


### PR DESCRIPTION
`@composeDirective` affects only the _federated_ SDL, not the SDL of the API exposed to clients. Directives other than `@deprecated` cannot be represented in introspection output.