### PR TITLE
 graphql-composition: optimize finding fields by name

### DIFF
--- a/crates/graphql-composition/src/compose/entity_interface.rs
+++ b/crates/graphql-composition/src/compose/entity_interface.rs
@@ -180,7 +180,7 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
         let fields_to_add = fields_to_add
             .iter()
             // Avoid adding fields that are already present on the object by virtue of the object implementing the interface.
-            .filter(|(name, _)| object.find_field(*name).is_none())
+            .filter(|(name, _)| object.field_by_name(*name).is_none())
             .map(|(_, field_ir)| field_ir);
 
         for field_ir in fields_to_add {

--- a/crates/graphql-composition/src/compose/input_object.rs
+++ b/crates/graphql-composition/src/compose/input_object.rs
@@ -14,7 +14,11 @@ pub(super) fn merge_input_object_definitions(
     let intersection: HashSet<StringId> = first
         .fields()
         .map(|field| field.name().id)
-        .filter(|field_name| definitions[1..].iter().all(|def| def.find_field(*field_name).is_some()))
+        .filter(|field_name| {
+            definitions[1..]
+                .iter()
+                .all(|def| def.field_by_name(*field_name).is_some())
+        })
         .collect();
 
     let mut all_fields: Vec<_> = definitions

--- a/crates/graphql-composition/src/compose/interface.rs
+++ b/crates/graphql-composition/src/compose/interface.rs
@@ -36,7 +36,7 @@ fn check_implementers(interface_name: StringId, field_names: &[subgraphs::String
             if !ctx
                 .subgraphs
                 .iter_definitions_with_name(implementer_name)
-                .any(|(_, def)| ctx.subgraphs.walk(def).find_field(*field_name).is_some())
+                .any(|(_, def)| ctx.subgraphs.walk(def).field_by_name(*field_name).is_some())
             {
                 ctx.diagnostics.push_fatal(format!(
                     "The `{}.{}` field is not implemented by `{}`, but it should be.",

--- a/crates/graphql-composition/src/ingest_subgraph/nested_key_fields.rs
+++ b/crates/graphql-composition/src/ingest_subgraph/nested_key_fields.rs
@@ -11,7 +11,7 @@ pub(super) fn ingest_nested_key_fields(ctx: &mut Context<'_>) {
                     let Selection::Field(field) = selection else { continue };
 
                     let Some(field_type) = definition
-                        .find_field(field.field)
+                        .field_by_name(field.field)
                         .and_then(|field| field.r#type().definition(subgraph_id))
                     else {
                         continue;
@@ -40,7 +40,7 @@ fn ingest_nested_key_fields_rec(
         return;
     };
 
-    let Some(field) = parent_definition.find_field(*field) else {
+    let Some(field) = parent_definition.field_by_name(*field) else {
         return;
     };
 

--- a/crates/graphql-composition/src/subgraphs.rs
+++ b/crates/graphql-composition/src/subgraphs.rs
@@ -201,6 +201,6 @@ impl Subgraphs {
             .sort_unstable_by_key(|directive| directive.directive_site_id);
         self.fields
             .fields
-            .sort_unstable_by_key(|field| field.parent_definition_id);
+            .sort_unstable_by_key(|field| (field.parent_definition_id, field.name))
     }
 }

--- a/crates/graphql-composition/src/validate/selection.rs
+++ b/crates/graphql-composition/src/validate/selection.rs
@@ -117,7 +117,7 @@ fn validate_field_selection(
         return;
     }
     // The selected field must exist.
-    let Some(field) = on_definition.find_field(selection.field) else {
+    let Some(field) = on_definition.field_by_name(selection.field) else {
         return ctx.diagnostics.push_fatal(format!(
             "[{subgraph_name}] Error in @{directive_name} at {directive_path}: the {field_in_selection} field does not exist on {definition_name}",
             field_in_selection = ctx.subgraphs.walk(selection.field).as_str(),
@@ -130,12 +130,12 @@ fn validate_field_selection(
         .arguments()
         .filter(|arg| arg.r#type().is_required() && arg.default().is_none())
     {
-        let arg_name = required_argument.name();
-        if selection.arguments.iter().all(|(name, _)| *name != arg_name.id) {
+        let arg_name = required_argument.id.1.name;
+        if selection.arguments.iter().all(|(name, _)| *name != arg_name) {
             ctx.diagnostics.push_fatal(format!(
                 "[{subgraph_name}] Error in @{directive_name} on {directive_path}: the {field_name}.{arg_name} argument is required but not provided.",
                 field_name = field.name().as_str(),
-                arg_name = arg_name.as_str(),
+                arg_name = ctx.subgraphs[arg_name],
                 directive_path = directive_path(),
             ));
         }
@@ -204,7 +204,7 @@ fn argument_type_matches(
             };
 
             fields.iter().all(|(field_name, field_value)| {
-                let Some(inner_field) = input_object_type.find_field(*field_name) else {
+                let Some(inner_field) = input_object_type.field_by_name(*field_name) else {
                     return false;
                 };
 


### PR DESCRIPTION
Instead of a binary search to find the definition's fields, then linear search on them until we find the one we want, sort the fields by (parent_definition_id, name) and binary search on that directly.