### PR TITLE
 cli: output pretty logs by default

### DIFF
--- a/.rules.md
+++ b/.rules.md
@@ -1,3 +1,8 @@
+# Repository structure
+
+- "The CLI" refers to the binary defined in `grafbase/`.
+- "The gateway" refers to the binary defined in `gateway/`.
+
 # Coding guidelines
 
 Code MUST be clear and concise and the same applies to comments. Clear code does not need comments explaining what it does. But you may explain _why_ you're solving a problem in a particular way.

--- a/cli/changelog/unreleased.md
+++ b/cli/changelog/unreleased.md
@@ -1,0 +1,4 @@
+## Improvements
+
+- New `--log-style` argument to set the style of logs. (https://github.com/grafbase/grafbase/pull/3357)
+- When RUST_LOG is set to `debug` or `trace`, the CLI will use a more spaced up, more readable log style. (https://github.com/grafbase/grafbase/pull/3357)

--- a/cli/src/cli_input.rs
+++ b/cli/src/cli_input.rs
@@ -36,6 +36,7 @@ pub(crate) use sub_command::SubCommand;
 pub(crate) use subgraph::{SubgraphCommand, SubgraphSubCommand};
 
 use crate::common::consts::TRACE_LOG_FILTER;
+use crate::common::log::LogStyle;
 use clap::Parser;
 use std::path::PathBuf;
 
@@ -73,6 +74,9 @@ pub struct Args {
     pub trace: u16,
     #[arg(long, hide = true)]
     pub custom_trace_filter: Option<String>,
+    /// Set the style of log output
+    #[arg(long)]
+    pub log_style: Option<LogStyle>,
     #[command(subcommand)]
     pub command: SubCommand,
     /// An optional replacement path for the home directory

--- a/cli/src/common.rs
+++ b/cli/src/common.rs
@@ -6,6 +6,7 @@ pub(crate) mod consts;
 pub(crate) mod debug_macros;
 pub(crate) mod environment;
 pub(crate) mod errors;
+pub(crate) mod log;
 pub(crate) mod trusted_documents;
 pub(crate) mod types;
 pub(crate) mod utils;

--- a/cli/src/common/log.rs
+++ b/cli/src/common/log.rs
@@ -1,0 +1,29 @@
+use clap::ValueEnum;
+use std::fmt;
+
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum LogStyle {
+    /// Pretty printed logs, used as the default in the terminal when using debug logs
+    Pretty,
+    /// Standard text, used as the default when pretty isn't used.
+    #[default]
+    Text,
+    /// JSON objects
+    Json,
+}
+
+impl AsRef<str> for LogStyle {
+    fn as_ref(&self) -> &str {
+        match self {
+            LogStyle::Pretty => "pretty",
+            LogStyle::Text => "text",
+            LogStyle::Json => "json",
+        }
+    }
+}
+
+impl fmt::Display for LogStyle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_ref())
+    }
+}


### PR DESCRIPTION
Like the gateway --log-style=pretty. It's more readable.

closes GB-9483