### PR TITLE
feat(composite/lookup): Accept namespaces for the output.

### DIFF
--- a/crates/engine/codegen/domain/schema.graphql
+++ b/crates/engine/codegen/domain/schema.graphql
@@ -391,6 +391,9 @@ type LookupResolverDefinition @meta(module: "resolver/lookup") @indexed(id_size:
   field_definition: FieldDefinition!
   resolver: ResolverDefinition!
   guest_batch: Boolean!
+  # If the lookup result is nested within a key such as: `{"data": [<entities>]}` for gRPC typically which
+  # doesn't support returning a list directly.
+  namespace_key: String
   injections: [ArgumentInjection!]!
 }
 

--- a/crates/engine/schema/src/builder/graph/directives/mod.rs
+++ b/crates/engine/schema/src/builder/graph/directives/mod.rs
@@ -8,10 +8,12 @@ use crate::builder::{Error, extension::ingest_extension_schema_directives, sdl};
 use super::*;
 pub(in crate::builder) use common::finalize_inaccessible;
 
+pub(crate) type PossibleCompositeEntityKeys<'sdl> =
+    FxHashMap<(EntityDefinitionId, SubgraphId), Vec<PossibleCompositeEntityKey<'sdl>>>;
+
 pub(crate) struct DirectivesIngester<'a, 'sdl> {
     pub builder: &'a mut GraphBuilder<'sdl>,
-    pub possible_composite_entity_keys:
-        FxHashMap<(EntityDefinitionId, SubgraphId), Vec<PossibleCompositeEntityKey<'sdl>>>,
+    pub possible_composite_entity_keys: PossibleCompositeEntityKeys<'sdl>,
     pub for_operation_analytics_only: bool,
 }
 

--- a/crates/engine/schema/src/generated/resolver/lookup.rs
+++ b/crates/engine/schema/src/generated/resolver/lookup.rs
@@ -4,7 +4,7 @@
 //! Generated with: `cargo run -p engine-codegen`
 //! Source file: <engine-codegen dir>/domain/schema.graphql
 use crate::{
-    FieldSet, FieldSetRecord,
+    FieldSet, FieldSetRecord, StringId,
     generated::{
         ArgumentInjection, ArgumentInjectionId, FieldDefinition, FieldDefinitionId, ResolverDefinition,
         ResolverDefinitionId,
@@ -22,6 +22,9 @@ use walker::{Iter, Walk};
 ///   field_definition: FieldDefinition!
 ///   resolver: ResolverDefinition!
 ///   guest_batch: Boolean!
+///   # If the lookup result is nested within a key such as: `{"data": [<entities>]}` for gRPC typically which
+///   # doesn't support returning a list directly.
+///   namespace_key: String
 ///   injections: [ArgumentInjection!]!
 /// }
 /// ```
@@ -31,6 +34,7 @@ pub struct LookupResolverDefinitionRecord {
     pub field_definition_id: FieldDefinitionId,
     pub resolver_id: ResolverDefinitionId,
     pub guest_batch: bool,
+    pub namespace_key_id: Option<StringId>,
     pub injection_ids: IdRange<ArgumentInjectionId>,
 }
 
@@ -65,6 +69,9 @@ impl<'a> LookupResolverDefinition<'a> {
     pub fn resolver(&self) -> ResolverDefinition<'a> {
         self.resolver_id.walk(self.schema)
     }
+    pub fn namespace_key(&self) -> Option<&'a str> {
+        self.namespace_key_id.walk(self.schema)
+    }
     pub fn injections(&self) -> impl Iter<Item = ArgumentInjection<'a>> + 'a {
         self.as_ref().injection_ids.walk(self.schema)
     }
@@ -94,6 +101,7 @@ impl std::fmt::Debug for LookupResolverDefinition<'_> {
             .field("field_definition", &self.field_definition())
             .field("resolver", &self.resolver())
             .field("guest_batch", &self.guest_batch)
+            .field("namespace_key", &self.namespace_key())
             .field("injections", &self.injections())
             .finish()
     }

--- a/crates/engine/src/resolver/graphql/federation/with_cache.rs
+++ b/crates/engine/src/resolver/graphql/federation/with_cache.rs
@@ -157,7 +157,7 @@ impl<'de> Visitor<'de> for PartiallyCachedEntitiesSeed<'_, '_, '_, 'de> {
     type Value = ();
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str("a non null entities list")
+        formatter.write_str("an non null entities list")
     }
 
     fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>

--- a/crates/engine/src/resolver/lookup/nested.rs
+++ b/crates/engine/src/resolver/lookup/nested.rs
@@ -1,0 +1,87 @@
+use serde::de::{DeserializeSeed, IgnoredAny, Visitor};
+
+use crate::response::Key;
+
+pub(in crate::resolver) struct NestedSeed<'ctx, Seed> {
+    pub key: &'ctx str,
+    pub seed: Seed,
+}
+
+impl<'de, 'ctx, Seed> DeserializeSeed<'de> for NestedSeed<'ctx, Seed>
+where
+    'ctx: 'de,
+    Seed: DeserializeSeed<'de>,
+{
+    type Value = <Seed as DeserializeSeed<'de>>::Value;
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(self)
+    }
+}
+
+impl<'de, 'ctx, Seed> Visitor<'de> for NestedSeed<'ctx, Seed>
+where
+    'ctx: 'de,
+    Seed: DeserializeSeed<'de>,
+{
+    type Value = <Seed as DeserializeSeed<'de>>::Value;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("an object")
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        self.visit_none()
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(self
+            .seed
+            .deserialize(serde_json::Value::Null)
+            .expect("Deserializer never fails"))
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        let Self {
+            key: expected_key,
+            seed,
+        } = self;
+        enum State<S, V> {
+            Seed(S),
+            Value(V),
+        }
+        let mut state = State::Seed(seed);
+
+        while let Some(key) = map.next_key::<Key<'_>>()? {
+            if key.as_ref() == expected_key {
+                state = match state {
+                    State::Seed(seed) => State::Value(map.next_value_seed(seed)?),
+                    s => {
+                        map.next_value::<IgnoredAny>()?;
+                        s
+                    }
+                };
+            } else {
+                map.next_value::<IgnoredAny>()?;
+            }
+        }
+
+        match state {
+            State::Value(value) => Ok(value),
+            State::Seed(seed) => Ok(seed
+                .deserialize(serde_json::Value::Null)
+                .expect("Deserializer never fails")),
+        }
+    }
+}

--- a/crates/engine/src/response/write/deserialize/mod.rs
+++ b/crates/engine/src/response/write/deserialize/mod.rs
@@ -15,6 +15,7 @@ use serde::de::DeserializeSeed;
 use crate::response::{GraphqlError, ResponseObjectRef};
 
 use self::r#enum::*;
+pub(crate) use key::*;
 use list::ListSeed;
 use scalar::*;
 pub(crate) use state::*;

--- a/crates/engine/src/response/write/deserialize/root/batch_objects.rs
+++ b/crates/engine/src/response/write/deserialize/root/batch_objects.rs
@@ -41,7 +41,7 @@ where
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_seq(self)
+        deserializer.deserialize_any(self)
     }
 }
 
