### PR TITLE
graphql-composition: handle entities with type extensions

### DIFF
--- a/cli/src/dev/subgraphs.rs
+++ b/cli/src/dev/subgraphs.rs
@@ -216,7 +216,7 @@ impl SubgraphCache {
             ));
         }
 
-        let result = graphql_composition::compose(&subgraphs);
+        let result = graphql_composition::compose(&mut subgraphs);
 
         {
             let mut warnings = result.diagnostics().iter_warnings().peekable();

--- a/cli/src/mcp.rs
+++ b/cli/src/mcp.rs
@@ -58,7 +58,7 @@ pub(crate) async fn run(args: McpCommand) -> anyhow::Result<()> {
         subgraphs
             .ingest_str(&schema, "api", Some(args.url.as_str()))
             .map_err(|err| anyhow::anyhow!("Invalid schema: {err}"))?;
-        let federated_graph = graphql_composition::compose(&subgraphs)
+        let federated_graph = graphql_composition::compose(&mut subgraphs)
             .into_result()
             .map_err(|diagnostics| {
                 anyhow::anyhow!(

--- a/crates/federation-audit-tests/tests/composition_comparisons.rs
+++ b/crates/federation-audit-tests/tests/composition_comparisons.rs
@@ -32,7 +32,7 @@ fn runner_for(suite: String) -> impl FnOnce() -> Result<(), Failed> + Send + 'st
                 .unwrap()
         }
 
-        let graph = graphql_composition::compose(&subgraphs).into_result().unwrap();
+        let graph = graphql_composition::compose(&mut subgraphs).into_result().unwrap();
         let output = graphql_composition::render_federated_sdl(&graph).unwrap();
 
         let output = prettify_sdl(&output);

--- a/crates/graphql-composition/CHANGELOG.md
+++ b/crates/graphql-composition/CHANGELOG.md
@@ -20,10 +20,12 @@
 - Fixed `Diagnostics::iter_warnings()` iterating over warnings instead of errors.
 - Interfaces both defined in federation v1 subgraphs and as entity interfaces in federation v2 subgraphs do not force the federation v1 subgraphs to define all implementers of the entity interface anymore.
 - Federation v1 subgraphs are no longer taken into account when composing entity interfaces.
+- Fixed handling of entities with type extensions, where in some cases `@key`s would be missed for scenarios where the same entity is extended, then defined in the same subgraph, with other definitions in between. (https://github.com/grafbase/grafbase/pull/3454)
 
 ## Breaking changes
 
 - Many types, fields and methods that are part of the `FederatedGraph` data structure are now private. `FederatedGraph` as a whole will become private as well, since the scope of this crate is only to render the federated SDL.
+- `compose()` now takes an `&mut Subgraphs` argument instead of `&Subgraphs`.
 
 ## 0.10.0 - 2025-07-30
 

--- a/crates/graphql-composition/src/lib.rs
+++ b/crates/graphql-composition/src/lib.rs
@@ -28,7 +28,9 @@ use self::{
 };
 
 /// Compose subgraphs into a federated graph.
-pub fn compose(subgraphs: &Subgraphs) -> CompositionResult {
+pub fn compose(subgraphs: &mut Subgraphs) -> CompositionResult {
+    subgraphs.sort_post_ingestion();
+
     let mut diagnostics = Diagnostics::default();
 
     if subgraphs.iter_subgraphs().len() == 0 {
@@ -113,7 +115,7 @@ mod tests {
         subgraphs
             .ingest_str(&schema, "grafbase-api", Some("https://api.grafbase.com"))
             .unwrap();
-        let result = compose(&subgraphs);
+        let result = compose(&mut subgraphs);
         assert!(!result.diagnostics().any_fatal());
     }
 }

--- a/crates/graphql-composition/src/subgraphs.rs
+++ b/crates/graphql-composition/src/subgraphs.rs
@@ -192,4 +192,15 @@ impl Subgraphs {
     pub(crate) fn emit_ingestion_diagnostics(&self, diagnostics: &mut crate::Diagnostics) {
         diagnostics.clone_all_from(&self.ingestion_diagnostics);
     }
+
+    /// After subgraphs have been ingested, we have to sort some of the vecs we expect to be sorted at the composition stage, because with type extensions, they may be out of order. For example keys may have had other definitions ingested before we are done ingesting a given type (always because of type extensions).
+    pub(crate) fn sort_post_ingestion(&mut self) {
+        self.keys.keys.sort_unstable_by_key(|key| key.definition_id);
+        self.directives
+            .extra_directives
+            .sort_unstable_by_key(|directive| directive.directive_site_id);
+        self.fields
+            .fields
+            .sort_unstable_by_key(|field| field.parent_definition_id);
+    }
 }

--- a/crates/graphql-composition/tests/composition/federation_v1/big_subgraph/api.graphql.snap
+++ b/crates/graphql-composition/tests/composition/federation_v1/big_subgraph/api.graphql.snap
@@ -1,0 +1,56 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: API SDL
+input_file: crates/graphql-composition/tests/composition/federation_v1/big_subgraph/test.md
+---
+enum Enum553 {
+  VALUE_1
+}
+
+type Year22 {
+  field2: Enum553!
+}
+
+type Year26 {
+  field132: ID!
+}
+
+type Year1989 {
+  field30097: [ID!]
+}
+
+type Year2009 {
+  field2: ID!
+  field30098: ID
+  field7: Int
+}
+
+type Year1996 {
+  field2: ID!
+  field30099: ID
+  field7: Int
+}
+
+type Year1990 {
+  field2: ID!
+  field7: Int
+}
+
+type Year1946 {
+  field2: ID!
+  field24: [Year1990!]
+}
+
+type Year2000 {
+  field2: ID!
+}
+
+type Query {
+  field30156(arg1: [ID!]!): [Year1996]
+}
+
+scalar Scalar8
+
+scalar Scalar1
+
+scalar Scalar4

--- a/crates/graphql-composition/tests/composition/federation_v1/big_subgraph/diagnostics.snap
+++ b/crates/graphql-composition/tests/composition/federation_v1/big_subgraph/diagnostics.snap
@@ -1,0 +1,14 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: Diagnostics
+input_file: crates/graphql-composition/tests/composition/federation_v1/big_subgraph/test.md
+---
+- ⚠️ [big]: Unknown directive `@directive1` at `Year1990`
+- ⚠️ [big]: Unknown directive `@directive1` at `Year1946`
+- ⚠️ [big]: Unknown directive `@directive1` at `Year2009`
+- ⚠️ [big]: Unknown directive `@directive1` at `Year1996`
+- ⚠️ [big]: Unknown directive `@directive2` at `Year1990.field2`
+- ⚠️ [big]: Unknown directive `@directive2` at `Year1946.field2`
+- ⚠️ [big]: Unknown directive `@directive1` at `Year1946.field24`
+- ⚠️ [big]: Unknown directive `@directive2` at `Year2009.field2`
+- ⚠️ [big]: Unknown directive `@directive2` at `Year1996.field2`

--- a/crates/graphql-composition/tests/composition/federation_v1/big_subgraph/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/federation_v1/big_subgraph/federated.graphql.snap
@@ -1,0 +1,97 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: Federated SDL
+input_file: crates/graphql-composition/tests/composition/federation_v1/big_subgraph/test.md
+---
+directive @join__unionMember(graph: join__Graph!, member: String!) on UNION
+
+directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT | INTERFACE
+
+directive @join__graph(name: String!, url: String) on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
+
+directive @join__owner(graph: join__Graph!) on OBJECT
+
+scalar Scalar8
+
+scalar Scalar1
+
+scalar Scalar4
+
+scalar join__FieldSet
+
+type Year22
+  @join__type(graph: BIG, key: "field2")
+{
+  field2: Enum553!
+}
+
+type Year26
+  @join__type(graph: BIG, key: "field132")
+{
+  field132: ID!
+}
+
+type Year1989
+  @join__type(graph: BIG)
+{
+  field30097: [ID!]
+}
+
+type Year2009
+  @join__type(graph: BIG, key: "field2")
+  @join__type(graph: BIG, key: "field2 field7")
+{
+  field2: ID!
+  field30098: ID
+  field7: Int
+}
+
+type Year1996
+  @join__type(graph: BIG, key: "field2")
+  @join__type(graph: BIG, key: "field2 field7")
+{
+  field2: ID!
+  field30099: ID
+  field7: Int
+}
+
+type Year1990
+  @join__type(graph: BIG, key: "field2")
+  @join__type(graph: BIG, key: "field2 field7")
+{
+  field2: ID!
+  field7: Int
+}
+
+type Year1946
+  @join__type(graph: BIG, key: "field2")
+{
+  field2: ID!
+  field24: [Year1990!]
+}
+
+type Year2000
+  @join__type(graph: BIG, key: "field2")
+{
+  field2: ID!
+}
+
+type Query
+{
+  field30156(arg1: [ID!]!): [Year1996] @join__field(graph: BIG)
+}
+
+enum Enum553
+  @join__type(graph: BIG)
+{
+  VALUE_1
+}
+
+enum join__Graph
+{
+  BIG @join__graph(name: "big", url: "http://example.com/big")
+}

--- a/crates/graphql-composition/tests/composition/federation_v1/big_subgraph/subgraphs/big.graphql
+++ b/crates/graphql-composition/tests/composition/federation_v1/big_subgraph/subgraphs/big.graphql
@@ -1,0 +1,64 @@
+scalar Scalar8
+
+enum Enum553 {
+  VALUE_1
+}
+
+type Year22 @key(fields: "field2") @extends {
+  field2: Enum553! @external
+}
+
+type Year26 @key(fields: "field132") @extends {
+  field132: ID! @external
+}
+
+extend type Year1989 {
+  field30097: [ID!]
+}
+
+extend type Year2009 {
+  field30098: ID
+}
+
+extend type Year1996 {
+  field30099: ID
+}
+
+directive @directive1(arg47: String!) on OBJECT | INPUT_OBJECT | FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @directive2 on FIELD_DEFINITION
+
+scalar Scalar1
+
+scalar Scalar4
+
+type Year1990 @key(fields: "field2") @key(fields: "field2 field7") @directive1(arg47: "anonymous-string") {
+  field2: ID! @directive2
+  field7: Int
+}
+
+type Year1946 @key(fields: "field2") @directive1(arg47: "anonymous-string") {
+  field2: ID! @directive2
+}
+
+extend type Year1946 {
+  field24: [Year1990!] @directive1(arg47: "anonymous-string")
+}
+
+type Year2000 @key(fields: "field2") {
+  field2: ID!
+}
+
+type Year2009 @key(fields: "field2") @key(fields: "field2 field7") @directive1(arg47: "anonymous-string") {
+  field2: ID! @directive2
+  field7: Int
+}
+
+type Year1996 @key(fields: "field2") @key(fields: "field2 field7") @directive1(arg47: "anonymous-string") {
+  field2: ID! @directive2
+  field7: Int
+}
+
+type Query @extends {
+  field30156(arg1: [ID!]!): [Year1996]
+}

--- a/crates/graphql-composition/tests/composition_special_cases.rs
+++ b/crates/graphql-composition/tests/composition_special_cases.rs
@@ -10,7 +10,7 @@ fn subgraph_names_that_differ_only_by_case_are_not_allowed() {
         .ingest_str("type Query { fullName: String }", "Valid", Some("example.com"))
         .unwrap();
 
-    let result = graphql_composition::compose(&subgraphs);
+    let result = graphql_composition::compose(&mut subgraphs);
     let diagnostics = result.diagnostics();
     let messages: Vec<_> = diagnostics.iter_messages().collect();
     assert_eq!(messages.len(), 1);

--- a/crates/graphql-composition/tests/composition_tests.rs
+++ b/crates/graphql-composition/tests/composition_tests.rs
@@ -49,7 +49,7 @@ fn run_test(test_path: &Path) -> anyhow::Result<()> {
         }
     }));
 
-    let result = graphql_composition::compose(&subgraphs);
+    let result = graphql_composition::compose(&mut subgraphs);
 
     let diagnostics = result.diagnostics();
     let mut rendered_diagnostics = String::new();

--- a/crates/integration-tests/src/gateway/builder.rs
+++ b/crates/integration-tests/src/gateway/builder.rs
@@ -166,7 +166,7 @@ impl GatewayBuilder {
                             )?;
                         }
 
-                        graphql_composition::compose(&composed_subgraphs)
+                        graphql_composition::compose(&mut composed_subgraphs)
                             .warnings_are_fatal()
                             .into_result()
                             .expect("schemas to compose succesfully")

--- a/gateway/tests/entity_caching/mod.rs
+++ b/gateway/tests/entity_caching/mod.rs
@@ -63,7 +63,7 @@ where
         subgraphs
             .ingest_str(subgraph_schema, "the-subgraph", Some(subgraph_url))
             .unwrap();
-        let graph = graphql_composition::compose(&subgraphs).into_result().unwrap();
+        let graph = graphql_composition::compose(&mut subgraphs).into_result().unwrap();
         graphql_composition::render_federated_sdl(&graph).unwrap()
     };
 

--- a/gateway/tests/telemetry/tracing.rs
+++ b/gateway/tests/telemetry/tracing.rs
@@ -549,7 +549,7 @@ fn with_mock_subgraph<T, F>(
         subgraphs
             .ingest_str(&subgraph_sdl, "the-subgraph", Some(subgraph_server.url().as_str()))
             .unwrap();
-        let graph = graphql_composition::compose(&subgraphs).into_result().unwrap();
+        let graph = graphql_composition::compose(&mut subgraphs).into_result().unwrap();
         graphql_composition::render_federated_sdl(&graph).unwrap()
     };
 


### PR DESCRIPTION
This is important for federation v1. If there are definitions in-between, subgraph schemas with something like:

```graphql
extend type A {
  fieldC: String
}

# ... definitions in between

type A @key(fields: "a b") {
  a: Int
  b: Int
}
```

would lead to non-contiguous sections of `subgraphs.keys.keys` to have the same definition id. So when we end up binary searching there, we would land in either section, and miss the key. This is solved by sorting the keys after subgraph ingestion.

To avoid the same problems with extra directives and fields in the future, this PR also makes sure we do this there, and stop relying on the BTreeMap with fields sorted by name, so the bug would manifest immediately for fields too if we didn't sort.