### PR TITLE
Change QueryPosition to be a u32 rather than u16

### DIFF
--- a/crates/engine/query-solver/src/solution_space/builder/operation_fields.rs
+++ b/crates/engine/query-solver/src/solution_space/builder/operation_fields.rs
@@ -52,7 +52,7 @@ struct OperationFieldsIngestor<'schema, 'op, 'builder> {
     builder: &'builder mut QuerySolutionSpaceBuilder<'schema, 'op>,
     // Needs to be a queue to have the right query_position for fields.
     queue: VecDeque<IngestSelectionSet<'op>>,
-    next_query_position: u16,
+    next_query_position: u32,
     // Temporary structures for DFS
     parent_type_conditions: Vec<CompositeTypeId>,
     parent_directive_ids: Vec<ExecutableDirectiveId>,

--- a/crates/engine/src/execution/operation/response_modifier.rs
+++ b/crates/engine/src/execution/operation/response_modifier.rs
@@ -103,11 +103,11 @@ impl<'ctx, R: Runtime> ExecutionContext<'ctx, R> {
                                 for (element_ix, error_ix) in element_to_error {
                                     let obj_ref = &parent_objects[element_ix as usize];
                                     let err = errors[error_ix as usize].clone();
-                                    response.make_inacessible(ResponseValueId::Field {
-                                        object_id: obj_ref.id,
-                                        key: target_field.key(),
-                                        nullable: true,
-                                    });
+                                    response.make_inacessible(ResponseValueId::field(
+                                        obj_ref.id,
+                                        target_field.key(),
+                                        true,
+                                    ));
                                     response.push_error(
                                         err.clone()
                                             .with_path((&obj_ref.path, target_field.response_key))
@@ -133,11 +133,11 @@ impl<'ctx, R: Runtime> ExecutionContext<'ctx, R> {
                                 // the current value as inaccessible. So null for the client, but
                                 // available for requirements to be sent to subgraphs.
                                 for obj_ref in parent_objects.iter() {
-                                    response.make_inacessible(ResponseValueId::Field {
-                                        object_id: obj_ref.id,
-                                        key: target_field.key(),
-                                        nullable: true,
-                                    });
+                                    response.make_inacessible(ResponseValueId::field(
+                                        obj_ref.id,
+                                        target_field.key(),
+                                        true,
+                                    ));
                                     response.push_error(
                                         err.clone()
                                             .with_path((&obj_ref.path, target_field.response_key))

--- a/crates/engine/src/prepare/cached/builder/shapes/mod.rs
+++ b/crates/engine/src/prepare/cached/builder/shapes/mod.rs
@@ -361,7 +361,7 @@ impl<'ctx> ShapesBuilder<'ctx> {
                 // We've exhausted the typename fields, so we know we're in the data fields now.
                 let offset = typename_fields_sorted_by_response_key_str_then_position_extra_last.len();
                 let mut first_id = data_fields_sorted_by_response_key_str_then_position_extra_last[i - offset];
-                let first = &query_plan[first_id];
+                let mut first = &query_plan[first_id];
                 self.data_fields_shape_count[usize::from(first_id)] += 1;
 
                 // We'll group data fields together by their response key
@@ -375,15 +375,16 @@ impl<'ctx> ShapesBuilder<'ctx> {
                     if field.response_key == first.response_key {
                         group.push(field_id);
                     } else {
-                        let field_shape = self.create_data_field_shape(&mut group, first_id);
+                        let field_shape = self.create_data_field_shape(&group, first_id);
                         field_shapes_buffer.push(field_shape);
+                        first = field;
                         first_id = field_id;
                         group.clear();
                         group.push(first_id);
                     }
                 }
 
-                let field_shape = self.create_data_field_shape(&mut group, first_id);
+                let field_shape = self.create_data_field_shape(&group, first_id);
                 field_shapes_buffer.push(field_shape);
 
                 group.clear();

--- a/crates/engine/src/prepare/cached/builder/shapes/mod.rs
+++ b/crates/engine/src/prepare/cached/builder/shapes/mod.rs
@@ -6,7 +6,7 @@ use fixedbitset::FixedBitSet;
 use id_newtypes::IdRange;
 use im::HashSet;
 use itertools::Itertools;
-use operation::ResponseKey;
+use operation::{QueryPosition, ResponseKey};
 use schema::{
     CompositeType, CompositeTypeId, ObjectDefinitionId, Schema, SubgraphId, TypeDefinition, TypeDefinitionId,
 };
@@ -233,12 +233,9 @@ impl<'ctx> ShapesBuilder<'ctx> {
             let mut fields = self.data_fields_buffer_pool.pop();
             fields.extend(selection_set.data_fields());
             fields.sort_unstable_by(|left, right| {
-                keys[left.response_key].cmp(&keys[right.response_key]).then(
-                    left.query_position
-                        .map(u16::from)
-                        .unwrap_or(u16::MAX)
-                        .cmp(&right.query_position.map(u16::from).unwrap_or(u16::MAX)),
-                )
+                keys[left.response_key]
+                    .cmp(&keys[right.response_key])
+                    .then_with(|| QueryPosition::cmp_with_none_last(left.query_position, right.query_position))
             });
             fields
         };
@@ -247,12 +244,9 @@ impl<'ctx> ShapesBuilder<'ctx> {
             let mut fields = self.typename_fields_buffer_pool.pop();
             fields.extend(selection_set.typename_fields());
             fields.sort_unstable_by(|left, right| {
-                keys[left.response_key].cmp(&keys[right.response_key]).then(
-                    left.query_position
-                        .map(u16::from)
-                        .unwrap_or(u16::MAX)
-                        .cmp(&right.query_position.map(u16::from).unwrap_or(u16::MAX)),
-                )
+                keys[left.response_key]
+                    .cmp(&keys[right.response_key])
+                    .then_with(|| QueryPosition::cmp_with_none_last(left.query_position, right.query_position))
             });
             fields
         };
@@ -477,20 +471,14 @@ impl<'ctx> ShapesBuilder<'ctx> {
             }
             let keys = &self.ctx.cached.operation.response_keys;
             data_fields.sort_unstable_by(|left, right| {
-                keys[left.response_key].cmp(&keys[right.response_key]).then(
-                    left.query_position
-                        .map(u16::from)
-                        .unwrap_or(u16::MAX)
-                        .cmp(&right.query_position.map(u16::from).unwrap_or(u16::MAX)),
-                )
+                keys[left.response_key]
+                    .cmp(&keys[right.response_key])
+                    .then_with(|| QueryPosition::cmp_with_none_last(left.query_position, right.query_position))
             });
             typename_fields.sort_unstable_by(|left, right| {
-                keys[left.response_key].cmp(&keys[right.response_key]).then(
-                    left.query_position
-                        .map(u16::from)
-                        .unwrap_or(u16::MAX)
-                        .cmp(&right.query_position.map(u16::from).unwrap_or(u16::MAX)),
-                )
+                keys[left.response_key]
+                    .cmp(&keys[right.response_key])
+                    .then_with(|| QueryPosition::cmp_with_none_last(left.query_position, right.query_position))
             });
             (data_fields, typename_fields)
         };
@@ -612,20 +600,14 @@ impl<'ctx> ShapesBuilder<'ctx> {
             }
             let keys = &self.ctx.cached.operation.response_keys;
             data_fields.sort_unstable_by(|left, right| {
-                keys[left.response_key].cmp(&keys[right.response_key]).then(
-                    left.query_position
-                        .map(u16::from)
-                        .unwrap_or(u16::MAX)
-                        .cmp(&right.query_position.map(u16::from).unwrap_or(u16::MAX)),
-                )
+                keys[left.response_key]
+                    .cmp(&keys[right.response_key])
+                    .then_with(|| QueryPosition::cmp_with_none_last(left.query_position, right.query_position))
             });
             typename_fields.sort_unstable_by(|left, right| {
-                keys[left.response_key].cmp(&keys[right.response_key]).then(
-                    left.query_position
-                        .map(u16::from)
-                        .unwrap_or(u16::MAX)
-                        .cmp(&right.query_position.map(u16::from).unwrap_or(u16::MAX)),
-                )
+                keys[left.response_key]
+                    .cmp(&keys[right.response_key])
+                    .then_with(|| QueryPosition::cmp_with_none_last(left.query_position, right.query_position))
             });
             (data_fields, typename_fields)
         };

--- a/crates/engine/src/prepare/cached/builder/shapes/mod.rs
+++ b/crates/engine/src/prepare/cached/builder/shapes/mod.rs
@@ -16,11 +16,11 @@ use crate::{
     prepare::{
         BatchFieldShape, DataOrLookupFieldId, DefaultFieldShapeRecord, Derive, DerivedEntityShapeId,
         DerivedEntityShapeRecord, LookupFieldId, OnRootFieldsError, RootFieldsShapeId, RootFieldsShapeRecord,
-        TypenameShapeRecord,
+        TypenameFieldId, TypenameShapeRecord,
         cached::{
-            CachedOperationContext, ConcreteShapeId, ConcreteShapeRecord, DataField, DataFieldId, FieldShapeId,
-            FieldShapeRecord, FieldShapeRefId, ObjectIdentifier, PartitionSelectionSet, PolymorphicShapeId,
-            PolymorphicShapeRecord, ResponseObjectSetId, Shape, Shapes, TypenameField,
+            CachedOperationContext, ConcreteShapeId, ConcreteShapeRecord, DataFieldId, FieldShapeId, FieldShapeRecord,
+            FieldShapeRefId, ObjectIdentifier, PartitionSelectionSet, PolymorphicShapeId, PolymorphicShapeRecord,
+            ResponseObjectSetId, Shape, Shapes,
         },
     },
     utils::BufferPool,
@@ -123,8 +123,8 @@ pub(super) struct ShapesBuilder<'ctx> {
     data_field_ids_with_selection_set_requiring_typename: Vec<DataFieldId>,
     field_shapes_buffer_pool: BufferPool<FieldShapeRecord>,
     typename_shapes_buffer_pool: BufferPool<TypenameShapeRecord>,
-    data_fields_buffer_pool: BufferPool<DataField<'ctx>>,
-    typename_fields_buffer_pool: BufferPool<TypenameField<'ctx>>,
+    data_fields_buffer_pool: BufferPool<DataFieldId>,
+    typename_fields_buffer_pool: BufferPool<TypenameFieldId>,
     current_subgraph_id: SubgraphId,
 }
 
@@ -229,10 +229,13 @@ impl<'ctx> ShapesBuilder<'ctx> {
         }
 
         let keys = &self.ctx.cached.operation.response_keys;
+        let query_plan = &self.ctx.cached.query_plan;
         let data_fields_sorted_by_response_key_str_then_position_extra_last = {
             let mut fields = self.data_fields_buffer_pool.pop();
-            fields.extend(selection_set.data_fields());
+            fields.extend(selection_set.data_field_ids_ordered_by_parent_entity_then_key);
             fields.sort_unstable_by(|left, right| {
+                let left = &query_plan[*left];
+                let right = &query_plan[*right];
                 keys[left.response_key]
                     .cmp(&keys[right.response_key])
                     .then_with(|| QueryPosition::cmp_with_none_last(left.query_position, right.query_position))
@@ -242,8 +245,10 @@ impl<'ctx> ShapesBuilder<'ctx> {
 
         let typename_fields_sorted_by_response_key_str_then_position_extra_last = {
             let mut fields = self.typename_fields_buffer_pool.pop();
-            fields.extend(selection_set.typename_fields());
+            fields.extend(selection_set.typename_field_ids);
             fields.sort_unstable_by(|left, right| {
+                let left = &query_plan[*left];
+                let right = &query_plan[*right];
                 keys[left.response_key]
                     .cmp(&keys[right.response_key])
                     .then_with(|| QueryPosition::cmp_with_none_last(left.query_position, right.query_position))
@@ -326,16 +331,18 @@ impl<'ctx> ShapesBuilder<'ctx> {
         &mut self,
         identifier: ObjectIdentifier,
         set_id: Option<ResponseObjectSetId>,
-        typename_fields_sorted_by_response_key_str_then_position_extra_last: &[TypenameField<'ctx>],
-        data_fields_sorted_by_response_key_str_then_position_extra_last: &[DataField<'ctx>],
+        typename_fields_sorted_by_response_key_str_then_position_extra_last: &[TypenameFieldId],
+        data_fields_sorted_by_response_key_str_then_position_extra_last: &[DataFieldId],
         included_typename_then_data_fields: FixedBitSet,
     ) -> ConcreteShapeId {
         let mut field_shapes_buffer = self.field_shapes_buffer_pool.pop();
         let mut distinct_typename_shapes = self.typename_shapes_buffer_pool.pop();
         let mut included = included_typename_then_data_fields.into_ones();
+        let query_plan = &self.ctx.cached.query_plan;
 
         while let Some(i) = included.next() {
-            if let Some(field) = typename_fields_sorted_by_response_key_str_then_position_extra_last.get(i) {
+            if let Some(&field_id) = typename_fields_sorted_by_response_key_str_then_position_extra_last.get(i) {
+                let field = &query_plan[field_id];
                 if distinct_typename_shapes
                     .last()
                     // fields aren't sorted by the response key but by the string value they point
@@ -346,35 +353,37 @@ impl<'ctx> ShapesBuilder<'ctx> {
                     distinct_typename_shapes.push(TypenameShapeRecord {
                         query_position_before_modifications: field.query_position,
                         response_key: field.response_key,
-                        id: field.id,
+                        id: field_id,
                         location: field.location,
                     });
                 }
             } else {
                 // We've exhausted the typename fields, so we know we're in the data fields now.
                 let offset = typename_fields_sorted_by_response_key_str_then_position_extra_last.len();
-                let mut first = data_fields_sorted_by_response_key_str_then_position_extra_last[i - offset];
-                self.data_fields_shape_count[usize::from(first.id)] += 1;
+                let mut first_id = data_fields_sorted_by_response_key_str_then_position_extra_last[i - offset];
+                let first = &query_plan[first_id];
+                self.data_fields_shape_count[usize::from(first_id)] += 1;
 
                 // We'll group data fields together by their response key
                 let mut group = self.data_fields_buffer_pool.pop();
-                group.push(first);
+                group.push(first_id);
 
                 for i in included.by_ref() {
-                    let field = data_fields_sorted_by_response_key_str_then_position_extra_last[i - offset];
-                    self.data_fields_shape_count[usize::from(field.id)] += 1;
+                    let field_id = data_fields_sorted_by_response_key_str_then_position_extra_last[i - offset];
+                    self.data_fields_shape_count[usize::from(field_id)] += 1;
+                    let field = &query_plan[field_id];
                     if field.response_key == first.response_key {
-                        group.push(field);
+                        group.push(field_id);
                     } else {
-                        let field_shape = self.create_data_field_shape(&mut group, first);
+                        let field_shape = self.create_data_field_shape(&mut group, first_id);
                         field_shapes_buffer.push(field_shape);
-                        first = field;
+                        first_id = field_id;
                         group.clear();
-                        group.push(first);
+                        group.push(first_id);
                     }
                 }
 
-                let field_shape = self.create_data_field_shape(&mut group, first);
+                let field_shape = self.create_data_field_shape(&mut group, first_id);
                 field_shapes_buffer.push(field_shape);
 
                 group.clear();
@@ -424,7 +433,8 @@ impl<'ctx> ShapesBuilder<'ctx> {
         self.push_concrete_shape(shape)
     }
 
-    fn create_data_field_shape(&mut self, group: &mut [DataField<'ctx>], first: DataField<'ctx>) -> FieldShapeRecord {
+    fn create_data_field_shape(&mut self, group: &[DataFieldId], first: DataFieldId) -> FieldShapeRecord {
+        let first = first.walk(self.ctx);
         let ty = first.definition().ty();
         let shape = if let Some(Derive::Root { batch_field_id }) = first.derive {
             Shape::DeriveEntity(self.create_derived_entity(batch_field_id, group, ty.definition_id.as_object()))
@@ -455,38 +465,53 @@ impl<'ctx> ShapesBuilder<'ctx> {
     fn create_derived_entity(
         &mut self,
         batch_field_id: Option<DataFieldId>,
-        parent_fields: &[DataField<'ctx>],
+        parent_field_ids: &[DataFieldId],
         object_definition_id: Option<ObjectDefinitionId>,
     ) -> DerivedEntityShapeId {
-        let set_id = parent_fields.iter().find_map(|field| field.output_id);
+        let keys = &self.ctx.cached.operation.response_keys;
+        let query_plan = &self.ctx.cached.query_plan;
         let (
+            set_id,
             data_fields_sorted_by_response_key_str_then_position_extra_last,
             typename_fields_sorted_by_response_key_str_then_position_extra_last,
         ) = {
+            let mut set_id = None;
             let mut data_fields = self.data_fields_buffer_pool.pop();
             let mut typename_fields = self.typename_fields_buffer_pool.pop();
-            for parent_field in parent_fields {
-                data_fields.extend(parent_field.selection_set().data_fields());
-                typename_fields.extend(parent_field.selection_set().typename_fields());
+            for &parent_field_id in parent_field_ids {
+                let parent_field = parent_field_id.walk(self.ctx);
+                if set_id.is_none() {
+                    set_id = parent_field.output_id;
+                }
+                data_fields.extend(
+                    parent_field
+                        .selection_set()
+                        .data_field_ids_ordered_by_parent_entity_then_key,
+                );
+                typename_fields.extend(parent_field.selection_set().typename_field_ids);
             }
-            let keys = &self.ctx.cached.operation.response_keys;
             data_fields.sort_unstable_by(|left, right| {
+                let left = &query_plan[*left];
+                let right = &query_plan[*right];
                 keys[left.response_key]
                     .cmp(&keys[right.response_key])
                     .then_with(|| QueryPosition::cmp_with_none_last(left.query_position, right.query_position))
             });
             typename_fields.sort_unstable_by(|left, right| {
+                let left = &query_plan[*left];
+                let right = &query_plan[*right];
                 keys[left.response_key]
                     .cmp(&keys[right.response_key])
                     .then_with(|| QueryPosition::cmp_with_none_last(left.query_position, right.query_position))
             });
-            (data_fields, typename_fields)
+            (set_id, data_fields, typename_fields)
         };
 
         let mut field_shapes_buffer = self.field_shapes_buffer_pool.pop();
         let mut distinct_typename_shapes = self.typename_shapes_buffer_pool.pop();
 
-        for field in typename_fields_sorted_by_response_key_str_then_position_extra_last {
+        for field_id in typename_fields_sorted_by_response_key_str_then_position_extra_last {
+            let field = &query_plan[field_id];
             if distinct_typename_shapes
                 .last()
                 // fields aren't sorted by the response key but by the string value they point
@@ -497,20 +522,21 @@ impl<'ctx> ShapesBuilder<'ctx> {
                 distinct_typename_shapes.push(TypenameShapeRecord {
                     query_position_before_modifications: field.query_position,
                     response_key: field.response_key,
-                    id: field.id,
+                    id: field_id,
                     location: field.location,
                 });
             }
         }
 
-        for field in data_fields_sorted_by_response_key_str_then_position_extra_last {
+        for field_id in data_fields_sorted_by_response_key_str_then_position_extra_last {
             if field_shapes_buffer
                 .last()
                 // fields aren't sorted by the response key but by the string value they point
                 // to. However, response keys are deduplicated so the equality also works here
                 // to ensure we only have distinct values.
-                .is_none_or(|shape| shape.response_key != field.response_key)
+                .is_none_or(|shape| shape.response_key != query_plan[field_id].response_key)
             {
+                let field = field_id.walk(self.ctx);
                 let ty = field.definition().ty();
                 let (expected_key, shape) = match field.derive {
                     Some(Derive::From(id)) => {
@@ -580,36 +606,53 @@ impl<'ctx> ShapesBuilder<'ctx> {
 
     fn create_field_composite_type_output_shape(
         &mut self,
-        parent_fields: &[DataField<'ctx>],
+        parent_field_ids: &[DataFieldId],
         output: CompositeType<'ctx>,
     ) -> Shape {
         //
         // Preparation
         //
-        let set_id = parent_fields.iter().find_map(|field| field.output_id);
+        let keys = &self.ctx.cached.operation.response_keys;
+        let query_plan = &self.ctx.cached.query_plan;
 
         let (
+            requires_typename,
+            set_id,
             data_fields_sorted_by_response_key_str_then_position_extra_last,
             typename_fields_sorted_by_response_key_str_then_position_extra_last,
         ) = {
+            let mut requires_typename = false;
+            let mut set_id = None;
             let mut data_fields = self.data_fields_buffer_pool.pop();
             let mut typename_fields = self.typename_fields_buffer_pool.pop();
-            for parent_field in parent_fields {
-                data_fields.extend(parent_field.selection_set().data_fields());
-                typename_fields.extend(parent_field.selection_set().typename_fields());
+            for &parent_field_id in parent_field_ids {
+                let parent_field = parent_field_id.walk(self.ctx);
+                if set_id.is_none() {
+                    set_id = parent_field.output_id;
+                }
+                requires_typename |= parent_field.selection_set_requires_typename;
+                data_fields.extend(
+                    parent_field
+                        .selection_set()
+                        .data_field_ids_ordered_by_parent_entity_then_key,
+                );
+                typename_fields.extend(parent_field.selection_set().typename_field_ids)
             }
-            let keys = &self.ctx.cached.operation.response_keys;
             data_fields.sort_unstable_by(|left, right| {
+                let left = &query_plan[*left];
+                let right = &query_plan[*right];
                 keys[left.response_key]
                     .cmp(&keys[right.response_key])
                     .then_with(|| QueryPosition::cmp_with_none_last(left.query_position, right.query_position))
             });
             typename_fields.sort_unstable_by(|left, right| {
+                let left = &query_plan[*left];
+                let right = &query_plan[*right];
                 keys[left.response_key]
                     .cmp(&keys[right.response_key])
                     .then_with(|| QueryPosition::cmp_with_none_last(left.query_position, right.query_position))
             });
-            (data_fields, typename_fields)
+            (requires_typename, set_id, data_fields, typename_fields)
         };
 
         //
@@ -623,8 +666,6 @@ impl<'ctx> ShapesBuilder<'ctx> {
             &typename_fields_sorted_by_response_key_str_then_position_extra_last,
             &data_fields_sorted_by_response_key_str_then_position_extra_last,
         );
-
-        let requires_typename = parent_fields.iter().any(|field| field.selection_set_requires_typename);
 
         //
         // Creating the right shape from the partitioning
@@ -651,7 +692,7 @@ impl<'ctx> ShapesBuilder<'ctx> {
                 // to know its actual type. We ensure that __typename will be present in the
                 // selection set we send to the subgraph and know how to read it.
                 self.data_field_ids_with_selection_set_requiring_typename
-                    .extend(parent_fields.iter().map(|field| field.id));
+                    .extend(parent_field_ids.iter().copied());
                 match output {
                     CompositeType::Interface(interface) => ObjectIdentifier::InterfaceTypename(interface.id),
                     CompositeType::Union(union) => ObjectIdentifier::UnionTypename(union.id),
@@ -674,7 +715,7 @@ impl<'ctx> ShapesBuilder<'ctx> {
             // treated the same. We may request no fields at all for some objects. So like before
             // we ensure we'll request the __typename in the subgraph query.
             self.data_field_ids_with_selection_set_requiring_typename
-                .extend(parent_fields.iter().map(|field| field.id));
+                .extend(parent_field_ids.iter().copied());
 
             let mut possibilities = Vec::with_capacity(partition_object_count);
             let mut fallback = None;
@@ -747,17 +788,20 @@ impl<'ctx> ShapesBuilder<'ctx> {
     fn compute_object_shape_partitions(
         &self,
         output: CompositeType<'ctx>,
-        typename_fields: &[TypenameField<'ctx>],
-        data_fields: &[DataField<'ctx>],
+        typename_fields: &[TypenameFieldId],
+        data_fields: &[DataFieldId],
     ) -> partition::Partitioning<ObjectDefinitionId, FixedBitSet> {
+        let query_plan = &self.ctx.cached.query_plan;
         let mut type_condition_and_field_position_in_bitset =
             Vec::with_capacity(typename_fields.len() + data_fields.len());
-        for (i, field) in typename_fields.iter().enumerate() {
+        for (i, field_id) in typename_fields.iter().enumerate() {
+            let field = &query_plan[*field_id];
             type_condition_and_field_position_in_bitset
                 .push((&self.ctx.cached.query_plan[field.type_condition_ids], i));
         }
         let offset = typename_fields.len();
-        for (i, field) in data_fields.iter().enumerate() {
+        for (i, field_id) in data_fields.iter().enumerate() {
+            let field = &query_plan[*field_id];
             type_condition_and_field_position_in_bitset
                 .push((&self.ctx.cached.query_plan[field.type_condition_ids], offset + i));
         }

--- a/crates/engine/src/prepare/cached/query_plan/selection_set.rs
+++ b/crates/engine/src/prepare/cached/query_plan/selection_set.rs
@@ -1,12 +1,4 @@
-use walker::Iter;
-
-use super::{DataField, PartitionSelectionSet};
-
-impl<'a> PartitionSelectionSet<'a> {
-    pub(crate) fn data_fields(&self) -> impl Iter<Item = DataField<'a>> + 'a {
-        self.data_fields_ordered_by_parent_entity_then_key()
-    }
-}
+use super::PartitionSelectionSet;
 
 impl std::fmt::Debug for PartitionSelectionSet<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/engine/src/prepare/cached/shape/field.rs
+++ b/crates/engine/src/prepare/cached/shape/field.rs
@@ -11,6 +11,7 @@ pub(crate) struct FieldShapeRecord {
     pub expected_key: ResponseKey,
     pub query_position_before_modifications: Option<QueryPosition>,
     pub response_key: ResponseKey,
+    // TODO: merge both discriminant into a u8?
     pub id: DataOrLookupFieldId,
     pub shape: Shape,
     pub wrapping: Wrapping,

--- a/crates/engine/src/prepare/cached/shape/mod.rs
+++ b/crates/engine/src/prepare/cached/shape/mod.rs
@@ -29,3 +29,26 @@ pub(crate) struct Shapes {
     #[indexed_by(DefaultFieldShapeId)]
     pub default_fields: Vec<DefaultFieldShapeRecord>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_field_size() {
+        assert_eq!(std::mem::size_of::<FieldShapeRecord>(), 24);
+        assert_eq!(std::mem::align_of::<FieldShapeRecord>(), 4);
+    }
+
+    #[test]
+    fn check_concrete_size() {
+        assert_eq!(std::mem::size_of::<ConcreteShapeRecord>(), 32);
+        assert_eq!(std::mem::align_of::<ConcreteShapeRecord>(), 4);
+    }
+
+    #[test]
+    fn check_polymorphic_size() {
+        assert_eq!(std::mem::size_of::<PolymorphicShapeRecord>(), 32);
+        assert_eq!(std::mem::align_of::<PolymorphicShapeRecord>(), 8);
+    }
+}

--- a/crates/engine/src/resolver/graphql/federation.rs
+++ b/crates/engine/src/resolver/graphql/federation.rs
@@ -118,8 +118,8 @@ impl std::fmt::Display for DisplayPath<'_> {
         f.write_fmt(format_args!(
             "{}",
             self.path.iter().format_with(".", |value_id, f| match value_id {
-                ResponseValueId::Field { key, .. } => {
-                    let field_key = &self.keys[*key];
+                ResponseValueId::Field { response_key, .. } => {
+                    let field_key = &self.keys[*response_key];
                     f(&format_args!("{field_key}"))
                 }
                 ResponseValueId::Index { index, .. } => f(&format_args!("{index}")),

--- a/crates/engine/src/response/data.rs
+++ b/crates/engine/src/response/data.rs
@@ -182,9 +182,11 @@ impl DataPart {
         match value_id {
             ResponseValueId::Field {
                 object_id: ResponseObjectId { part_id, object_id },
-                key,
+                query_position,
+                response_key,
                 nullable,
             } => {
+                let key = response_key.with_position(query_position);
                 debug_assert!(part_id == self.id && nullable, "{part_id} == {} && {nullable}", self.id);
                 match self[object_id]
                     .fields_sorted_by_key

--- a/crates/engine/src/response/path.rs
+++ b/crates/engine/src/response/path.rs
@@ -1,7 +1,7 @@
 use std::cell::Ref;
 
 use error::{ErrorPath, InsertIntoErrorPath};
-use operation::PositionedResponseKey;
+use operation::{PositionedResponseKey, QueryPosition, ResponseKey};
 
 use super::{DataPartId, ResponseListId, ResponseObjectId};
 
@@ -11,7 +11,8 @@ use super::{DataPartId, ResponseListId, ResponseObjectId};
 pub(crate) enum ResponseValueId {
     Field {
         object_id: ResponseObjectId,
-        key: PositionedResponseKey,
+        query_position: Option<QueryPosition>,
+        response_key: ResponseKey,
         nullable: bool,
     },
     Index {
@@ -22,6 +23,14 @@ pub(crate) enum ResponseValueId {
 }
 
 impl ResponseValueId {
+    pub fn field(object_id: ResponseObjectId, key: PositionedResponseKey, nullable: bool) -> Self {
+        Self::Field {
+            object_id,
+            query_position: key.query_position,
+            response_key: key.response_key,
+            nullable,
+        }
+    }
     pub fn is_nullable(&self) -> bool {
         match self {
             ResponseValueId::Field { nullable, .. } => *nullable,
@@ -40,7 +49,7 @@ impl ResponseValueId {
 impl InsertIntoErrorPath for &ResponseValueId {
     fn insert_into(self, path: &mut ErrorPath) {
         match self {
-            ResponseValueId::Field { key, .. } => key.insert_into(path),
+            ResponseValueId::Field { response_key, .. } => response_key.insert_into(path),
             ResponseValueId::Index { index, .. } => index.insert_into(path),
         }
     }

--- a/crates/engine/src/response/value.rs
+++ b/crates/engine/src/response/value.rs
@@ -157,3 +157,10 @@ fn check_response_value_size() {
     assert_eq!(std::mem::size_of::<ResponseValue>(), 24);
     assert_eq!(std::mem::align_of::<ResponseValue>(), 8);
 }
+
+#[cfg(test)]
+#[test]
+fn check_response_object_field_size() {
+    assert_eq!(std::mem::size_of::<ResponseObjectField>(), 32);
+    assert_eq!(std::mem::align_of::<ResponseObjectField>(), 8);
+}

--- a/crates/engine/src/response/write/deserialize/object/derive.rs
+++ b/crates/engine/src/response/write/deserialize/object/derive.rs
@@ -22,11 +22,11 @@ pub(super) struct DeriveContext<'ctx, 'parent, 'seed> {
 impl DeriveContext<'_, '_, '_> {
     pub fn ingest(mut self, parent_object_id: ResponseObjectId, response_fields: &mut Vec<ResponseObjectField>) {
         let key = self.field.key();
-        self.local_path.push(ResponseValueId::Field {
-            object_id: parent_object_id,
+        self.local_path.push(ResponseValueId::field(
+            parent_object_id,
             key,
-            nullable: self.field.wrapping.is_nullable(),
-        });
+            self.field.wrapping.is_nullable(),
+        ));
         let value = if let Some(batch_field) = self.shape.batch_field_shape {
             let value = response_fields
                 .iter()

--- a/crates/engine/src/response/write/deserialize/object/fields.rs
+++ b/crates/engine/src/response/write/deserialize/object/fields.rs
@@ -401,11 +401,11 @@ impl<'ctx> ConcreteShapeFieldsSeed<'ctx, '_, '_> {
         }
         .with_query_position_if(included);
 
-        self.state.local_path_mut().push(ResponseValueId::Field {
-            object_id: self.object_id,
+        self.state.local_path_mut().push(ResponseValueId::field(
+            self.object_id,
             key,
-            nullable: field.wrapping.is_nullable(),
-        });
+            field.wrapping.is_nullable(),
+        ));
         let result = map.next_value_seed(FieldSeed {
             state: self.state,
             field,

--- a/crates/engine/src/response/write/deserialize/root/fields_guest_batch.rs
+++ b/crates/engine/src/response/write/deserialize/root/fields_guest_batch.rs
@@ -205,11 +205,11 @@ where
 
         while let Some((parent_object, response_fields)) = parent_objects.next() {
             state.reset(parent_object.path.as_slice());
-            state.local_path_mut().push(ResponseValueId::Field {
-                object_id: parent_object.id,
+            state.local_path_mut().push(ResponseValueId::field(
+                parent_object.id,
                 key,
-                nullable: field.wrapping.is_nullable(),
-            });
+                field.wrapping.is_nullable(),
+            ));
             let value = seq.next_element_seed(FieldSeed {
                 state,
                 field,

--- a/crates/engine/src/response/write/deserialize/root/fields_host_batch.rs
+++ b/crates/engine/src/response/write/deserialize/root/fields_host_batch.rs
@@ -78,11 +78,11 @@ impl<'ctx, 'parent> SeedState<'ctx, 'parent> {
         let key = field.key();
 
         self.reset(parent_object.path.as_slice());
-        self.local_path_mut().push(ResponseValueId::Field {
-            object_id: parent_object.id,
+        self.local_path_mut().push(ResponseValueId::field(
+            parent_object.id,
             key,
-            nullable: field.wrapping.is_nullable(),
-        });
+            field.wrapping.is_nullable(),
+        ));
         let seed = FieldSeed {
             state: self,
             field: field.as_ref(),
@@ -196,11 +196,11 @@ impl<'ctx, 'parent> SeedState<'ctx, 'parent> {
                 wrapping: field.wrapping.to_mutable(),
             };
             let key = field.key();
-            self.local_path_mut().push(ResponseValueId::Field {
-                object_id: parent_object.id,
+            self.local_path_mut().push(ResponseValueId::field(
+                parent_object.id,
                 key,
-                nullable: field.wrapping.is_nullable(),
-            });
+                field.wrapping.is_nullable(),
+            ));
             match result {
                 Ok(data) => {
                     let result = match &data {

--- a/crates/engine/src/response/write/deserialize/state.rs
+++ b/crates/engine/src/response/write/deserialize/state.rs
@@ -132,8 +132,8 @@ fn write_path(
     let mut values = values.into_iter();
     if let Some(first) = values.next() {
         match first {
-            ResponseValueId::Field { key, .. } => {
-                f.write_str(&keys[key])?;
+            ResponseValueId::Field { response_key, .. } => {
+                f.write_str(&keys[response_key])?;
             }
             ResponseValueId::Index { index, .. } => {
                 index.fmt(f)?;
@@ -142,8 +142,8 @@ fn write_path(
         for value in values {
             f.write_str(".")?;
             match value {
-                ResponseValueId::Field { key, .. } => {
-                    f.write_str(&keys[key])?;
+                ResponseValueId::Field { response_key, .. } => {
+                    f.write_str(&keys[response_key])?;
                 }
                 ResponseValueId::Index { index, .. } => {
                     index.fmt(f)?;


### PR DESCRIPTION
We the track the position of every field within the query as a `QueryPosition`. Later it becomes a `Option<QueryPosition>` as fields we add for requirements don't have any.

We use it to return fields in the right order in the response as that's part of the GraphQL spec. The problem is that we need to create those while we're exploding fragments which can result in a huge number of fields, beyond what `u16` supports. De-duplication can only happen after as we might need to plan things differently.

As I've changed this, we increased the size of both `ResposneValueId`, used in the response object path and `FieldShapeRecord`. I could fix the first. But the second requires really complex logic. Unfortunately, it's a really sensible struct for the shape generation so it slowed us down in the worst benchmark case, so we lost 5-7% there. I've improved a bit the shape generation to handle ids rather than walkers which led to a sped up of 5% or so compared to `main`.