### PR TITLE
 graphql-composition: store argument records in Vec 

### DIFF
--- a/crates/graphql-composition/src/subgraphs/field_types.rs
+++ b/crates/graphql-composition/src/subgraphs/field_types.rs
@@ -127,7 +127,7 @@ impl<'a> FieldTypeWalker<'a> {
 
 impl std::fmt::Display for FieldTypeWalker<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.id.wrapping.type_display(self.type_name().as_str()))
+        self.id.wrapping.type_display(self.type_name().as_str()).fmt(f)
     }
 }
 

--- a/crates/graphql-composition/src/subgraphs/ids.rs
+++ b/crates/graphql-composition/src/subgraphs/ids.rs
@@ -30,6 +30,7 @@ macro_rules! make_ids {
 }
 
 make_ids! {
+    fields.arguments[ArgumentId] -> ArgumentRecord,
     definitions.definitions[DefinitionId] -> Definition,
     directives.extra_directives[DirectiveId] -> ExtraDirectiveRecord,
     extensions[ExtensionId] -> ExtensionRecord,


### PR DESCRIPTION


Instead of a BTreeMap. Primary storage access should always be O(1). The existing data structure that holds arguments by name is now an index of top of the new Vec<ArgumentRecord>.

