### PR TITLE
Upgrade rmcp to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,7 +963,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "log",
@@ -5568,15 +5568,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -6598,7 +6589,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.16",
  "http 1.3.1",
@@ -8212,9 +8203,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b008b927a85d514699ff304be84c5084598596e6cad4a6f5bc67207715fafe5f"
+checksum = "824daba0a34f8c5c5392295d381e0800f88fd986ba291699f8785f05fa344c1e"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -8244,9 +8235,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7465280d5f73f2c5c99017a04af407b2262455a149f255ad22f2b0b29087695c"
+checksum = "ad6543c0572a4dbc125c23e6f54963ea9ba002294fd81dd4012c204219b0dcaa"
 dependencies = [
  "darling 0.21.0",
  "proc-macro2",

--- a/cli/tests/integration/mcp.rs
+++ b/cli/tests/integration/mcp.rs
@@ -72,7 +72,7 @@ async fn test_mcp() {
       },
       "serverInfo": {
         "name": "rmcp",
-        "version": "0.3.0"
+        "version": "0.3.1"
       }
     }
     "#);

--- a/crates/integration-tests/tests/gateway/mcp/basic.rs
+++ b/crates/integration-tests/tests/gateway/mcp/basic.rs
@@ -39,7 +39,7 @@ fn server_info() {
         },
         "serverInfo": {
           "name": "rmcp",
-          "version": "0.3.0"
+          "version": "0.3.1"
         },
         "instructions": null
       }


### PR DESCRIPTION
For this commit: https://github.com/modelcontextprotocol/rust-sdk/commit/d251800d19f7cd8e6305f35a348817c7f604687d

We'll return 405s for GETs now.