### PR TITLE
graphql-composition: fix Diagnostics::iter_warnings()

### DIFF
--- a/crates/graphql-composition/CHANGELOG.md
+++ b/crates/graphql-composition/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixes
 
 - Fixed a panic in validation for `@provides` on fields returning a built-in scalar type, like `Int`.
+- Fixed `Diagnostics::iter_warnings()` iterating over warnings instead of errors.
 
 ## 0.10.0 - 2025-07-30
 

--- a/crates/graphql-composition/src/diagnostics.rs
+++ b/crates/graphql-composition/src/diagnostics.rs
@@ -26,7 +26,7 @@ impl Diagnostics {
     pub fn iter_warnings(&self) -> impl Iterator<Item = &str> {
         self.0
             .iter()
-            .filter(|diagnostic| !diagnostic.severity.is_warning())
+            .filter(|diagnostic| diagnostic.severity.is_warning())
             .map(|diagnostic| diagnostic.message.as_str())
     }
 


### PR DESCRIPTION
It would iterate over the errors instead.