@@ -53,7 +53,23 @@ where
     type Value = ();
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str("a non null entities list")
+        formatter.write_str("an entities list")
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        self.visit_none()
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        self.deserialize(serde_json::Value::Array(Vec::new()))
+            .expect("Deserializer never fails");
+        Ok(())
     }
 
     fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>

--- a/crates/integration-tests/tests/gateway/composite/lookup/is/batch/composite.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/is/batch/composite.rs
@@ -33,7 +33,7 @@ fn basic() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -90,7 +90,7 @@ fn renames() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -147,7 +147,7 @@ fn arg_type_compatibility_nullable_list() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -204,7 +204,7 @@ fn arg_type_compatibility_inner_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -261,7 +261,7 @@ fn arg_type_compatibility_inner_and_list_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -318,7 +318,7 @@ fn arg_with_same_name_and_extra_optional_input_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -376,7 +376,7 @@ fn arg_with_same_name_and_extra_optional_input_field() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -433,7 +433,7 @@ fn different_input_field_types() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -491,7 +491,7 @@ fn field_with_default_value() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -550,7 +550,7 @@ fn field_with_default_value_coercion() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -610,7 +610,7 @@ fn cannot_inject_nullable_field_into_required() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -653,7 +653,7 @@ fn invalid_batch() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -696,7 +696,7 @@ fn extra_required_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -740,7 +740,7 @@ fn extra_required_field() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 

--- a/crates/integration-tests/tests/gateway/composite/lookup/is/batch/mod.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/is/batch/mod.rs
@@ -1,5 +1,6 @@
 mod composite;
-mod nested;
+mod nested_key;
+mod nested_output;
 mod oneof;
 mod oneof_composite;
 
@@ -32,7 +33,7 @@ fn basic() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -81,7 +82,7 @@ fn arg_type_compatibility_nullable_list() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -130,7 +131,7 @@ fn arg_type_compatibility_inner_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -179,7 +180,7 @@ fn arg_type_compatibility_inner_and_list_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -228,7 +229,7 @@ fn arg_with_default_value() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -277,7 +278,7 @@ fn arg_with_default_value_coercion() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -328,7 +329,7 @@ fn multiple_injections() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -379,7 +380,7 @@ fn no_matching_key() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -416,7 +417,7 @@ fn cannot_inject_nullable_into_required() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -453,7 +454,7 @@ fn bad_type() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -490,7 +491,7 @@ fn not_a_list() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -527,7 +528,7 @@ fn extra_required_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 

--- a/crates/integration-tests/tests/gateway/composite/lookup/is/batch/nested_output.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/is/batch/nested_output.rs
@@ -1,0 +1,275 @@
+use integration_tests::{gateway::Gateway, runtime};
+
+use super::super::super::{EchoLookup, gql_id};
+
+#[test]
+fn single_field() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph(gql_id())
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "echo-1.0.0", import: ["@echo"])
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key", "@is", "@shareable"])
+
+
+                type Query {
+                    productLookup(id: [ID!]! @is(field: "[id]")): Namespace! @lookup @echo
+                }
+
+                type Namespace {
+                    product: [Product!]!
+                }
+
+                type Product @key(fields: "id") {
+                    id: ID!
+                    args: JSON
+                }
+
+                scalar JSON
+                "#,
+            )
+            .with_extension(EchoLookup::batch().namespaced("product"))
+            .build()
+            .await;
+
+        let response = engine.post("query { products { args } }").await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "products": [
+              {
+                "args": {
+                  "id": [
+                    "1"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+        "#);
+    })
+}
+
+#[test]
+fn other_unrelated_fields() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph(gql_id())
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "echo-1.0.0", import: ["@echo"])
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key", "@is", "@shareable"])
+
+
+                type Query {
+                    productLookup(id: [ID!]! @is(field: "[id]")): Namespace! @lookup @echo
+                }
+
+                type Namespace {
+                    product: [Product!]!
+                    other: String
+                    anything: JSON
+                }
+
+                type Product @key(fields: "id") {
+                    id: ID!
+                    args: JSON
+                }
+
+                scalar JSON
+                "#,
+            )
+            .with_extension(EchoLookup::batch().namespaced("product"))
+            .build()
+            .await;
+
+        let response = engine.post("query { products { args } }").await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "products": [
+              {
+                "args": {
+                  "id": [
+                    "1"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+        "#);
+    })
+}
+
+#[test]
+fn invalid_namespace_key_at_runtime() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph(gql_id())
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "echo-1.0.0", import: ["@echo"])
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key", "@is", "@shareable"])
+
+
+                type Query {
+                    productLookup(id: [ID!]! @is(field: "[id]")): Namespace! @lookup @echo
+                }
+
+                type Namespace {
+                    product: [Product!]!
+                }
+
+                type Product @key(fields: "id") {
+                    id: ID!
+                    args: JSON
+                }
+
+                scalar JSON
+                "#,
+            )
+            .with_extension(EchoLookup::batch().namespaced("wrong key"))
+            .build()
+            .await;
+
+        let response = engine.post("query { products { args } }").await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "products": [
+              {
+                "args": null
+              }
+            ]
+          },
+          "errors": [
+            {
+              "message": "Invalid response from subgraph",
+              "locations": [
+                {
+                  "line": 1,
+                  "column": 20
+                }
+              ],
+              "path": [
+                "products",
+                0,
+                "args"
+              ],
+              "extensions": {
+                "code": "SUBGRAPH_INVALID_RESPONSE_ERROR"
+              }
+            }
+          ]
+        }
+        "#);
+    })
+}
+
+#[test]
+fn nested_but_unknown_fields() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph(gql_id())
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "echo-1.0.0", import: ["@echo"])
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key", "@is", "@shareable"])
+
+
+                type Query {
+                    productLookup(id: [ID!]! @is(field: "[id]")): Namespace! @lookup @echo
+                }
+
+                type Namespace {
+                    other: String
+                    anything: JSON
+                }
+
+                type Product @key(fields: "id") {
+                    id: ID!
+                    args: JSON
+                }
+
+                scalar JSON
+                "#,
+            )
+            .with_extension(EchoLookup::batch().namespaced("product"))
+            .try_build()
+            .await;
+
+        insta::assert_snapshot!(result.unwrap_err(), @r"
+        At site Query.productLookup, for directive @lookup Type Namespace doesn't define any keys with @key directive that may be used for @lookup. Tried treating it as a namespace type, but it didn't have any fields that may be used for @lookup.
+        See schema at 23:1:
+        type Namespace
+          @join__type(graph: EXT)
+        {
+          anything: JSON
+          other: String
+        }
+        ");
+    })
+}
+
+#[test]
+fn multiple_entities() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph(gql_id())
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "echo-1.0.0", import: ["@echo"])
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key", "@is", "@shareable"])
+
+
+                type Query {
+                    productLookup(id: [ID!]! @is(field: "[id]")): Namespace! @lookup @echo
+                }
+
+                type Namespace {
+                    product: [Product!]!
+                    account: [Account!]!
+                }
+
+                type Product @key(fields: "id") {
+                    id: ID!
+                    args: JSON
+                }
+
+                type Account @key(fields: "id") {
+                    id: ID!
+                    args: JSON
+                }
+
+                scalar JSON
+                "#,
+            )
+            .with_extension(EchoLookup::batch().namespaced("product"))
+            .try_build()
+            .await;
+
+        insta::assert_snapshot!(result.unwrap_err(), @r"
+        At site Query.productLookup, for directive @lookup Type Namespace doesn't define any keys with @key directive that may be used for @lookup. Tried treating it as a namespace type, but it has multiple fields that may be used for @lookup: product and account
+        See schema at 23:1:
+        type Namespace
+          @join__type(graph: EXT)
+        {
+          account: [Account!]!
+          product: [Product!]!
+        }
+        ");
+    })
+}

