### PR TITLE
feat(examples): Policy example

### DIFF
--- a/examples/authorization/Dockerfile.gateway
+++ b/examples/authorization/Dockerfile.gateway
@@ -1,7 +1,7 @@
-FROM rust:1.87.0-alpine3.20 AS builder
+FROM rust:1.88.0-alpine3.22 AS builder
 
 WORKDIR /var/lib/grafbase
-RUN apk --no-cache add curl bash musl-dev && curl -fsSL https://grafbase.com/downloads/cli | bash -s 0.92.0 && mv ~/.grafbase/bin/grafbase /usr/bin/grafbase
+RUN apk --no-cache add curl bash musl-dev && curl -fsSL https://grafbase.com/downloads/cli | bash -s 0.101.0 && mv ~/.grafbase/bin/grafbase /usr/bin/grafbase
 COPY extensions ./extensions
 
 RUN cd extensions/authentication \

--- a/examples/authorization/Dockerfile.rust
+++ b/examples/authorization/Dockerfile.rust
@@ -1,4 +1,4 @@
-FROM rust:1.87.0-alpine3.20 AS builder
+FROM rust:1.88.0-alpine3.22 AS builder
 
 WORKDIR /usr/src/service
 COPY Cargo.toml Cargo.lock ./
@@ -10,7 +10,7 @@ COPY src ./src
 RUN touch src/main.rs
 RUN cargo build --release
 
-FROM alpine:3.21
+FROM alpine:3.22
 
 ARG BINARY_NAME
 COPY --from=builder /usr/src/service/target/release/${BINARY_NAME} /usr/local/bin/service

--- a/gateway/tests/access_logs/mod.rs
+++ b/gateway/tests/access_logs/mod.rs
@@ -22,10 +22,11 @@ fn with_working_subgraph_rate_limited() {
 
         [subgraphs.accounts.rate_limit]
         limit = 1
-        duration = "1m"
+        duration = "5s"
     "#};
 
     with_gateway(&config, Some(200), |gateway| async move {
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
         let resp = gateway
             .gql::<serde_json::Value>("query Simple { me { id } }")
             .header("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01")


### PR DESCRIPTION
Will pass the CI once I've publised the latest CLI & gateway.

Add a `policy` extension in our authorization example, following the same logic as Apollo federation `@policy`. It requests data from an external auth service.