### PR TITLE
graphql-composition: fixed panic in @provides validation on fields of built-in scalar type

### DIFF
--- a/crates/graphql-composition/CHANGELOG.md
+++ b/crates/graphql-composition/CHANGELOG.md
@@ -7,6 +7,10 @@
 - `Diagnostic::composite_schemas_error_code` is now exposed. Note that as the spec and this implementation evolve, more error codes will be added to this enum and its variants.
 - Implemented some composite schemas spec validations for the `@override` directive, resulting in more consistent logic and better diagnostics (https://github.com/grafbase/grafbase/pull/3374)
 
+### Fixes
+
+- Fixed a panic in validation for `@provides` on fields returning a built-in scalar type, like `Int`.
+
 ## 0.10.0 - 2025-07-30
 
 ### Improvements

--- a/crates/graphql-composition/src/validate/selection.rs
+++ b/crates/graphql-composition/src/validate/selection.rs
@@ -33,10 +33,13 @@ pub(super) fn validate_selections(ctx: &mut ValidateContext<'_>, field: subgraph
             )
         };
 
-        let field_type = field
-            .r#type()
-            .definition(field.parent_definition().subgraph_id())
-            .unwrap();
+        let Some(field_type) = field.r#type().definition(field.parent_definition().subgraph_id()) else {
+            ctx.diagnostics.push_fatal(format!(
+                "Invalid @provides at {}: no selection possible on this field type.",
+                directive_path()
+            ));
+            continue;
+        };
 
         validate_selection(ctx, selection, field_type, &directive_path, "provides");
     }

--- a/crates/graphql-composition/tests/composition/provides/provides_scalar/api.graphql.snap
+++ b/crates/graphql-composition/tests/composition/provides/provides_scalar/api.graphql.snap
@@ -1,0 +1,6 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: API SDL
+input_file: crates/graphql-composition/tests/composition/provides/provides_scalar/test.md
+---
+

--- a/crates/graphql-composition/tests/composition/provides/provides_scalar/diagnostics.snap
+++ b/crates/graphql-composition/tests/composition/provides/provides_scalar/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: Diagnostics
+input_file: crates/graphql-composition/tests/composition/provides/provides_scalar/test.md
+---
+- ❌ Invalid @provides at Color.provideGreen: no selection possible on this field type.

--- a/crates/graphql-composition/tests/composition/provides/provides_scalar/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/provides/provides_scalar/federated.graphql.snap
@@ -1,0 +1,6 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: Federated SDL
+input_file: crates/graphql-composition/tests/composition/provides/provides_scalar/test.md
+---
+

--- a/crates/graphql-composition/tests/composition/provides/provides_scalar/subgraphs/test.graphql
+++ b/crates/graphql-composition/tests/composition/provides/provides_scalar/subgraphs/test.graphql
@@ -1,0 +1,24 @@
+extend schema @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@shareable", "@provides"])
+
+type Query {
+  shirt: Shirt!
+}
+
+type Shirt {
+  id: ID!
+  name: String!
+  size: Size!
+  color: Color
+}
+
+type Size {
+  width: Float!
+  height: Float!
+}
+
+type Color {
+  red: Int
+  green: Int @external
+  blue: Int
+  provideGreen: Int @provides(fields: "green")
+}


### PR DESCRIPTION
Incidentally found that panic, just fixing it.