--- a/crates/integration-tests/tests/gateway/composite/lookup/is/batch/oneof.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/is/batch/oneof.rs
@@ -31,7 +31,7 @@ fn basic() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -89,7 +89,7 @@ fn multiple_keys() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -162,7 +162,7 @@ fn nullable_lookup() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -217,7 +217,7 @@ fn arg_type_compatibility_inner_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -273,7 +273,7 @@ fn arg_with_same_name_and_extra_input_field_with_matching_type() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -329,7 +329,7 @@ fn other_input_field() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -384,7 +384,7 @@ fn invalid_batch() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -425,7 +425,7 @@ fn multiple_injections_oneof() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -466,7 +466,7 @@ fn extra_required_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 

--- a/crates/integration-tests/tests/gateway/composite/lookup/is/batch/oneof_composite.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/is/batch/oneof_composite.rs
@@ -37,7 +37,7 @@ fn basic() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -100,7 +100,7 @@ fn nullable_lookup() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -163,7 +163,7 @@ fn arg_type_compatibility_inner_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -227,7 +227,7 @@ fn arg_with_same_name_and_extra_input_field() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -290,7 +290,7 @@ fn arg_with_different_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -353,7 +353,7 @@ fn invalid_batch() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -400,7 +400,7 @@ fn extra_required_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -448,7 +448,7 @@ fn extra_required_field() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 

--- a/crates/integration-tests/tests/gateway/composite/lookup/is/single/composite.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/is/single/composite.rs
@@ -33,7 +33,7 @@ fn basic() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -88,7 +88,7 @@ fn renames() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -143,7 +143,7 @@ fn arg_type_compatibility_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -198,7 +198,7 @@ fn all_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -253,7 +253,7 @@ fn arg_with_same_name_and_extra_optional_input_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -309,7 +309,7 @@ fn arg_with_same_name_and_extra_optional_input_field() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -364,7 +364,7 @@ fn different_input_field_types() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -420,7 +420,7 @@ fn field_with_default_value() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -477,7 +477,7 @@ fn field_with_default_value_coercion() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -535,7 +535,7 @@ fn cannot_inject_nullable_field_into_required() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -578,7 +578,7 @@ fn invalid_single() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -621,7 +621,7 @@ fn extra_required_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -665,7 +665,7 @@ fn extra_required_field() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 

--- a/crates/integration-tests/tests/gateway/composite/lookup/is/single/mod.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/is/single/mod.rs
@@ -1,5 +1,6 @@
 mod composite;
-mod nested;
+mod nested_key;
+mod nested_output;
 mod oneof;
 mod oneof_composite;
 
@@ -32,7 +33,7 @@ fn basic() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -79,7 +80,7 @@ fn arg_type_compatibility_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -126,7 +127,7 @@ fn arg_with_default_value() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -173,7 +174,7 @@ fn arg_with_default_value_coercion() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -222,7 +223,7 @@ fn multiple_injections() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -269,7 +270,7 @@ fn no_matching_key() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -306,7 +307,7 @@ fn cannot_inject_nullable_into_required() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -343,7 +344,7 @@ fn bad_type() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -380,7 +381,7 @@ fn is_a_list() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -417,7 +418,7 @@ fn extra_required_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 

--- a/crates/integration-tests/tests/gateway/composite/lookup/is/single/nested_output.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/is/single/nested_output.rs
@@ -1,0 +1,252 @@
+use integration_tests::{gateway::Gateway, runtime};
+
+use super::super::super::{EchoLookup, gql_id};
+
+#[test]
+fn single_field() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph(gql_id())
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "echo-1.0.0", import: ["@echo"])
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key", "@is", "@shareable"])
+
+
+                type Query {
+                    productLookup(id: ID! @is(field: "id")): Namespace! @lookup @echo
+                }
+
+                type Namespace {
+                    product: Product!
+                }
+
+                type Product @key(fields: "id") {
+                    id: ID!
+                    args: JSON
+                }
+
+                scalar JSON
+                "#,
+            )
+            .with_extension(EchoLookup::single().namespaced("product"))
+            .build()
+            .await;
+
+        let response = engine.post("query { products { args } }").await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "products": [
+              {
+                "args": {
+                  "id": "1"
+                }
+              }
+            ]
+          }
+        }
+        "#);
+    })
+}
+
+#[test]
+fn other_unrelated_fields() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph(gql_id())
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "echo-1.0.0", import: ["@echo"])
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key", "@is", "@shareable"])
+
+
+                type Query {
+                    productLookup(id: ID! @is(field: "id")): Namespace! @lookup @echo
+                }
+
+                type Namespace {
+                    product: Product!
+                    other: String
+                    anything: JSON
+                }
+
+                type Product @key(fields: "id") {
+                    id: ID!
+                    args: JSON
+                }
+
+                scalar JSON
+                "#,
+            )
+            .with_extension(EchoLookup::single().namespaced("product"))
+            .build()
+            .await;
+
+        let response = engine.post("query { products { args } }").await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "products": [
+              {
+                "args": {
+                  "id": "1"
+                }
+              }
+            ]
+          }
+        }
+        "#);
+    })
+}
+
+#[test]
+fn invalid_namespace_key_at_runtime() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph(gql_id())
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "echo-1.0.0", import: ["@echo"])
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key", "@is", "@shareable"])
+
+
+                type Query {
+                    productLookup(id: ID! @is(field: "id")): Namespace! @lookup @echo
+                }
+
+                type Namespace {
+                    product: Product!
+                }
+
+                type Product @key(fields: "id") {
+                    id: ID!
+                    args: JSON
+                }
+
+                scalar JSON
+                "#,
+            )
+            .with_extension(EchoLookup::single().namespaced("wrong key"))
+            .build()
+            .await;
+
+        let response = engine.post("query { products { args } }").await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "products": [
+              {
+                "args": null
+              }
+            ]
+          }
+        }
+        "#);
+    })
+}
+
+#[test]
+fn nested_but_unknown_fields() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph(gql_id())
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "echo-1.0.0", import: ["@echo"])
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key", "@is", "@shareable"])
+
+
+                type Query {
+                    productLookup(id: ID! @is(field: "id")): Namespace! @lookup @echo
+                }
+
+                type Namespace {
+                    other: String
+                    anything: JSON
+                }
+
+                type Product @key(fields: "id") {
+                    id: ID!
+                    args: JSON
+                }
+
+                scalar JSON
+                "#,
+            )
+            .with_extension(EchoLookup::single().namespaced("product"))
+            .try_build()
+            .await;
+
+        insta::assert_snapshot!(result.unwrap_err(), @r"
+        At site Query.productLookup, for directive @lookup Type Namespace doesn't define any keys with @key directive that may be used for @lookup. Tried treating it as a namespace type, but it didn't have any fields that may be used for @lookup.
+        See schema at 23:1:
+        type Namespace
+          @join__type(graph: EXT)
+        {
+          anything: JSON
+          other: String
+        }
+        ");
+    })
+}
+
+#[test]
+fn multiple_entities() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph(gql_id())
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "echo-1.0.0", import: ["@echo"])
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key", "@is", "@shareable"])
+
+
+                type Query {
+                    productLookup(id: ID! @is(field: "id")): Namespace! @lookup @echo
+                }
+
+                type Namespace {
+                    product: Product!
+                    account: Account!
+                }
+
+                type Product @key(fields: "id") {
+                    id: ID!
+                    args: JSON
+                }
+
+                type Account @key(fields: "id") {
+                    id: ID!
+                    args: JSON
+                }
+
+                scalar JSON
+                "#,
+            )
+            .with_extension(EchoLookup::single().namespaced("product"))
+            .try_build()
+            .await;
+
+        insta::assert_snapshot!(result.unwrap_err(), @r"
+        At site Query.productLookup, for directive @lookup Type Namespace doesn't define any keys with @key directive that may be used for @lookup. Tried treating it as a namespace type, but it has multiple fields that may be used for @lookup: product and account
+        See schema at 23:1:
+        type Namespace
+          @join__type(graph: EXT)
+        {
+          account: Account!
+          product: Product!
+        }
+        ");
+    })
+}

