### PR TITLE
chore: Speed up integration-tests

### DIFF
--- a/.github/workflows/rust-prs.yml
+++ b/.github/workflows/rust-prs.yml
@@ -40,6 +40,19 @@ jobs:
           # Seems like if it's not zero you dont get branches
           fetch-depth: 0
 
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-${{ matrix.platform.target }}
+
       - name: Install rust
         uses: ./.github/actions/install-rust
 
@@ -122,6 +135,16 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-${{ matrix.platform.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Install Rust
         uses: ./.github/actions/install-rust
         with:
@@ -158,6 +181,16 @@ jobs:
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-${{ matrix.platform.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build the grafbase cli
         shell: bash
@@ -229,6 +262,17 @@ jobs:
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            .grafbase/wasm-cache
+            target/
+          key: ${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-${{ matrix.platform.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install Rust
         uses: ./.github/actions/install-rust
@@ -384,6 +428,8 @@ jobs:
           needs.what-changed.outputs.cargo-test-specs
           && matrix.platform.target != 'x86_64-unknown-linux-musl'
         shell: bash
+        env:
+          RUSTC_WRAPPER: 'sccache'
         run: |
           cargo nextest run --target ${{ matrix.platform.target }} --no-tests=warn --profile ci ${{ needs.what-changed.outputs.cargo-test-specs }}
 
@@ -403,6 +449,8 @@ jobs:
           needs.what-changed.outputs.cargo-docker-test-specs
           && matrix.platform.target == 'x86_64-unknown-linux-musl'
         shell: bash
+        env:
+          RUSTC_WRAPPER: 'sccache'
         run: |
           cargo nextest run --target ${{ matrix.platform.target }} --no-tests=warn --profile ci ${{ needs.what-changed.outputs.cargo-docker-test-specs }}
 
@@ -531,6 +579,16 @@ jobs:
 
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ github.workflow }}-${{ github.job }}-${{ runner.os }}-${{ matrix.platform.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Fetch CLI assets
         uses: ./.github/actions/fetch-assets

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+.grafbase
 
 # dependencies
 node_modules

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11142,6 +11142,7 @@ dependencies = [
  "anyhow",
  "async-nats",
  "base64 0.22.1",
+ "blake3",
  "bytes",
  "crossbeam",
  "dashmap 6.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,10 +311,17 @@ debug = true
 # normal optimizations during the compilation stage)
 lto = "thin"
 
-# Boost snapshot diffing performance
+# Set the settings for build scripts and proc-macros.
+[profile.dev.build-override]
+opt-level = 2
+
+[profile.dev.package."*"]
+opt-level = 2
+
 [profile.dev.package]
-insta.opt-level = 2
-similar.opt-level = 2
+# Ensure wasmtime re-uses the same cache, which it doesn't for debug builds.
+# https://github.com/bytecodealliance/wasmtime/blob/main/crates/cache/src/lib.rs#L234
+wasmtime-internal-cache.debug-assertions = false
 
 [profile.lambda]
 inherits = "release"

--- a/crates/gateway-config/src/lib.rs
+++ b/crates/gateway-config/src/lib.rs
@@ -20,6 +20,7 @@ mod size_ext;
 mod subscription_protocol;
 pub mod telemetry;
 mod trusted_documents;
+mod wasm;
 mod websockets_config;
 
 use std::{
@@ -50,6 +51,7 @@ pub use rate_limit::*;
 use size::Size;
 pub use telemetry::*;
 use url::Url;
+pub use wasm::*;
 
 const DEFAULT_GATEWAY_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_SUBGRAPH_TIMEOUT: Duration = Duration::from_secs(30);
@@ -218,6 +220,7 @@ pub struct Config {
     pub websockets: WebsocketsConfig,
     /// Model Control Protocol configuration
     pub mcp: Option<ModelControlProtocolConfig>,
+    pub wasm: Option<WasmConfig>,
 }
 
 impl Config {
@@ -255,6 +258,14 @@ impl Config {
             }
         }
 
+        if let Some(wasm) = &mut self.wasm {
+            if let Some(dir) = &mut wasm.cache_path {
+                if dir.is_relative() {
+                    *dir = parent.join(&dir);
+                }
+            }
+        }
+
         Some(self)
     }
 }
@@ -286,6 +297,7 @@ impl Default for Config {
             websockets: Default::default(),
             extensions: Default::default(),
             mcp: Default::default(),
+            wasm: Default::default(),
         }
     }
 }

--- a/crates/gateway-config/src/wasm.rs
+++ b/crates/gateway-config/src/wasm.rs
@@ -1,0 +1,7 @@
+use std::path::PathBuf;
+
+#[derive(Default, Clone, Debug, serde::Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct WasmConfig {
+    pub cache_path: Option<PathBuf>,
+}

--- a/crates/integration-tests/tests/gateway/extensions/contracts/config.rs
+++ b/crates/integration-tests/tests/gateway/extensions/contracts/config.rs
@@ -146,11 +146,8 @@ fn invalid_cache_size() {
             .await;
 
         insta::assert_snapshot!(gateway.unwrap_err(), @r#"
-        TOML parse error at line 7, column 34
-          |
-        7 |                 cache.max_size = -1
-          |                                  ^^
-        invalid value: integer `-1`, expected usize
+        Failed to parse configuration: invalid value: integer `-1`, expected usize
+        in `graph.contracts.cache.max_size`
         "#);
     });
 }

--- a/crates/wasi-component-loader/Cargo.toml
+++ b/crates/wasi-component-loader/Cargo.toml
@@ -5,6 +5,12 @@ license.workspace = true
 homepage.workspace = true
 keywords.workspace = true
 repository.workspace = true
+build = "build.rs"
+
+[build-dependencies]
+anyhow.workspace = true
+base64.workspace = true
+blake3.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/wasi-component-loader/build.rs
+++ b/crates/wasi-component-loader/build.rs
@@ -1,0 +1,23 @@
+use base64::prelude::*;
+use std::path::Path;
+
+// Getting a cryptographic hash of the Cargo.lock to ensure we don't mix wasmtime caches.
+// Wasmtime seems to have a mechanism for it relying on GIT_REV, but doesn't to work that well.
+fn main() -> anyhow::Result<()> {
+    let lock_path = Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap())
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("Cargo.lock");
+
+    let hash = blake3::hash(&std::fs::read(&lock_path).unwrap());
+    let mut out = String::new();
+    out.push_str("pub const CARGO_LOCK_HASH: &str = \"");
+    out.push_str(&BASE64_URL_SAFE_NO_PAD.encode(hash.as_bytes()));
+    out.push_str("\";");
+
+    std::fs::write(format!("{}/built.rs", std::env::var("OUT_DIR")?), out)?;
+
+    Ok(())
+}

--- a/crates/wasi-component-loader/src/extension/engine.rs
+++ b/crates/wasi-component-loader/src/extension/engine.rs
@@ -1,0 +1,35 @@
+use gateway_config::WasmConfig;
+use wasmtime::{CacheConfig, Engine};
+
+pub(crate) fn build_engine(config: WasmConfig) -> wasmtime::Result<Engine> {
+    let mut cfg = wasmtime::Config::new();
+
+    let cache_dir = config
+        .cache_path
+        .inspect(|path| {
+            assert!(path.is_absolute(), "Config.with_absolute_paths() was not called.");
+        })
+        .or_else(|| {
+            let path = std::env::current_dir().ok()?;
+            Some(path.join(".grafbase").join("wasm-cache"))
+        })
+        .unwrap_or_else(|| std::env::temp_dir().join("grafbase-wasm-cache"));
+
+    tracing::debug!("Using Wasm cache dir: {}", cache_dir.display());
+    cfg.wasm_component_model(true).async_support(true).cache({
+        // Wasmtime seems to have a mechanism to re-use the cache.
+        // But it relies on a GIT_REV var which doesn't exist during compilation
+        // Furthermore the default behavior with debug assertions is to use last modified
+        // time of the current executable, which always changes for integration-tests...
+        let dir = cache_dir.join(crate::built_info::CARGO_LOCK_HASH);
+        if std::fs::create_dir_all(&dir).is_ok() || std::fs::read_dir(&dir).is_ok() {
+            let mut cfg = CacheConfig::new();
+            cfg.with_directory(dir);
+            wasmtime::Cache::new(cfg).ok()
+        } else {
+            None
+        }
+    });
+
+    Engine::new(&cfg)
+}

--- a/crates/wasi-component-loader/src/extension/loader.rs
+++ b/crates/wasi-component-loader/src/extension/loader.rs
@@ -4,7 +4,7 @@ use super::ExtensionInstance;
 use crate::{ExtensionState, extension::api::SdkPre, state::InstanceState};
 use engine_schema::Schema;
 use wasmtime::{
-    CacheConfig, Engine,
+    Engine,
     component::{Component, Linker},
 };
 
@@ -14,33 +14,16 @@ pub(crate) struct ExtensionLoader {
 }
 
 impl ExtensionLoader {
-    pub(crate) fn new(schema: Arc<Schema>, state: Arc<ExtensionState>) -> wasmtime::Result<Self> {
-        let mut wasm_config = wasmtime::Config::new();
-
+    pub(crate) fn new(engine: &Engine, schema: Arc<Schema>, state: Arc<ExtensionState>) -> wasmtime::Result<Self> {
         let cfg = &state.config.wasm;
-        wasm_config
-            .wasm_component_model(true)
-            .async_support(true)
-            .cache(cfg.location.parent().and_then(|parent| {
-                let dir = parent.join("cache");
-                if std::fs::create_dir(&dir).is_ok() || std::fs::read_dir(&dir).is_ok() {
-                    let mut cfg = CacheConfig::new();
-                    cfg.with_directory(dir);
-                    wasmtime::Cache::new(cfg).ok()
-                } else {
-                    None
-                }
-            }));
-
-        let engine = Engine::new(&wasm_config)?;
-        let component = Component::from_file(&engine, &cfg.location)?;
+        let component = Component::from_file(engine, &cfg.location)?;
 
         tracing::debug!(
             location = cfg.location.to_str(),
             "loaded the provided web assembly component successfully",
         );
 
-        let mut linker = Linker::<InstanceState>::new(&engine);
+        let mut linker = Linker::<InstanceState>::new(engine);
 
         // adds the wasi interfaces to our component
         wasmtime_wasi::p2::add_to_linker_async(&mut linker)?;

--- a/crates/wasi-component-loader/src/extension/mod.rs
+++ b/crates/wasi-component-loader/src/extension/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod api;
 mod collection;
 mod config;
+mod engine;
 mod instance;
 mod loader;
 mod pool;
@@ -8,6 +9,8 @@ mod runtime;
 
 pub use collection::*;
 pub(crate) use config::*;
+#[cfg(test)]
+pub(crate) use engine::*;
 pub(crate) use instance::*;
 pub(crate) use loader::*;
 pub(crate) use pool::*;

--- a/crates/wasi-component-loader/src/lib.rs
+++ b/crates/wasi-component-loader/src/lib.rs
@@ -24,3 +24,8 @@ pub use crossbeam::sync::WaitGroup;
 pub use extension::api::wit::Error as GuestError;
 
 use state::{ExtensionState, InstanceState};
+
+mod built_info {
+    // The file has been placed there by the build script.
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}

--- a/crates/wasi-component-loader/src/tests/extensions.rs
+++ b/crates/wasi-component-loader/src/tests/extensions.rs
@@ -2,7 +2,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use crate::{
     ExtensionState, WasmContext,
-    extension::{ExtensionConfig, ExtensionLoader, WasmConfig},
+    extension::{ExtensionConfig, ExtensionLoader, WasmConfig, build_engine},
 };
 use engine_schema::Schema;
 use extension_catalog::{ExtensionId, TypeDiscriminants};
@@ -304,7 +304,9 @@ async fn on_response_hook() {
 }
 
 async fn load(config: ExtensionConfig) -> ExtensionLoader {
+    let engine = build_engine(Default::default()).unwrap();
     ExtensionLoader::new(
+        &engine,
         Arc::new(Schema::from_sdl_or_panic("").await),
         Arc::new(ExtensionState::new(config)),
     )

--- a/gateway/tests/integration_tests.rs
+++ b/gateway/tests/integration_tests.rs
@@ -406,7 +406,14 @@ impl<'a> GatewayBuilder<'a> {
         ];
 
         if let Some(config) = self.toml_config.0 {
-            fs::write(&config_path, config.as_ref()).unwrap();
+            let crate_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+            let project_root = crate_path.parent().unwrap().parent().unwrap();
+            let cache_path = project_root.join(".grafbase").join("wasm-cache");
+
+            let mut config = config.into_owned();
+            config.push_str(&format!("\n[wasm]\ncache_path = \"{}\"\n", cache_path.display()));
+
+            fs::write(&config_path, &config).unwrap();
             args.push("--config".to_string());
             args.push(config_path.to_str().unwrap().to_string());
         }


### PR DESCRIPTION
Currently, even on my 32-cores machines, integration tests are extremely slow because of the wasm compilation. What I didn't realize while adding the wasm cache is that wasmtime adds the mtime of the current executable by default in the path in debug builds... (by checking if debug assertions are enabled or not).
Wasmtime uses a `GIT_REV` var to distinguish between versions, but doesn't work for me. So now disabled the mtime and added a hash of the main `Cargo.lock` file in the path to prevent problems.

In wasi-component-loader I've the structure to use a single engine, instead of one per extension, as the documentation suggests. Before, I was using a nested `cache` dir in the extension folder. That doesn't work anymore now that the engine is shared. So added a:

```toml
[wasm]
cache_path = ".."
```

in the configuration, mostly for us than anything else. If not present it defaults to `<current working dir>/.grafbase/wasm-cache`, and if that doesn't work to `<tmp dir>/grafbase-wasm-cache`.

`integration-tests` & `gateway` tests override it to be `.grafbase/wasm-cache` at the project root level to share the cache as the gateway test re-uses some of the compiled extensions.

Similar to Nexus, adding caching for `~/.cargo` & `target` directories.

Now, on my machine, the `integration-tests` run in 8s warm, 12s cold. It took forever before, especially because of contracts tests that use extensions extensively. We still have cli extension build test that take forever also, but don't know how to solve them yet...