### PR TITLE
graphql-composition: fix ingesting extensions after subgraphs

### DIFF
--- a/crates/graphql-composition/src/compose/context.rs
+++ b/crates/graphql-composition/src/compose/context.rs
@@ -4,6 +4,7 @@ use crate::{
     federated_graph as federated,
     subgraphs::{self, StringWalker},
 };
+use std::collections::HashMap;
 
 /// Context for [`compose`](crate::compose::compose).
 pub(crate) struct Context<'a> {
@@ -18,6 +19,21 @@ impl<'a> Context<'a> {
     pub(crate) fn new(subgraphs: &'a subgraphs::Subgraphs, diagnostics: &'a mut Diagnostics) -> Self {
         subgraphs.emit_ingestion_diagnostics(diagnostics);
 
+        // We want link_url here because that's the one that appears in the schema SDL.
+        let extensions_by_link_url: HashMap<_, _> = subgraphs
+            .iter_extensions()
+            .map(|extension| (extension.link_url, extension.id))
+            .collect();
+
+        let linked_schema_to_extension = subgraphs
+            .iter_linked_schemas()
+            .filter_map(|linked_schema| {
+                extensions_by_link_url
+                    .get(&linked_schema.url)
+                    .map(|extension_id| (linked_schema.id, *extension_id))
+            })
+            .collect();
+
         let mut context = Context {
             subgraphs,
             diagnostics,
@@ -25,6 +41,7 @@ impl<'a> Context<'a> {
         };
 
         context.ir.used_extensions = fixedbitset::FixedBitSet::with_capacity(subgraphs.iter_extensions().len());
+        context.ir.linked_schema_to_extension = linked_schema_to_extension;
 
         for builtin_scalar in subgraphs.iter_builtin_scalars() {
             context.insert_scalar(builtin_scalar.as_str(), None, Vec::new());
@@ -258,6 +275,20 @@ impl<'a> Context<'a> {
 
     pub(crate) fn set_subscription(&mut self, id: federated::ObjectId) {
         self.ir.subscription_type = Some(id);
+    }
+
+    /// Is this linked schema from a Grafbase extension?
+    pub(crate) fn get_extension_for_linked_schema(
+        &self,
+        linked_schema_id: subgraphs::LinkedSchemaId,
+    ) -> Option<subgraphs::ExtensionId> {
+        let idx = self
+            .ir
+            .linked_schema_to_extension
+            .binary_search_by_key(&linked_schema_id, |(linked_schema_id, _)| *linked_schema_id)
+            .ok()?;
+
+        Some(self.ir.linked_schema_to_extension[idx].1)
     }
 
     pub(crate) fn mark_used_extension(&mut self, id: subgraphs::ExtensionId) {

--- a/crates/graphql-composition/src/compose/directives.rs
+++ b/crates/graphql-composition/src/compose/directives.rs
@@ -1,5 +1,3 @@
-use crate::subgraphs::LinkedSchemaType;
-
 use super::*;
 
 pub(super) fn create_join_type_from_definitions(
@@ -70,32 +68,32 @@ pub(super) fn collect_composed_directives<'a>(
                 subgraphs::DirectiveProvenance::Linked {
                     linked_schema_id,
                     is_composed_directive,
-                } => match (
-                    &ctx.subgraphs[linked_schema_id].linked_schema_type,
-                    is_composed_directive,
-                ) {
-                    (LinkedSchemaType::Extension { .. }, true) => {
-                        ctx.diagnostics.push_fatal(String::from(
-                            "Directives from extensions must not be composed with `@composeDirective`",
-                        ));
-                        None
+                } => {
+                    let extension_id = ctx.get_extension_for_linked_schema(linked_schema_id);
+                    match (extension_id, is_composed_directive) {
+                        (Some(_), true) => {
+                            ctx.diagnostics.push_fatal(String::from(
+                                "Directives from extensions must not be composed with `@composeDirective`",
+                            ));
+                            None
+                        }
+                        (Some(extension_id), false) => {
+                            ctx.mark_used_extension(extension_id);
+                            Some(ir::DirectiveProvenance::LinkedFromExtension {
+                                linked_schema_id,
+                                extension_id,
+                            })
+                        }
+                        (None, true) => Some(ir::DirectiveProvenance::ComposeDirective),
+                        (None, false) => {
+                            ctx.diagnostics.push_warning(format!(
+                                "Directive `{}` is not defined in any extension or composed directive",
+                                &ctx[directive.name]
+                            ));
+                            None
+                        }
                     }
-                    (LinkedSchemaType::Extension(extension_id), false) => {
-                        ctx.mark_used_extension(*extension_id);
-                        Some(ir::DirectiveProvenance::LinkedFromExtension {
-                            linked_schema_id,
-                            extension_id: *extension_id,
-                        })
-                    }
-                    (_, true) => Some(ir::DirectiveProvenance::ComposeDirective),
-                    (_, false) => {
-                        ctx.diagnostics.push_warning(format!(
-                            "Directive `{}` is not defined in any extension or composed directive",
-                            &ctx[directive.name]
-                        ));
-                        None
-                    }
-                },
+                }
             };
 
             let Some(provenance) = provenance else {

--- a/crates/graphql-composition/src/composition_ir.rs
+++ b/crates/graphql-composition/src/composition_ir.rs
@@ -42,6 +42,8 @@ pub(crate) struct CompositionIr {
     pub(crate) fields: Vec<FieldIr>,
     pub(crate) union_members: BTreeSet<(federated::StringId, federated::StringId)>,
 
+    /// Link declaration in subgraphs that link to a Grafbase extension. Sorted.
+    pub(crate) linked_schema_to_extension: Vec<(subgraphs::LinkedSchemaId, subgraphs::ExtensionId)>,
     // indexed by ExtensionId
     pub(crate) used_extensions: fixedbitset::FixedBitSet,
 }

--- a/crates/graphql-composition/src/lib.rs
+++ b/crates/graphql-composition/src/lib.rs
@@ -13,8 +13,6 @@ mod result;
 mod subgraphs;
 mod validate;
 
-use crate::subgraphs::LinkedSchemaType;
-
 pub use self::{
     diagnostics::Diagnostics,
     federated_graph::{DomainError, FederatedGraph, render_api_sdl, render_federated_sdl},
@@ -63,7 +61,7 @@ pub fn compose(subgraphs: &Subgraphs) -> CompositionResult {
             continue;
         };
 
-        if let LinkedSchemaType::Extension(extension_id) = context.subgraphs[linked_schema_id].linked_schema_type {
+        if let Some(extension_id) = context.get_extension_for_linked_schema(linked_schema_id) {
             context.mark_used_extension(extension_id);
         } else if !is_composed_directive {
             context.diagnostics.push_warning(format!(

--- a/crates/graphql-composition/src/subgraphs/extensions.rs
+++ b/crates/graphql-composition/src/subgraphs/extensions.rs
@@ -4,6 +4,7 @@ pub(crate) type Extension<'a> = View<'a, ExtensionId, ExtensionRecord>;
 
 pub(crate) struct ExtensionRecord {
     pub(crate) url: StringId,
+    pub(crate) link_url: StringId,
     pub(crate) name: StringId,
 }
 

--- a/crates/graphql-composition/tests/composition/grafbase_extensions/extensions_directives_on_schema_definition/api.graphql.snap
+++ b/crates/graphql-composition/tests/composition/grafbase_extensions/extensions_directives_on_schema_definition/api.graphql.snap
@@ -1,9 +1,19 @@
 ---
 source: crates/graphql-composition/tests/composition_tests.rs
-expression: actual_api_sdl
-input_file: crates/graphql-composition/tests/composition/extensions_directives_on_schema_definition/test.md
+expression: "The directives from extensions that are on schema definitions are treated slightly differently, so this is a dedicated test case to check that they are emitted and roundtrip through SDL correctly."
+input_file: crates/graphql-composition/tests/composition/grafbase_extensions/extensions_directives_on_schema_definition/test.md
 ---
+type Book {
+  genres: [String!]
+  id: ID!
+  pages: Int
+  published: Boolean
+  title: String!
+}
+
 type Query {
+  book(id: ID!): Book
+  books: [Book!]
   hello: String
   hi: String
 }

--- a/crates/graphql-composition/tests/composition/grafbase_extensions/extensions_directives_on_schema_definition/extensions.toml
+++ b/crates/graphql-composition/tests/composition/grafbase_extensions/extensions_directives_on_schema_definition/extensions.toml
@@ -1,3 +1,7 @@
 [[extensions]]
 name = "rest"
 url = "https://grafbase.com/extensions/rest"
+
+[[extensions]]
+name = "selection-set-resolver"
+url = "file:///selection-set-resolver-015-1.0.0"

--- a/crates/graphql-composition/tests/composition/grafbase_extensions/extensions_directives_on_schema_definition/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/grafbase_extensions/extensions_directives_on_schema_definition/federated.graphql.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/graphql-composition/tests/composition_tests.rs
 expression: "The directives from extensions that are on schema definitions are treated slightly differently, so this is a dedicated test case to check that they are emitted and roundtrip through SDL correctly."
-input_file: crates/graphql-composition/tests/composition/extensions_directives_on_schema_definition/test.md
+input_file: crates/graphql-composition/tests/composition/grafbase_extensions/extensions_directives_on_schema_definition/test.md
 ---
 directive @join__unionMember(graph: join__Graph!, member: String!) on UNION
 
@@ -17,8 +17,20 @@ directive @join__owner(graph: join__Graph!) on OBJECT
 
 scalar join__FieldSet
 
+type Book
+  @join__type(graph: INIT)
+{
+  genres: [String!]
+  id: ID!
+  pages: Int
+  published: Boolean
+  title: String!
+}
+
 type Query
 {
+  book(id: ID!): Book @join__field(graph: INIT)
+  books: [Book!] @join__field(graph: INIT)
   hello: String @join__field(graph: DEFINITION)
   hi: String @join__field(graph: SCHEMA_EXTENSION)
 }
@@ -26,10 +38,12 @@ type Query
 enum join__Graph
 {
   DEFINITION @join__graph(name: "definition", url: "http://example.com/definition")
+  INIT @join__graph(name: "init", url: "http://example.com/init")
   SCHEMA_EXTENSION @join__graph(name: "schema-extension", url: "http://example.com/schema-extension")
 }
 
 enum extension__Link
 {
   REST @extension__link(url: "https://grafbase.com/extensions/rest", schemaDirectives: [{graph: DEFINITION, name: "assured", arguments: {}}, {graph: SCHEMA_EXTENSION, name: "assured", arguments: {}}])
+  SELECTION_SET_RESOLVER @extension__link(url: "file:///selection-set-resolver-015-1.0.0", schemaDirectives: [{graph: INIT, name: "init", arguments: {}}])
 }

--- a/crates/graphql-composition/tests/composition/grafbase_extensions/extensions_directives_on_schema_definition/subgraphs/init.graphql
+++ b/crates/graphql-composition/tests/composition/grafbase_extensions/extensions_directives_on_schema_definition/subgraphs/init.graphql
@@ -1,0 +1,14 @@
+extend schema @link(url: "file:///selection-set-resolver-015-1.0.0", import: ["@init"]) @init
+
+type Book {
+  id: ID!
+  title: String!
+  pages: Int
+  published: Boolean
+  genres: [String!]
+}
+
+type Query {
+  book(id: ID!): Book
+  books: [Book!]
+}


### PR DESCRIPTION
The changes in #3334 make the logic easier, but also order dependent: you have to ingest extensions, then subgraphs, otherwise your extensions are silently ignored. We do it the other way around in the schema registry.

No changelog because the original change hasn't been released yet.