### PR TITLE
graphql-composition: composite schemas PROVIDES_DIRECTIVE_IN_FIELDS_ARG

### DIFF
--- a/crates/graphql-composition/src/compose/directives.rs
+++ b/crates/graphql-composition/src/compose/directives.rs
@@ -49,11 +49,11 @@ pub(super) fn collect_composed_directives<'a>(
     }
 
     for site in sites.clone() {
-        tags.extend(site.tags().map(|t| t.id));
+        tags.extend(site.id.tags(ctx.subgraphs));
 
         // The directive is added whenever it's applied in any subgraph.
-        is_inaccessible = is_inaccessible || site.inaccessible();
-        authenticated = authenticated || site.authenticated();
+        is_inaccessible = is_inaccessible || site.id.inaccessible(ctx.subgraphs);
+        authenticated = authenticated || site.id.authenticated(ctx.subgraphs);
 
         cost = cost.or(site.cost());
         list_size = list_size.or(site.list_size());

--- a/crates/graphql-composition/src/diagnostics.rs
+++ b/crates/graphql-composition/src/diagnostics.rs
@@ -193,6 +193,8 @@ pub enum CompositeSchemasSourceSchemaValidationErrorCode {
     LookupReturnsNonNullableType,
     /// https://graphql.github.io/composite-schemas-spec/draft/#sec-Override-from-Self
     OverrideFromSelf,
+    /// https://graphql.github.io/composite-schemas-spec/draft/#sec-Provides-Directive-in-Fields-Argument
+    ProvidesDirectiveInFieldsArgument,
 }
 
 impl CompositeSchemasSourceSchemaValidationErrorCode {
@@ -200,7 +202,7 @@ impl CompositeSchemasSourceSchemaValidationErrorCode {
         use CompositeSchemasSourceSchemaValidationErrorCode::*;
 
         match self {
-            QueryRootTypeInaccessible | OverrideFromSelf => Severity::Error,
+            QueryRootTypeInaccessible | OverrideFromSelf | ProvidesDirectiveInFieldsArgument => Severity::Error,
 
             LookupReturnsNonNullableType => Severity::Warning,
         }

--- a/crates/graphql-composition/src/emit_federated_graph.rs
+++ b/crates/graphql-composition/src/emit_federated_graph.rs
@@ -296,6 +296,7 @@ fn attach_selection(
                     field,
                     arguments,
                     subselection,
+                    has_directives: _,
                 }) => {
                     if &ctx[*field] == "__typename" {
                         federated::Selection::Typename
@@ -330,7 +331,11 @@ fn attach_selection(
                         })
                     }
                 }
-                subgraphs::Selection::InlineFragment { on, subselection } => {
+                subgraphs::Selection::InlineFragment {
+                    on,
+                    subselection,
+                    has_directives: _,
+                } => {
                     let on = ctx.insert_string(ctx.subgraphs.walk(*on));
                     let on = ctx.definitions[&on];
 

--- a/crates/graphql-composition/src/ingest_subgraph/nested_key_fields.rs
+++ b/crates/graphql-composition/src/ingest_subgraph/nested_key_fields.rs
@@ -35,6 +35,7 @@ fn ingest_nested_key_fields_rec(
         field,
         arguments: _,
         subselection,
+        has_directives: _,
     }) = selection
     else {
         return;

--- a/crates/graphql-composition/src/subgraphs/keys.rs
+++ b/crates/graphql-composition/src/subgraphs/keys.rs
@@ -78,6 +78,7 @@ impl Subgraphs {
                             field,
                             arguments,
                             subselection,
+                            has_directives: item.directives().next().is_some(),
                         }))
                     }
                     ast::Selection::InlineFragment(fragment) => {
@@ -89,6 +90,7 @@ impl Subgraphs {
                         Ok(Selection::InlineFragment {
                             on: subgraphs.strings.intern(on),
                             subselection,
+                            has_directives: fragment.directives().next().is_some(),
                         })
                     }
                     _ => Err("fragment spreads are not allowed.".to_owned()),
@@ -165,7 +167,11 @@ pub(crate) struct Key {
 #[derive(PartialEq, PartialOrd, Debug)]
 pub(crate) enum Selection {
     Field(FieldSelection),
-    InlineFragment { on: StringId, subselection: Vec<Selection> },
+    InlineFragment {
+        on: StringId,
+        subselection: Vec<Selection>,
+        has_directives: bool,
+    },
 }
 
 #[derive(PartialEq, PartialOrd, Debug)]
@@ -173,6 +179,7 @@ pub(crate) struct FieldSelection {
     pub(crate) field: StringId,
     pub(crate) arguments: Vec<(StringId, Value)>,
     pub(crate) subselection: Vec<Selection>,
+    pub(crate) has_directives: bool,
 }
 
 pub(crate) type KeyWalker<'a> = Walker<'a, KeyId>;

--- a/crates/graphql-composition/tests/composition/composite_schemas/source_schema_validations/provides_directive_in_fields_argument/api.graphql.snap
+++ b/crates/graphql-composition/tests/composition/composite_schemas/source_schema_validations/provides_directive_in_fields_argument/api.graphql.snap
@@ -1,0 +1,6 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: "https://graphql.github.io/composite-schemas-spec/draft/#sec-Provides-Directive-in-Fields-Argument"
+input_file: crates/graphql-composition/tests/composition/composite_schemas/source_schema_validations/provides_directive_in_fields_argument/test.md
+---
+

--- a/crates/graphql-composition/tests/composition/composite_schemas/source_schema_validations/provides_directive_in_fields_argument/diagnostics.snap
+++ b/crates/graphql-composition/tests/composition/composite_schemas/source_schema_validations/provides_directive_in_fields_argument/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: "https://graphql.github.io/composite-schemas-spec/draft/#sec-Provides-Directive-in-Fields-Argument"
+input_file: crates/graphql-composition/tests/composition/composite_schemas/source_schema_validations/provides_directive_in_fields_argument/test.md
+---
+- ❌ { SourceSchema(ProvidesDirectiveInFieldsArgument) } [test] Error at User.address: no directives are allowed in the selection sets in `@provides(fields:)`.

--- a/crates/graphql-composition/tests/composition/composite_schemas/source_schema_validations/provides_directive_in_fields_argument/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/composite_schemas/source_schema_validations/provides_directive_in_fields_argument/federated.graphql.snap
@@ -1,0 +1,6 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: "https://graphql.github.io/composite-schemas-spec/draft/#sec-Provides-Directive-in-Fields-Argument"
+input_file: crates/graphql-composition/tests/composition/composite_schemas/source_schema_validations/provides_directive_in_fields_argument/test.md
+---
+

--- a/crates/graphql-composition/tests/composition/composite_schemas/source_schema_validations/provides_directive_in_fields_argument/subgraphs/test.graphql
+++ b/crates/graphql-composition/tests/composition/composite_schemas/source_schema_validations/provides_directive_in_fields_argument/subgraphs/test.graphql
@@ -1,0 +1,16 @@
+extend schema @link(url: "https://specs.grafbase.com/composite-schemas/v1", import: ["@lookup"])
+
+type Query {
+  me: User
+}
+
+type User {
+  id: ID!
+  address: Address! @provides(fields: "name @test country")
+}
+
+type Address @key(fields: "id") {
+  id: ID!
+  name: String! @external
+  country: String! @external
+}

--- a/crates/graphql-composition/tests/composition/composite_schemas/source_schema_validations/provides_directive_in_fields_argument/test.md
+++ b/crates/graphql-composition/tests/composition/composite_schemas/source_schema_validations/provides_directive_in_fields_argument/test.md
@@ -1,0 +1,1 @@
+https://graphql.github.io/composite-schemas-spec/draft/#sec-Provides-Directive-in-Fields-Argument


### PR DESCRIPTION
It's a validation.

https://graphql.github.io/composite-schemas-spec/draft/#sec-Provides-Directive-in-Fields-Argument