### PR TITLE
graphql-schema-validation: allow implementing an interface extension

### DIFF
--- a/crates/graphql-schema-validation/CHANGELOG.md
+++ b/crates/graphql-schema-validation/CHANGELOG.md
@@ -8,6 +8,7 @@
   we were skipping the validation whenever the type is the default one for
   the root (Query, Mutation or Subscription). This commit makes the validation
   stricter. If Query does not exist, it is an error. (#1502)
+- It is now valid to implement an interface that is only defined in interface extensions when the FORBID_EXTENDING_UNKNOWN_TYPES option is not enabled.
 
 ### Fixes
 

--- a/crates/graphql-schema-validation/src/context.rs
+++ b/crates/graphql-schema-validation/src/context.rs
@@ -11,6 +11,7 @@ pub(crate) struct Context<'a> {
 
     /// Definition name -> definition AST node
     pub(crate) definition_names: HashMap<&'a str, &'a Positioned<ast::TypeDefinition>>,
+    pub(crate) extension_names: HashMap<&'a str, Vec<&'a Positioned<ast::TypeDefinition>>>,
 
     /// Directive name -> directive AST node
     pub(crate) directive_names: HashMap<&'a str, &'a Positioned<ast::DirectiveDefinition>>,
@@ -49,6 +50,7 @@ impl<'a> Context<'a> {
             diagnostics,
             options,
 
+            extension_names: HashMap::default(),
             strings_buf: HashMap::default(),
             directive_names: HashMap::default(),
             extended_interface_implementations: HashMap::default(),

--- a/crates/graphql-schema-validation/src/lib.rs
+++ b/crates/graphql-schema-validation/src/lib.rs
@@ -45,9 +45,9 @@ bitflags::bitflags! {
     pub struct Options: u8 {
         /// If included, this flag enables the validation checking that any type extension extends
         /// a type defined in the same document.
-        const FORBID_EXTENDING_UNKNOWN_TYPES = 0b1;
+        const FORBID_EXTENDING_UNKNOWN_TYPES = 1;
         /// Include validations that are in the current spec draft but not included or not relevant
         /// in the 2021 edition of the spec.
-        const DRAFT_VALIDATIONS = 0b01;
+        const DRAFT_VALIDATIONS = 1 << 1;
     }
 }

--- a/crates/graphql-schema-validation/src/validate/type_definition.rs
+++ b/crates/graphql-schema-validation/src/validate/type_definition.rs
@@ -44,6 +44,9 @@ pub(crate) fn validate_type_definition<'a>(typedef: &'a Positioned<ast::TypeDefi
             }
             _ => (),
         }
+
+        ctx.extension_names.entry(type_name).or_default().push(typedef);
+
         return;
     }
 

--- a/crates/graphql-schema-validation/tests/valid_schemas/extend_unknown_allowed.graphql
+++ b/crates/graphql-schema-validation/tests/valid_schemas/extend_unknown_allowed.graphql
@@ -1,0 +1,6 @@
+# Extension of unknown type is allowed when FORBID_EXTENDING_UNKNOWN_TYPES is not set
+# @option: DRAFT_VALIDATIONS
+
+extend type Cat {
+  litterNeedsChanging: Boolean
+}

--- a/crates/graphql-schema-validation/tests/valid_schemas/object_implements_interface_extension.graphql
+++ b/crates/graphql-schema-validation/tests/valid_schemas/object_implements_interface_extension.graphql
@@ -1,0 +1,11 @@
+# @option: DRAFT_VALIDATIONS
+
+extend interface ABC {
+  name: String
+}
+
+type DEF implements ABC {
+  id: ID!
+  name: String
+  others: [ABC!]
+}

--- a/crates/graphql-schema-validation/tests/validation_errors/errors@extend_unknown_without_forbid.snap
+++ b/crates/graphql-schema-validation/tests/validation_errors/errors@extend_unknown_without_forbid.snap
@@ -1,0 +1,6 @@
+---
+source: crates/graphql-schema-validation/tests/validation_tests.rs
+expression: displayed
+input_file: crates/graphql-schema-validation/tests/validation_errors/extend_unknown_without_forbid.graphql
+---
+  × Cannot extend unknown object Cat

--- a/crates/graphql-schema-validation/tests/validation_errors/extend_unknown_without_forbid.graphql
+++ b/crates/graphql-schema-validation/tests/validation_errors/extend_unknown_without_forbid.graphql
@@ -1,0 +1,6 @@
+# No validation errors expected without FORBID_EXTENDING_UNKNOWN_TYPES  
+# (empty options means use default which includes FORBID_EXTENDING_UNKNOWN_TYPES)
+
+extend type Cat {
+  litterNeedsChanging: Boolean
+}


### PR DESCRIPTION
Also extend the test setup to support passing validation options.