### PR TITLE
Adding default affinity for gateway pod

### DIFF
--- a/gateway/helm/templates/deployment.yaml
+++ b/gateway/helm/templates/deployment.yaml
@@ -114,9 +114,24 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- if or .Values.affinity .Values.defaultAffinity.enabled }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- if .Values.affinity }}
+        {{- toYaml .Values.affinity | nindent 8 }}
+        {{- end }}
+        {{- if .Values.defaultAffinity.enabled }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                        - {{ include "app.name" . }}
+                topologyKey: kubernetes.io/hostname
+        {{- end }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/gateway/helm/values.yaml
+++ b/gateway/helm/values.yaml
@@ -131,6 +131,9 @@ tolerations: []
 # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
 
+defaultAffinity:
+  enabled: false
+
 # Configmap that will be mounted as env vars
 # https://kubernetes.io/docs/concepts/configuration/configmap/
 configmap:


### PR DESCRIPTION
Adding default affinity which tries to make sure that pods are not scheduled on the same node. This improves reactions to outages as a node failure is less likely to result in an service outage.