--- a/crates/integration-tests/tests/gateway/composite/lookup/is/single/oneof.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/is/single/oneof.rs
@@ -31,7 +31,7 @@ fn basic() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -87,7 +87,7 @@ fn multiple_keys() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -156,7 +156,7 @@ fn nullable_lookup() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -209,7 +209,7 @@ fn arg_type_compatibility_inner_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -263,7 +263,7 @@ fn arg_with_same_name_and_extra_input_field_with_matching_type() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -316,7 +316,7 @@ fn arg_with_different_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -370,7 +370,7 @@ fn other_input_field() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -423,7 +423,7 @@ fn invalid_single() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -464,7 +464,7 @@ fn multiple_injections_oneof() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -505,7 +505,7 @@ fn extra_required_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 

--- a/crates/integration-tests/tests/gateway/composite/lookup/is/single/oneof_composite.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/is/single/oneof_composite.rs
@@ -37,7 +37,7 @@ fn basic() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -98,7 +98,7 @@ fn nullable_lookup() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -160,7 +160,7 @@ fn arg_with_same_name_and_extra_input_field() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -221,7 +221,7 @@ fn arg_with_different_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -282,7 +282,7 @@ fn invalid_single() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -329,7 +329,7 @@ fn extra_required_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -377,7 +377,7 @@ fn extra_required_field() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 

--- a/crates/integration-tests/tests/gateway/composite/lookup/key/batch/composite.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/key/batch/composite.rs
@@ -33,7 +33,7 @@ fn arg_with_same_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -90,7 +90,7 @@ fn arg_type_compatibility_nullable_list() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -147,7 +147,7 @@ fn arg_type_compatibility_inner_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -204,7 +204,7 @@ fn arg_type_compatibility_inner_and_list_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -261,7 +261,7 @@ fn arg_with_same_name_and_extra_optional_input_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -319,7 +319,7 @@ fn arg_with_same_name_and_extra_optional_input_field_with_matching_type() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -376,7 +376,7 @@ fn arg_with_different_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -435,7 +435,7 @@ fn arg_with_different_name_and_extra_optional_arg_with_matching_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -493,7 +493,7 @@ fn field_with_default_value() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -552,7 +552,7 @@ fn field_with_default_value_coercion() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -607,7 +607,7 @@ fn no_arguments() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -645,7 +645,7 @@ fn no_matching_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -688,7 +688,7 @@ fn good_name_bad_type() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -731,7 +731,7 @@ fn good_name_not_a_list() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -774,7 +774,7 @@ fn cannot_inject_nullable_field_into_required() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -817,7 +817,7 @@ fn ambiguous_multiple_arg_matches() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -861,7 +861,7 @@ fn ambiguous_multiple_input_field_matches() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -904,7 +904,7 @@ fn extra_required_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -948,7 +948,7 @@ fn extra_required_field() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 

--- a/crates/integration-tests/tests/gateway/composite/lookup/key/batch/mod.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/key/batch/mod.rs
@@ -1,5 +1,6 @@
 mod composite;
-mod nested;
+mod nested_key;
+mod nested_output;
 mod oneof;
 mod oneof_composite;
 
@@ -32,7 +33,7 @@ fn arg_with_same_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -81,7 +82,7 @@ fn arg_type_compatibility_nullable_list() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -130,7 +131,7 @@ fn arg_type_compatibility_inner_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -179,7 +180,7 @@ fn arg_type_compatibility_inner_and_list_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -228,7 +229,7 @@ fn arg_with_same_name_and_extra_optional_arg_with_matching_type() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -277,7 +278,7 @@ fn arg_with_different_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -326,7 +327,7 @@ fn arg_with_different_name_and_extra_optional_arg_with_matching_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -375,7 +376,7 @@ fn arg_with_default_value() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -424,7 +425,7 @@ fn arg_with_default_value_coercion() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -475,7 +476,7 @@ fn no_arguments() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -512,7 +513,7 @@ fn no_matching_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -549,7 +550,7 @@ fn cannot_inject_nullable_into_required() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -586,7 +587,7 @@ fn good_name_bad_type() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -623,7 +624,7 @@ fn good_name_not_a_list() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -660,7 +661,7 @@ fn ambiguous_multiple_matches() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -697,7 +698,7 @@ fn extra_required_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 

--- a/crates/integration-tests/tests/gateway/composite/lookup/key/batch/oneof.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/key/batch/oneof.rs
@@ -31,7 +31,7 @@ fn arg_with_same_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -89,7 +89,7 @@ fn multiple_keys() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -162,7 +162,7 @@ fn nullable_lookup() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -217,7 +217,7 @@ fn arg_type_compatibility_inner_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -273,7 +273,7 @@ fn arg_with_same_name_and_extra_input_field_with_matching_type() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -328,7 +328,7 @@ fn arg_with_different_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -384,7 +384,7 @@ fn arg_with_different_name_and_extra_optional_arg_with_matching_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -439,7 +439,7 @@ fn good_name_not_a_list() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -480,7 +480,7 @@ fn ambiguous_multiple_arg_matches() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -521,7 +521,7 @@ fn lookup_arg_in_a_list() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -563,7 +563,7 @@ fn ambiguous_multiple_oneof_field_matches() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -604,7 +604,7 @@ fn extra_required_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 

