### PR TITLE
ci: push latest gateway docker image tag again

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -62,7 +62,7 @@ jobs:
       packages: write
 
   docker-gateway:
-    needs: [check]
+    needs: [check, detect-change-type]
     if: ${{ (needs.detect-change-type.outputs.build == 'true' || startsWith(github.ref, 'refs/tags/')) }}
     runs-on: depot-ubuntu-24.04
     permissions:


### PR DESCRIPTION
It broke in https://github.com/grafbase/grafbase/pull/3340

The issue is that the docker-gateway job was changed from depending on test (which depended on lint, which depended on detect-change-type) to depending only on check. However, the job still references needs.detect-change-type.outputs.build in its condition, but detect-change-type is no longer in its dependency chain. This causes the condition to always evaluate to false for non-tag pushes, so the job never runs on main branch pushes anymore - only on tags.