### PR TITLE
gateway: release 0.46.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3978,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase-gateway"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "anyhow",
  "ascii",

--- a/gateway/CHANGELOG.md
+++ b/gateway/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.46.1] - 2025-07-31
+
+[CHANGELOG](changelog/0.46.1.md)
+
 ## [0.36.0] - 2025-04-24
 
 [CHANGELOG](changelog/0.36.0.md)

--- a/gateway/Cargo.toml
+++ b/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grafbase-gateway"
-version = "0.46.0"
+version = "0.46.1"
 edition.workspace = true
 license = "MPL-2.0"
 homepage.workspace = true

--- a/gateway/changelog/0.46.1.md
+++ b/gateway/changelog/0.46.1.md
@@ -1,0 +1,3 @@
+## Bug fixes
+
+- Using --graph-ref with a graph ref containing a branch that has slashes or other special characters in its name now works as expected, instead of behaving as if the branch did not exist. (https://github.com/grafbase/grafbase/pull/3336)


### PR DESCRIPTION
## Bug fixes

- Using --graph-ref with a graph ref containing a branch that has slashes or other special characters in its name now works as expected, instead of behaving as if the branch did not exist. (https://github.com/grafbase/grafbase/pull/3336)