--- a/crates/integration-tests/tests/gateway/composite/lookup/key/batch/oneof_composite.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/key/batch/oneof_composite.rs
@@ -37,7 +37,7 @@ fn arg_with_same_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -100,7 +100,7 @@ fn nullable_lookup() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -163,7 +163,7 @@ fn arg_type_compatibility_inner_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -227,7 +227,7 @@ fn arg_with_same_name_and_extra_input_field() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -290,7 +290,7 @@ fn arg_with_different_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -355,7 +355,7 @@ fn arg_with_different_name_and_extra_optional_arg_with_matching_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .build()
             .await;
 
@@ -418,7 +418,7 @@ fn not_a_list() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -465,7 +465,7 @@ fn ambiguous_multiple_arg_matches() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -513,7 +513,7 @@ fn ambiguous_multiple_oneof_input_field_matches() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -561,7 +561,7 @@ fn ambiguous_multiple_input_field_matches() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -608,7 +608,7 @@ fn extra_required_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 
@@ -656,7 +656,7 @@ fn extra_required_field() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: true })
+            .with_extension(EchoLookup::batch())
             .try_build()
             .await;
 

--- a/crates/integration-tests/tests/gateway/composite/lookup/key/single/composite.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/key/single/composite.rs
@@ -33,7 +33,7 @@ fn arg_with_same_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -88,7 +88,7 @@ fn arg_type_compatibility_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -143,7 +143,7 @@ fn arg_with_same_name_and_extra_optional_input_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -199,7 +199,7 @@ fn arg_with_same_name_and_extra_optional_input_field_with_matching_type() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -254,7 +254,7 @@ fn arg_with_different_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -311,7 +311,7 @@ fn arg_with_different_name_and_extra_optional_arg_with_matching_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -367,7 +367,7 @@ fn field_with_default_value() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -424,7 +424,7 @@ fn field_with_default_value_coercion() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -477,7 +477,7 @@ fn no_arguments() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -515,7 +515,7 @@ fn no_matching_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -558,7 +558,7 @@ fn good_name_bad_type() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -601,7 +601,7 @@ fn good_name_but_a_list() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -644,7 +644,7 @@ fn cannot_inject_nullable_field_into_required() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -687,7 +687,7 @@ fn ambiguous_multiple_arg_matches() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -731,7 +731,7 @@ fn ambiguous_multiple_input_field_matches() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -774,7 +774,7 @@ fn extra_required_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -818,7 +818,7 @@ fn extra_required_field() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 

--- a/crates/integration-tests/tests/gateway/composite/lookup/key/single/mod.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/key/single/mod.rs
@@ -1,5 +1,6 @@
 mod composite;
-mod nested;
+mod nested_key;
+mod nested_output;
 mod oneof;
 mod oneof_composite;
 
