### PR TITLE
fix tracing debug

### DIFF
--- a/crates/engine/src/resolver/extension/query_or_mutation.rs
+++ b/crates/engine/src/resolver/extension/query_or_mutation.rs
@@ -85,9 +85,12 @@ impl super::ExtensionResolver {
                 .await;
             tracing::debug!(
                 "Received:\n{}",
-                batched_field_results.iter().format_with("\n", |(field, result), f| {
-                    f(&format_args!("{}: {}", field.subgraph_response_key_str(), result))
-                })
+                batched_field_results
+                    .iter()
+                    .format_with("\n", |(field, result), f| {
+                        f(&format_args!("{}: {}", field.subgraph_response_key_str(), result))
+                    })
+                    .to_string() // opentelemetry fails otherwise.
             );
 
             let state = response_part.into_seed_state(plan.shape().id);
@@ -169,6 +172,7 @@ impl super::ExtensionResolver {
                             result
                         ))
                     })
+                    .to_string() // opentelemetry fails otherwise.
             );
 
             let state = response_part.into_seed_state(plan.shape().id);

--- a/crates/engine/src/resolver/extension/selection_set/query_or_mutation.rs
+++ b/crates/engine/src/resolver/extension/selection_set/query_or_mutation.rs
@@ -64,6 +64,7 @@ impl super::SelectionSetExtensionResolver {
                         result
                     ))
                 })
+                .to_string() // opentelemetry fails otherwise.
         );
 
         let state = response_part.into_seed_state(plan.shape().id);


### PR DESCRIPTION
Fixes a panic in itertools because somehow `std::fmt::Display.fmt` gets called twice with opentelemetry and the result of `format_with` doesn't support it.
```
 FormatWith: was already formatted once
```