### PR TITLE
sdk: fix typo in public API

### DIFF
--- a/crates/grafbase-sdk/changelog/unreleased.md
+++ b/crates/grafbase-sdk/changelog/unreleased.md
@@ -1,0 +1,3 @@
+## Fixes
+
+- (breaking) Renamed the `authorization_icontext_by_key` on `AuthorizedOperationContext` to `authorization_context_by_key`. This was a typo.

--- a/crates/grafbase-sdk/src/types/context.rs
+++ b/crates/grafbase-sdk/src/types/context.rs
@@ -70,7 +70,7 @@ impl AuthorizedOperationContext {
     ///
     /// Use [authorization_context()](AuthorizedOperationContext::authorization_context()) if you have only one
     /// authorization extension returning a non-empty state.
-    pub fn authorization_icontext_by_key(&self, key: &str) -> Result<Vec<u8>, SdkError> {
+    pub fn authorization_context_by_key(&self, key: &str) -> Result<Vec<u8>, SdkError> {
         self.0.authorization_context(Some(key)).map_err(Into::into)
     }
 }


### PR DESCRIPTION
Renaming the `authorization_icontext_by_key` on `AuthorizedOperationContext` to `authorization_context_by_key`.