@@ -21,7 +22,7 @@ fn arg_with_same_name() {
 
 
                 type Query {
-                    productBatch(id: ID!): Product! @lookup @echo
+                    ProductLookup(id: ID!): Product! @lookup @echo
                 }
 
                 type Product @key(fields: "id") {
@@ -32,7 +33,7 @@ fn arg_with_same_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -68,7 +69,7 @@ fn arg_type_compatibility_nullable() {
 
 
                 type Query {
-                    productBatch(id: ID): Product! @lookup @echo
+                    ProductLookup(id: ID): Product! @lookup @echo
                 }
 
                 type Product @key(fields: "id") {
@@ -79,7 +80,7 @@ fn arg_type_compatibility_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -115,7 +116,7 @@ fn arg_with_same_name_and_extra_optional_arg_with_matching_type() {
 
 
                 type Query {
-                    productBatch(id: ID!, anything: ID): Product! @lookup @echo
+                    ProductLookup(id: ID!, anything: ID): Product! @lookup @echo
                 }
 
                 type Product @key(fields: "id") {
@@ -126,7 +127,7 @@ fn arg_with_same_name_and_extra_optional_arg_with_matching_type() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -162,7 +163,7 @@ fn arg_with_different_name() {
 
 
                 type Query {
-                    productBatch(productId: ID!): Product! @lookup @echo
+                    ProductLookup(productId: ID!): Product! @lookup @echo
                 }
 
                 type Product @key(fields: "id") {
@@ -173,7 +174,7 @@ fn arg_with_different_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -209,7 +210,7 @@ fn arg_with_different_name_and_extra_optional_arg_with_matching_name() {
 
 
                 type Query {
-                    productBatch(productId: ID!, id: Int): Product! @lookup @echo
+                    ProductLookup(productId: ID!, id: Int): Product! @lookup @echo
                 }
 
                 type Product @key(fields: "id") {
@@ -220,7 +221,7 @@ fn arg_with_different_name_and_extra_optional_arg_with_matching_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -256,7 +257,7 @@ fn arg_with_default_value() {
 
 
                 type Query {
-                    productBatch(id: ID!, extra: Boolean! = true): Product! @lookup @echo
+                    ProductLookup(id: ID!, extra: Boolean! = true): Product! @lookup @echo
                 }
 
                 type Product @key(fields: "id") {
@@ -267,7 +268,7 @@ fn arg_with_default_value() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -303,7 +304,7 @@ fn arg_with_default_value_coercion() {
 
 
                 type Query {
-                    productBatch(id: ID!, extra: [Boolean!]! = true): Product! @lookup @echo
+                    ProductLookup(id: ID!, extra: [Boolean!]! = true): Product! @lookup @echo
                 }
 
                 type Product @key(fields: "id") {
@@ -314,7 +315,7 @@ fn arg_with_default_value_coercion() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -352,7 +353,7 @@ fn no_arguments() {
 
 
                 type Query {
-                    productBatch: Product! @lookup @echo
+                    ProductLookup: Product! @lookup @echo
                 }
 
                 type Product @key(fields: "id") {
@@ -363,14 +364,14 @@ fn no_arguments() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
         insta::assert_snapshot!(result.unwrap_err(), @r#"
-        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        At site Query.ProductLookup, for directive @lookup no matching @key directive was found
         See schema at 29:3:
-        productBatch: Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
+        ProductLookup: Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
         "#);
     })
 }
@@ -389,7 +390,7 @@ fn no_matching_argument() {
 
 
                 type Query {
-                    productBatch(somethign: Int): Product! @lookup @echo
+                    ProductLookup(somethign: Int): Product! @lookup @echo
                 }
 
                 type Product @key(fields: "id") {
@@ -400,14 +401,14 @@ fn no_matching_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
         insta::assert_snapshot!(result.unwrap_err(), @r#"
-        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        At site Query.ProductLookup, for directive @lookup no matching @key directive was found
         See schema at 29:3:
-        productBatch(somethign: Int): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
+        ProductLookup(somethign: Int): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
         "#);
     })
 }
@@ -426,7 +427,7 @@ fn cannot_inject_nullable_into_required() {
 
 
                 type Query {
-                    productBatch(id: ID!): Product! @lookup @echo
+                    ProductLookup(id: ID!): Product! @lookup @echo
                 }
 
                 type Product @key(fields: "id") {
@@ -437,14 +438,14 @@ fn cannot_inject_nullable_into_required() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
         insta::assert_snapshot!(result.unwrap_err(), @r#"
-        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        At site Query.ProductLookup, for directive @lookup no matching @key directive was found
         See schema at 29:3:
-        productBatch(id: ID!): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
+        ProductLookup(id: ID!): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
         "#);
     })
 }
@@ -463,7 +464,7 @@ fn good_name_bad_type() {
 
 
                 type Query {
-                    productBatch(id: Int): Product! @lookup @echo
+                    ProductLookup(id: Int): Product! @lookup @echo
                 }
 
                 type Product @key(fields: "id") {
@@ -474,14 +475,14 @@ fn good_name_bad_type() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
         insta::assert_snapshot!(result.unwrap_err(), @r#"
-        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        At site Query.ProductLookup, for directive @lookup no matching @key directive was found
         See schema at 29:3:
-        productBatch(id: Int): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
+        ProductLookup(id: Int): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
         "#);
     })
 }
@@ -500,7 +501,7 @@ fn good_name_but_is_a_list() {
 
 
                 type Query {
-                    productBatch(id: ID!): [Product!] @lookup @echo
+                    ProductLookup(id: ID!): [Product!] @lookup @echo
                 }
 
                 type Product @key(fields: "id") {
@@ -511,14 +512,14 @@ fn good_name_but_is_a_list() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
         insta::assert_snapshot!(result.unwrap_err(), @r#"
-        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        At site Query.ProductLookup, for directive @lookup no matching @key directive was found
         See schema at 29:3:
-        productBatch(id: ID!): [Product!] @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
+        ProductLookup(id: ID!): [Product!] @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
         "#);
     })
 }
@@ -537,7 +538,7 @@ fn ambiguous_multiple_matches() {
 
 
                 type Query {
-                    productBatch(a: ID!, b: ID!): Product! @lookup @echo
+                    ProductLookup(a: ID!, b: ID!): Product! @lookup @echo
                 }
 
                 type Product @key(fields: "id") {
@@ -548,14 +549,14 @@ fn ambiguous_multiple_matches() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
         insta::assert_snapshot!(result.unwrap_err(), @r#"
-        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        At site Query.ProductLookup, for directive @lookup no matching @key directive was found
         See schema at 29:3:
-        productBatch(a: ID!, b: ID!): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
+        ProductLookup(a: ID!, b: ID!): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
         "#);
     })
 }
@@ -574,7 +575,7 @@ fn extra_required_argument() {
 
 
                 type Query {
-                    productBatch(id: ID!, required: Boolean!): Product! @lookup @echo
+                    ProductLookup(id: ID!, required: Boolean!): Product! @lookup @echo
                 }
 
                 type Product @key(fields: "id") {
@@ -585,14 +586,14 @@ fn extra_required_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
         insta::assert_snapshot!(result.unwrap_err(), @r#"
-        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        At site Query.ProductLookup, for directive @lookup no matching @key directive was found
         See schema at 29:3:
-        productBatch(id: ID!, required: Boolean!): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
+        ProductLookup(id: ID!, required: Boolean!): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
         "#);
     })
 }

--- a/crates/integration-tests/tests/gateway/composite/lookup/key/single/nested_key.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/key/single/nested_key.rs
@@ -16,7 +16,7 @@ fn arg_with_same_name() {
 
 
                 type Query {
-                    productBatch(nested: NestedInput!): Product! @lookup @echo
+                    productLookup(nested: NestedInput!): Product! @lookup @echo
                 }
 
                 input NestedInput {
@@ -35,7 +35,7 @@ fn arg_with_same_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -72,7 +72,7 @@ fn arg_type_compatibility_nullable() {
 
 
                 type Query {
-                    productBatch(nested: NestedInput): Product! @lookup @echo
+                    productLookup(nested: NestedInput): Product! @lookup @echo
                 }
 
                 input NestedInput {
@@ -91,7 +91,7 @@ fn arg_type_compatibility_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -128,7 +128,7 @@ fn arg_type_compatibility_nested_nullable() {
 
 
                 type Query {
-                    productBatch(nested: NestedInput!): Product! @lookup @echo
+                    productLookup(nested: NestedInput!): Product! @lookup @echo
                 }
 
                 input NestedInput {
@@ -147,7 +147,7 @@ fn arg_type_compatibility_nested_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -184,7 +184,7 @@ fn arg_type_compatibility_all_nullable() {
 
 
                 type Query {
-                    productBatch(nested: NestedInput): Product! @lookup @echo
+                    productLookup(nested: NestedInput): Product! @lookup @echo
                 }
 
                 input NestedInput {
@@ -203,7 +203,7 @@ fn arg_type_compatibility_all_nullable() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -240,7 +240,7 @@ fn arg_with_same_name_and_extra_optional_arg_with_matching_type() {
 
 
                 type Query {
-                    productBatch(nested: NestedInput!, anything: NestedInput): Product! @lookup @echo
+                    productLookup(nested: NestedInput!, anything: NestedInput): Product! @lookup @echo
                 }
 
                 input NestedInput {
@@ -260,7 +260,7 @@ fn arg_with_same_name_and_extra_optional_arg_with_matching_type() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -297,7 +297,7 @@ fn arg_with_different_name() {
 
 
                 type Query {
-                    productBatch(x: NestedInput!): Product! @lookup @echo
+                    productLookup(x: NestedInput!): Product! @lookup @echo
                 }
 
                 input NestedInput {
@@ -316,7 +316,7 @@ fn arg_with_different_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -353,7 +353,7 @@ fn arg_with_different_name_and_extra_optional_arg_with_matching_name() {
 
 
                 type Query {
-                    productBatch(x: NestedInput!, nested: ID): Product! @lookup @echo
+                    productLookup(x: NestedInput!, nested: ID): Product! @lookup @echo
                 }
 
                 input NestedInput {
@@ -373,7 +373,7 @@ fn arg_with_different_name_and_extra_optional_arg_with_matching_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -410,7 +410,7 @@ fn arg_with_default_value() {
 
 
                 type Query {
-                    productBatch(nested: NestedInput!, extra: Boolean! = true): Product! @lookup @echo
+                    productLookup(nested: NestedInput!, extra: Boolean! = true): Product! @lookup @echo
                 }
 
                 input NestedInput {
@@ -430,7 +430,7 @@ fn arg_with_default_value() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -469,7 +469,7 @@ fn arg_with_default_value_coercion() {
 
 
                 type Query {
-                    productBatch(nested: NestedInput!, extra: [Boolean!]! = true): Product! @lookup @echo
+                    productLookup(nested: NestedInput!, extra: [Boolean!]! = true): Product! @lookup @echo
                 }
 
                 input NestedInput {
@@ -489,7 +489,7 @@ fn arg_with_default_value_coercion() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -532,7 +532,7 @@ fn no_arguments() {
 
 
                 type Query {
-                    productBatch: Product! @lookup @echo
+                    productLookup: Product! @lookup @echo
                 }
 
                 input NestedInput {
@@ -551,14 +551,14 @@ fn no_arguments() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
         insta::assert_snapshot!(result.unwrap_err(), @r#"
-        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        At site Query.productLookup, for directive @lookup no matching @key directive was found
         See schema at 36:3:
-        productBatch: Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
+        productLookup: Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
         "#);
     })
 }
@@ -577,7 +577,7 @@ fn no_matching_argument() {
 
 
                 type Query {
-                    productBatch(somethign: Int): Product! @lookup @echo
+                    productLookup(somethign: Int): Product! @lookup @echo
                 }
 
                 input NestedInput {
@@ -596,14 +596,14 @@ fn no_matching_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
         insta::assert_snapshot!(result.unwrap_err(), @r#"
-        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        At site Query.productLookup, for directive @lookup no matching @key directive was found
         See schema at 36:3:
-        productBatch(somethign: Int): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
+        productLookup(somethign: Int): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
         "#);
     })
 }
@@ -622,7 +622,7 @@ fn no_matching_nested_field() {
 
 
                 type Query {
-                    productBatch(nested: NestedInput!): Product! @lookup @echo
+                    productLookup(nested: NestedInput!): Product! @lookup @echo
                 }
 
                 input NestedInput {
@@ -641,14 +641,14 @@ fn no_matching_nested_field() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
         insta::assert_snapshot!(result.unwrap_err(), @r#"
-        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        At site Query.productLookup, for directive @lookup no matching @key directive was found
         See schema at 36:3:
-        productBatch(nested: NestedInput!): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
+        productLookup(nested: NestedInput!): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
         "#);
     })
 }
@@ -667,7 +667,7 @@ fn arg_good_name_bad_type() {
 
 
                 type Query {
-                    productBatch(nested: Int): Product! @lookup @echo
+                    productLookup(nested: Int): Product! @lookup @echo
                 }
 
                 type Product @key(fields: "nested { id }") {
@@ -682,14 +682,14 @@ fn arg_good_name_bad_type() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
         insta::assert_snapshot!(result.unwrap_err(), @r#"
-        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        At site Query.productLookup, for directive @lookup no matching @key directive was found
         See schema at 36:3:
-        productBatch(nested: Int): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
+        productLookup(nested: Int): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
         "#);
     })
 }
@@ -708,7 +708,7 @@ fn field_good_name_bad_type() {
 
 
                 type Query {
-                    productBatch(nested: NestedInput!): Product! @lookup @echo
+                    productLookup(nested: NestedInput!): Product! @lookup @echo
                 }
 
                 input NestedInput {
@@ -727,14 +727,14 @@ fn field_good_name_bad_type() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
         insta::assert_snapshot!(result.unwrap_err(), @r#"
-        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        At site Query.productLookup, for directive @lookup no matching @key directive was found
         See schema at 36:3:
-        productBatch(nested: NestedInput!): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
+        productLookup(nested: NestedInput!): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
         "#);
     })
 }
@@ -753,7 +753,7 @@ fn good_name_but_a_list() {
 
 
                 type Query {
-                    productBatch(nested: [NestedInput!]): Product! @lookup @echo
+                    productLookup(nested: [NestedInput!]): Product! @lookup @echo
                 }
 
                 input NestedInput {
@@ -772,14 +772,14 @@ fn good_name_but_a_list() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
         insta::assert_snapshot!(result.unwrap_err(), @r#"
-        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        At site Query.productLookup, for directive @lookup no matching @key directive was found
         See schema at 36:3:
-        productBatch(nested: [NestedInput!]): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
+        productLookup(nested: [NestedInput!]): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
         "#);
     })
 }
@@ -798,7 +798,7 @@ fn ambiguous_multiple_arg_matches() {
 
 
                 type Query {
-                    productBatch(a: NestedInput!, b: NestedInput!): Product! @lookup @echo
+                    productLookup(a: NestedInput!, b: NestedInput!): Product! @lookup @echo
                 }
 
                 input NestedInput {
@@ -817,14 +817,14 @@ fn ambiguous_multiple_arg_matches() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
         insta::assert_snapshot!(result.unwrap_err(), @r#"
-        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        At site Query.productLookup, for directive @lookup no matching @key directive was found
         See schema at 36:3:
-        productBatch(a: NestedInput!, b: NestedInput!): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
+        productLookup(a: NestedInput!, b: NestedInput!): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
         "#);
     })
 }
@@ -843,7 +843,7 @@ fn ambiguous_multiple_field_matches() {
 
 
                 type Query {
-                    productBatch(a: NestedInput!): Product! @lookup @echo
+                    productLookup(a: NestedInput!): Product! @lookup @echo
                 }
 
                 input NestedInput {
@@ -863,14 +863,14 @@ fn ambiguous_multiple_field_matches() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
         insta::assert_snapshot!(result.unwrap_err(), @r#"
-        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        At site Query.productLookup, for directive @lookup no matching @key directive was found
         See schema at 36:3:
-        productBatch(a: NestedInput!): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
+        productLookup(a: NestedInput!): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
         "#);
     })
 }
@@ -889,7 +889,7 @@ fn extra_required_argument() {
 
 
                 type Query {
-                    productBatch(nested: NestedInput!, required: Boolean!): Product! @lookup @echo
+                    productLookup(nested: NestedInput!, required: Boolean!): Product! @lookup @echo
                 }
 
                 input NestedInput {
@@ -908,14 +908,14 @@ fn extra_required_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
         insta::assert_snapshot!(result.unwrap_err(), @r#"
-        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        At site Query.productLookup, for directive @lookup no matching @key directive was found
         See schema at 36:3:
-        productBatch(nested: NestedInput!, required: Boolean!): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
+        productLookup(nested: NestedInput!, required: Boolean!): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
         "#);
     })
 }
@@ -934,7 +934,7 @@ fn extra_required_field() {
 
 
                 type Query {
-                    productBatch(nested: NestedInput!): Product! @lookup @echo
+                    productLookup(nested: NestedInput!): Product! @lookup @echo
                 }
 
                 input NestedInput {
@@ -954,14 +954,14 @@ fn extra_required_field() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
         insta::assert_snapshot!(result.unwrap_err(), @r#"
-        At site Query.productBatch, for directive @lookup no matching @key directive was found
+        At site Query.productLookup, for directive @lookup no matching @key directive was found
         See schema at 36:3:
-        productBatch(nested: NestedInput!): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
+        productLookup(nested: NestedInput!): Product! @composite__lookup(graph: EXT) @extension__directive(graph: EXT, extension: ECHO, name: "echo", arguments: {}) @join__field(graph: EXT)
         "#);
     })
 }

--- a/crates/integration-tests/tests/gateway/composite/lookup/key/single/nested_output.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/key/single/nested_output.rs
@@ -1,0 +1,252 @@
+use integration_tests::{gateway::Gateway, runtime};
+
+use super::super::super::{EchoLookup, gql_id};
+
+#[test]
+fn single_field() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph(gql_id())
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "echo-1.0.0", import: ["@echo"])
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key", "@shareable"])
+
+
+                type Query {
+                    productLookup(id: ID!): Namespace! @lookup @echo
+                }
+
+                type Namespace {
+                    product: Product!
+                }
+
+                type Product @key(fields: "id") {
+                    id: ID!
+                    args: JSON
+                }
+
+                scalar JSON
+                "#,
+            )
+            .with_extension(EchoLookup::single().namespaced("product"))
+            .build()
+            .await;
+
+        let response = engine.post("query { products { args } }").await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "products": [
+              {
+                "args": {
+                  "id": "1"
+                }
+              }
+            ]
+          }
+        }
+        "#);
+    })
+}
+
+#[test]
+fn other_unrelated_fields() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph(gql_id())
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "echo-1.0.0", import: ["@echo"])
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key", "@shareable"])
+
+
+                type Query {
+                    productLookup(id: ID!): Namespace! @lookup @echo
+                }
+
+                type Namespace {
+                    product: Product!
+                    other: String
+                    anything: JSON
+                }
+
+                type Product @key(fields: "id") {
+                    id: ID!
+                    args: JSON
+                }
+
+                scalar JSON
+                "#,
+            )
+            .with_extension(EchoLookup::single().namespaced("product"))
+            .build()
+            .await;
+
+        let response = engine.post("query { products { args } }").await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "products": [
+              {
+                "args": {
+                  "id": "1"
+                }
+              }
+            ]
+          }
+        }
+        "#);
+    })
+}
+
+#[test]
+fn invalid_namespace_key_at_runtime() {
+    runtime().block_on(async {
+        let engine = Gateway::builder()
+            .with_subgraph(gql_id())
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "echo-1.0.0", import: ["@echo"])
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key", "@shareable"])
+
+
+                type Query {
+                    productLookup(id: ID!): Namespace! @lookup @echo
+                }
+
+                type Namespace {
+                    product: Product!
+                }
+
+                type Product @key(fields: "id") {
+                    id: ID!
+                    args: JSON
+                }
+
+                scalar JSON
+                "#,
+            )
+            .with_extension(EchoLookup::single().namespaced("wrong key"))
+            .build()
+            .await;
+
+        let response = engine.post("query { products { args } }").await;
+        insta::assert_json_snapshot!(response, @r#"
+        {
+          "data": {
+            "products": [
+              {
+                "args": null
+              }
+            ]
+          }
+        }
+        "#);
+    })
+}
+
+#[test]
+fn nested_but_unknown_fields() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph(gql_id())
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "echo-1.0.0", import: ["@echo"])
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key", "@shareable"])
+
+
+                type Query {
+                    productLookup(id: ID!): Namespace! @lookup @echo
+                }
+
+                type Namespace {
+                    other: String
+                    anything: JSON
+                }
+
+                type Product @key(fields: "id") {
+                    id: ID!
+                    args: JSON
+                }
+
+                scalar JSON
+                "#,
+            )
+            .with_extension(EchoLookup::single().namespaced("product"))
+            .try_build()
+            .await;
+
+        insta::assert_snapshot!(result.unwrap_err(), @r"
+        At site Query.productLookup, for directive @lookup Type Namespace doesn't define any keys with @key directive that may be used for @lookup. Tried treating it as a namespace type, but it didn't have any fields that may be used for @lookup.
+        See schema at 19:1:
+        type Namespace
+          @join__type(graph: EXT)
+        {
+          anything: JSON
+          other: String
+        }
+        ");
+    })
+}
+
+#[test]
+fn multiple_entities() {
+    runtime().block_on(async {
+        let result = Gateway::builder()
+            .with_subgraph(gql_id())
+            .with_subgraph_sdl(
+                "ext",
+                r#"
+                extend schema
+                    @link(url: "echo-1.0.0", import: ["@echo"])
+                    @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup", "@key", "@shareable"])
+
+
+                type Query {
+                    productLookup(id: ID!): Namespace! @lookup @echo
+                }
+
+                type Namespace {
+                    product: Product!
+                    account: Account!
+                }
+
+                type Product @key(fields: "id") {
+                    id: ID!
+                    args: JSON
+                }
+
+                type Account @key(fields: "id") {
+                    id: ID!
+                    args: JSON
+                }
+
+                scalar JSON
+                "#,
+            )
+            .with_extension(EchoLookup::single().namespaced("product"))
+            .try_build()
+            .await;
+
+        insta::assert_snapshot!(result.unwrap_err(), @r"
+        At site Query.productLookup, for directive @lookup Type Namespace doesn't define any keys with @key directive that may be used for @lookup. Tried treating it as a namespace type, but it has multiple fields that may be used for @lookup: product and account
+        See schema at 19:1:
+        type Namespace
+          @join__type(graph: EXT)
+        {
+          account: Account!
+          product: Product!
+        }
+        ");
+    })
+}

--- a/crates/integration-tests/tests/gateway/composite/lookup/key/single/oneof.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/key/single/oneof.rs
@@ -31,7 +31,7 @@ fn arg_with_same_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -87,7 +87,7 @@ fn multiple_keys() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -156,7 +156,7 @@ fn nullable_lookup() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -210,7 +210,7 @@ fn arg_with_same_name_and_extra_input_field_with_matching_type() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -263,7 +263,7 @@ fn arg_with_different_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -317,7 +317,7 @@ fn arg_with_different_name_and_extra_optional_arg_with_matching_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -370,7 +370,7 @@ fn good_name_but_a_list() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -411,7 +411,7 @@ fn ambiguous_multiple_arg_matches() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -452,7 +452,7 @@ fn lookup_arg_in_a_list() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -494,7 +494,7 @@ fn ambiguous_multiple_oneof_field_matches() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -535,7 +535,7 @@ fn extra_required_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 

--- a/crates/integration-tests/tests/gateway/composite/lookup/key/single/oneof_composite.rs
+++ b/crates/integration-tests/tests/gateway/composite/lookup/key/single/oneof_composite.rs
@@ -37,7 +37,7 @@ fn arg_with_same_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -98,7 +98,7 @@ fn nullable_lookup() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -160,7 +160,7 @@ fn arg_with_same_name_and_extra_input_field() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -221,7 +221,7 @@ fn arg_with_different_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -284,7 +284,7 @@ fn arg_with_different_name_and_extra_optional_arg_with_matching_name() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .build()
             .await;
 
@@ -345,7 +345,7 @@ fn is_a_list() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -392,7 +392,7 @@ fn ambiguous_multiple_arg_matches() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -440,7 +440,7 @@ fn ambiguous_multiple_oneof_input_field_matches() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -488,7 +488,7 @@ fn ambiguous_multiple_input_field_matches() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -535,7 +535,7 @@ fn extra_required_argument() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 
@@ -583,7 +583,7 @@ fn extra_required_field() {
                 scalar JSON
                 "#,
             )
-            .with_extension(EchoLookup { batch: false })
+            .with_extension(EchoLookup::single())
             .try_build()
             .await;
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -11,6 +11,9 @@
     cargo-nextest
     cargo-insta
 
+    # TOML
+    taplo
+
     # Examples
     hurl
   ];


### PR DESCRIPTION
In gRPC we can't return a list directly, it's always returned within a message which ends up looking like:

```graphql
type Query {
  products(ids: [ID!]!): ProductsResponse! @lookup
}

type ProductsResponse {
    products: [Product!]!
}

type Product @key(fields: "id") {
  id: ID!
}
```

Today, adding `@lookup` on `products` would fail since the output isn't an entity. So added support for namespaces, where we automatically retrieve from a nested field the entities.