### PR TITLE
graphql-composition: release 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3323,7 +3323,7 @@ dependencies = [
  "grafbase-telemetry",
  "grafbase-workspace-hack",
  "graph-ref",
- "graphql-composition 0.10.0",
+ "graphql-composition 0.11.0",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -3364,7 +3364,7 @@ version = "0.0.0"
 dependencies = [
  "cynic-parser",
  "grafbase-workspace-hack",
- "graphql-composition 0.10.0",
+ "graphql-composition 0.11.0",
  "integration-tests",
  "libtest-mimic",
  "reqwest 0.12.22",
@@ -3898,7 +3898,7 @@ dependencies = [
  "grafbase-telemetry",
  "grafbase-workspace-hack",
  "graph-ref",
- "graphql-composition 0.10.0",
+ "graphql-composition 0.11.0",
  "graphql-lint",
  "graphql-mocks",
  "graphql-schema-validation",
@@ -3985,7 +3985,7 @@ dependencies = [
  "grafbase-telemetry",
  "grafbase-workspace-hack",
  "graph-ref",
- "graphql-composition 0.10.0",
+ "graphql-composition 0.11.0",
  "graphql-mocks",
  "handlebars 6.3.2",
  "http 1.3.1",
@@ -4092,7 +4092,7 @@ dependencies = [
  "fxhash",
  "grafbase-sdk-derive",
  "grafbase-sdk-mock",
- "graphql-composition 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "graphql-composition 0.10.0",
  "graphql-ws-client",
  "hashbrown 0.15.4",
  "http 1.3.1",
@@ -4348,6 +4348,24 @@ dependencies = [
 [[package]]
 name = "graphql-composition"
 version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628239fc5052b42ee1306fe83e0c95235a08f737029495f730dfa4b01927cabb"
+dependencies = [
+ "bitflags 2.9.1",
+ "cynic-parser",
+ "cynic-parser-deser",
+ "fixedbitset",
+ "graphql-wrapping-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 2.10.0",
+ "itertools 0.14.0",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "graphql-composition"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "bitflags 2.9.1",
@@ -4365,24 +4383,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "toml 0.9.2",
- "url",
-]
-
-[[package]]
-name = "graphql-composition"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628239fc5052b42ee1306fe83e0c95235a08f737029495f730dfa4b01927cabb"
-dependencies = [
- "bitflags 2.9.1",
- "cynic-parser",
- "cynic-parser-deser",
- "fixedbitset",
- "graphql-wrapping-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 2.10.0",
- "itertools 0.14.0",
- "serde",
- "serde_json",
  "url",
 ]
 
@@ -5414,7 +5414,7 @@ dependencies = [
  "gateway-config",
  "grafbase-telemetry",
  "grafbase-workspace-hack",
- "graphql-composition 0.10.0",
+ "graphql-composition 0.11.0",
  "graphql-mocks",
  "graphql-ws-client",
  "headers",

--- a/crates/graphql-composition/CHANGELOG.md
+++ b/crates/graphql-composition/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.11.0 - 2025-08-27
+
 ### Improvements
 
 - Significant performance improvements. We saw a 66% improvement on a very large federated graph, from various optimizations, including iterating over flat data structures instead of BTrees.

--- a/crates/graphql-composition/Cargo.toml
+++ b/crates/graphql-composition/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graphql-composition"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 license = "MPL-2.0"
 description = "An implementation of GraphQL federated schema composition"

--- a/crates/graphql-composition/src/compose.rs
+++ b/crates/graphql-composition/src/compose.rs
@@ -58,7 +58,9 @@ fn merge_object_definitions<'a>(
     first: &DefinitionWalker<'a>,
     definitions: &[DefinitionWalker<'a>],
 ) {
-    let is_shareable = definitions.iter().any(|definition| definition.directives().shareable());
+    let is_shareable = definitions
+        .iter()
+        .any(|definition| definition.view().directives.shareable(ctx.subgraphs));
 
     if let Some(incompatible) = definitions
         .iter()
@@ -77,8 +79,11 @@ fn merge_object_definitions<'a>(
 
     let is_entity = validate_consistent_entityness(ctx, definitions);
 
-    let description = definitions.iter().find_map(|def| def.description());
-    let mut directives = collect_composed_directives(definitions.iter().map(|def| def.directives()), ctx);
+    let description = definitions
+        .iter()
+        .find_map(|def| def.view().description)
+        .map(|desc| ctx.subgraphs[desc].as_ref());
+    let mut directives = collect_composed_directives(definitions.iter().map(|def| def.view().directives), ctx);
 
     if is_entity {
         directives.extend(definitions.iter().flat_map(|def| def.entity_keys()).map(|key| {
@@ -158,8 +163,11 @@ fn merge_union_definitions(
 ) {
     let union_name = ctx.insert_string(first_union.name().id);
 
-    let description = definitions.iter().find_map(|def| def.description());
-    let mut directives = collect_composed_directives(definitions.iter().map(|def| def.directives()), ctx);
+    let description = definitions
+        .iter()
+        .find_map(|def| def.view().description)
+        .map(|desc| ctx.subgraphs[desc].as_ref());
+    let mut directives = collect_composed_directives(definitions.iter().map(|def| def.view().directives), ctx);
 
     for member in definitions
         .iter()

--- a/crates/graphql-composition/src/compose/context.rs
+++ b/crates/graphql-composition/src/compose/context.rs
@@ -1,8 +1,7 @@
 use crate::{
     Diagnostics, VecExt,
     composition_ir::{self as ir, CompositionIr},
-    federated_graph as federated,
-    subgraphs::{self, StringWalker},
+    federated_graph as federated, subgraphs,
 };
 use std::collections::HashMap;
 
@@ -182,10 +181,10 @@ impl<'a> Context<'a> {
     pub(crate) fn insert_object(
         &mut self,
         name: federated::StringId,
-        description: Option<StringWalker<'_>>,
+        description: Option<&str>,
         directives: Vec<ir::Directive>,
     ) -> federated::ObjectId {
-        let description = description.map(|description| self.ir.strings.insert(description.as_str()));
+        let description = description.map(|description| self.ir.strings.insert(description));
 
         let object = federated::Object {
             name,
@@ -230,9 +229,9 @@ impl<'a> Context<'a> {
         &mut self,
         name: federated::StringId,
         directives: Vec<ir::Directive>,
-        description: Option<StringWalker<'_>>,
+        description: Option<&str>,
     ) -> federated::UnionId {
-        let description = description.map(|description| self.ir.strings.insert(description.as_str()));
+        let description = description.map(|description| self.ir.strings.insert(description));
 
         let union = ir::UnionIr {
             federated: federated::Union {

--- a/crates/graphql-composition/src/compose/entity_interface.rs
+++ b/crates/graphql-composition/src/compose/entity_interface.rs
@@ -84,7 +84,7 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
                 ));
             }
 
-            if interface.directives().interface_object() {
+            if interface.view().directives.interface_object(ctx.subgraphs) {
                 ctx.diagnostics.push_fatal(format!(
                     "[{}] The @interfaceObject directive is not valid on interfaces (on `{}`).",
                     interface.subgraph().name().as_str(),
@@ -94,9 +94,9 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
         }
     }
 
-    let description = interface_def.description().map(|d| d.as_str());
+    let description = interface_def.view().description.map(|d| ctx.subgraphs[d].as_ref());
     let interface_name = ctx.insert_string(interface_name.id);
-    let directives = collect_composed_directives(definitions.iter().map(|def| def.directives()), ctx);
+    let directives = collect_composed_directives(definitions.iter().map(|def| def.view().directives), ctx);
     let interface_id = ctx.insert_interface(interface_name, description, directives);
 
     let Some(expected_key) = interface_def.entity_keys().next() else {
@@ -112,7 +112,7 @@ pub(crate) fn merge_entity_interface_definitions<'a>(
 
     // Each object in other subgraphs has to have @interfaceObject and the same key as the entity interface.
     for definition in definitions.iter().filter(|def| def.kind() == DefinitionKind::Object) {
-        if !definition.directives().interface_object() {
+        if !definition.view().directives.interface_object(ctx.subgraphs) {
             ctx.diagnostics.push_fatal(format!(
                 "`{}` is an entity interface but the object type `{}` is missing the @interfaceObject directive in the `{}` subgraph.",
                 definition.name().as_str(),

--- a/crates/graphql-composition/src/compose/fields.rs
+++ b/crates/graphql-composition/src/compose/fields.rs
@@ -54,7 +54,7 @@ fn compose_field_types<'a>(
 ) -> Option<subgraphs::FieldType> {
     let mut fields = fields.map(|field| {
         let is_guest_batched = field.arguments().any(|arg| {
-            arg.directives().iter_ir_directives().any(|dir| {
+            arg.id.1.directives.iter_ir_directives(ctx.subgraphs).any(|dir| {
                 let ir::Directive::CompositeRequire { field, .. } = dir else {
                     return false;
                 };

--- a/crates/graphql-composition/src/compose/input_object.rs
+++ b/crates/graphql-composition/src/compose/input_object.rs
@@ -6,7 +6,10 @@ pub(super) fn merge_input_object_definitions(
     definitions: &[DefinitionWalker<'_>],
 ) {
     let mut fields_range: Option<federated::InputValueDefinitions> = None;
-    let description = definitions.iter().find_map(|def| def.description()).map(|d| d.as_str());
+    let description = definitions
+        .iter()
+        .find_map(|def| def.view().description)
+        .map(|d| ctx.subgraphs[d].as_ref());
 
     let input_object_name = ctx.insert_string(first.name().id);
 
@@ -51,7 +54,7 @@ pub(super) fn merge_input_object_definitions(
             continue;
         }
 
-        let directive_containers = fields.iter().map(|(_, field)| field.directives());
+        let directive_containers = fields.iter().map(|(_, field)| field.id.1.directives);
         let mut directives = collect_composed_directives(directive_containers, ctx);
 
         let description = fields
@@ -93,7 +96,7 @@ pub(super) fn merge_input_object_definitions(
         }
     }
 
-    let mut directives = collect_composed_directives(definitions.iter().map(|def| def.directives()), ctx);
+    let mut directives = collect_composed_directives(definitions.iter().map(|def| def.view().directives), ctx);
     directives.extend(create_join_type_from_definitions(definitions));
     let fields = fields_range.unwrap_or(federated::NO_INPUT_VALUE_DEFINITION);
     ctx.insert_input_object(input_object_name, description, directives, fields);

--- a/crates/graphql-composition/src/compose/scalar.rs
+++ b/crates/graphql-composition/src/compose/scalar.rs
@@ -8,9 +8,12 @@ pub(crate) fn merge_scalar_definitions<'a>(
     if first.name().as_str() == "join__FieldSet" {
         return;
     }
-    let directive_containers = definitions.iter().map(|def| def.directives());
+    let directive_containers = definitions.iter().map(|def| def.view().directives);
     let directives = collect_composed_directives(directive_containers, ctx);
-    let description = definitions.iter().find_map(|def| def.description()).map(|d| d.as_str());
+    let description = definitions
+        .iter()
+        .find_map(|def| def.view().description)
+        .map(|d| ctx.subgraphs[d].as_ref());
 
     ctx.insert_scalar(first.name().as_str(), description, directives);
 }

--- a/crates/graphql-composition/src/compose/validate.rs
+++ b/crates/graphql-composition/src/compose/validate.rs
@@ -10,7 +10,7 @@ pub(super) fn override_source_has_override(fields: &[FieldWalker<'_>], ctx: &mut
     // Early exit if we don't have at least 2 overrides
     if fields
         .iter()
-        .filter(|f| f.directives().r#override().is_some())
+        .filter(|f| f.id.1.directives.r#override(ctx.subgraphs).is_some())
         .take(2)
         .count()
         < 2
@@ -26,7 +26,7 @@ pub(super) fn override_source_has_override(fields: &[FieldWalker<'_>], ctx: &mut
     let mut overrides_by_source: BTreeMap<StringId, OverrideEntry<'_>> = BTreeMap::new();
 
     for field in fields {
-        if let Some(override_directive) = field.directives().r#override() {
+        if let Some(override_directive) = field.id.1.directives.r#override(ctx.subgraphs) {
             use std::collections::btree_map::Entry;
             match overrides_by_source.entry(override_directive.from) {
                 Entry::Vacant(e) => {
@@ -56,7 +56,7 @@ pub(super) fn override_source_has_override(fields: &[FieldWalker<'_>], ctx: &mut
             let source_has_override = fields
                 .iter()
                 .find(|f| f.parent_definition().subgraph().name().id == source)
-                .and_then(|f| f.directives().r#override())
+                .and_then(|f| f.id.1.directives.r#override(ctx.subgraphs))
                 .is_some();
 
             let message = if source_has_override {

--- a/crates/graphql-composition/src/emit_federated_graph/directive.rs
+++ b/crates/graphql-composition/src/emit_federated_graph/directive.rs
@@ -296,12 +296,16 @@ fn transform_join_field_directive(
             field.parent_definition().subgraph_id().idx(),
         )),
         requires: field
-            .directives()
-            .requires()
+            .id
+            .1
+            .directives
+            .requires(ctx.subgraphs)
             .map(|field_set| attach_selection(field_set, ctx.out[field_id].parent_entity_id.into(), ctx)),
         provides: field
-            .directives()
-            .provides()
+            .id
+            .1
+            .directives
+            .provides(ctx.subgraphs)
             .map(|field_set| attach_selection(field_set, ctx.out[field_id].r#type.definition, ctx)),
         r#type: r#type.map(|ty| ctx.insert_field_type(ctx.subgraphs.walk(ty))),
         external: *external,

--- a/crates/graphql-composition/src/subgraphs/definitions.rs
+++ b/crates/graphql-composition/src/subgraphs/definitions.rs
@@ -16,6 +16,15 @@ pub(crate) struct Definition {
     pub(crate) subgraph_id: SubgraphId,
     pub(crate) name: StringId,
     pub(crate) kind: DefinitionKind,
+    /// ```graphql,ignore
+    /// """
+    /// The root query type.
+    /// """
+    /// ^^^^^^^^^^^^^^^^^^^^
+    /// type Query {
+    ///   # ...
+    /// }
+    /// ```
     pub(crate) description: Option<StringId>,
     pub(crate) directives: DirectiveSiteId,
 }
@@ -140,29 +149,12 @@ impl<'a> DefinitionWalker<'a> {
         self.view().kind
     }
 
-    /// ```graphql,ignore
-    /// """
-    /// The root query type.
-    /// """
-    /// ^^^^^^^^^^^^^^^^^^^^
-    /// type Query {
-    ///   # ...
-    /// }
-    /// ```
-    pub fn description(self) -> Option<StringWalker<'a>> {
-        self.view().description.map(|id| self.walk(id))
-    }
-
     pub(crate) fn subgraph_id(self) -> SubgraphId {
         self.view().subgraph_id
     }
 
     pub(crate) fn subgraph(self) -> SubgraphWalker<'a> {
         self.subgraphs.walk_subgraph(self.subgraph_id())
-    }
-
-    pub(crate) fn directives(self) -> DirectiveSiteWalker<'a> {
-        self.walk(self.view().directives)
     }
 }
 

--- a/crates/graphql-composition/src/subgraphs/directives.rs
+++ b/crates/graphql-composition/src/subgraphs/directives.rs
@@ -279,7 +279,7 @@ impl DirectiveSiteId {
         subgraphs.directives.r#override.get(&self)
     }
 
-    pub(crate) fn policies<'a>(self, subgraphs: &'a Subgraphs) -> impl Iterator<Item = &'a [StringId]> {
+    pub(crate) fn policies(self, subgraphs: &Subgraphs) -> impl Iterator<Item = &[StringId]> {
         subgraphs
             .directives
             .policies
@@ -288,7 +288,7 @@ impl DirectiveSiteId {
             .map(|(_, policies)| policies.as_slice())
     }
 
-    pub(crate) fn requires_scopes<'a>(self, subgraphs: &'a Subgraphs) -> impl Iterator<Item = &'a [StringId]> {
+    pub(crate) fn requires_scopes(self, subgraphs: &Subgraphs) -> impl Iterator<Item = &[StringId]> {
         subgraphs
             .directives
             .requires_scopes

--- a/crates/graphql-composition/src/subgraphs/enums.rs
+++ b/crates/graphql-composition/src/subgraphs/enums.rs
@@ -43,9 +43,4 @@ impl<'a> EnumValueWalker<'a> {
         let (_enum_id, value_name, _directives) = self.id;
         self.walk(value_name)
     }
-
-    pub(crate) fn directives(self) -> DirectiveSiteWalker<'a> {
-        let (_enum_id, _value_name, directives) = self.id;
-        self.walk(directives)
-    }
 }

--- a/crates/graphql-composition/src/subgraphs/fields.rs
+++ b/crates/graphql-composition/src/subgraphs/fields.rs
@@ -188,11 +188,6 @@ impl<'a> FieldWalker<'a> {
         tuple.description.map(|id| self.walk(id))
     }
 
-    pub(crate) fn directives(self) -> DirectiveSiteWalker<'a> {
-        let (_, tuple) = self.id;
-        self.walk(tuple.directives)
-    }
-
     pub fn parent_definition(self) -> DefinitionWalker<'a> {
         let (FieldPath(parent_definition_id, _), _) = self.id;
         self.walk(parent_definition_id)
@@ -216,10 +211,6 @@ impl<'a> FieldWalker<'a> {
     pub(crate) fn r#type(self) -> FieldTypeWalker<'a> {
         let (_, tuple) = self.id;
         self.walk(tuple.r#type)
-    }
-
-    pub(crate) fn is_external(self) -> bool {
-        self.directives().external() || self.parent_definition().directives().external()
     }
 }
 
@@ -279,11 +270,6 @@ impl<'a> FieldArgumentWalker<'a> {
     pub(crate) fn r#type(&self) -> FieldTypeWalker<'a> {
         let (_, tuple) = self.id;
         self.walk(tuple.r#type)
-    }
-
-    pub(crate) fn directives(&self) -> DirectiveSiteWalker<'a> {
-        let (_, tuple) = self.id;
-        self.walk(tuple.directives)
     }
 
     pub(crate) fn default(&self) -> Option<&'a Value> {

--- a/crates/graphql-composition/src/validate/composite_schemas/source_schema.rs
+++ b/crates/graphql-composition/src/validate/composite_schemas/source_schema.rs
@@ -27,8 +27,10 @@ pub(crate) fn query_root_type_inaccessible(ctx: &mut ValidateContext<'_>) {
 pub(crate) fn lookup_returns_non_nullable_type(ctx: &mut ValidateContext<'_>, field: subgraphs::FieldWalker<'_>) {
     if field.r#type().is_required()
         && field
-            .directives()
-            .iter_ir_directives()
+            .id
+            .1
+            .directives
+            .iter_ir_directives(ctx.subgraphs)
             .any(|directive| matches!(directive, crate::composition_ir::Directive::CompositeLookup(_)))
     {
         let source_schema_name = field.parent_definition().subgraph().name().as_str();
@@ -48,7 +50,7 @@ pub(crate) fn lookup_returns_non_nullable_type(ctx: &mut ValidateContext<'_>, fi
 }
 
 pub(crate) fn override_from_self(ctx: &mut ValidateContext<'_>, field: subgraphs::FieldWalker<'_>) {
-    let Some(r#override) = field.directives().r#override() else {
+    let Some(r#override) = field.id.1.directives.r#override(ctx.subgraphs) else {
         return;
     };
 

--- a/crates/graphql-composition/src/validate/selection.rs
+++ b/crates/graphql-composition/src/validate/selection.rs
@@ -7,9 +7,9 @@ pub(super) fn validate_selections(ctx: &mut ValidateContext<'_>, field: subgraph
     let parent_definition = ctx.subgraphs.at(field_record.parent_definition_id);
     let subgraph_name = &ctx.subgraphs[ctx.subgraphs[parent_definition.subgraph_id].name];
 
-    let directives = field.directives();
-    for (selection, directive_name) in directives
-        .requires()
+    for (selection, directive_name) in field_record
+        .directives
+        .requires(ctx.subgraphs)
         .into_iter()
         .flatten()
         .map(|selection| (selection, "requires"))
@@ -17,8 +17,7 @@ pub(super) fn validate_selections(ctx: &mut ValidateContext<'_>, field: subgraph
         let directive_path = || {
             format!(
                 "{}.{}",
-                field.parent_definition().name().as_str(),
-                field.name().as_str()
+                ctx.subgraphs[parent_definition.name], ctx.subgraphs[field_record.name]
             )
         };
         validate_selection(
@@ -31,12 +30,11 @@ pub(super) fn validate_selections(ctx: &mut ValidateContext<'_>, field: subgraph
         );
     }
 
-    for selection in directives.provides().into_iter().flatten() {
+    for selection in field_record.directives.provides(ctx.subgraphs).into_iter().flatten() {
         let directive_path = || {
             format!(
                 "{}.{}",
-                field.parent_definition().name().as_str(),
-                field.name().as_str()
+                ctx.subgraphs[parent_definition.name], ctx.subgraphs[field_record.name]
             )
         };
 


### PR DESCRIPTION
The first commit in this PR is a refactoring. See the commit message.

### Improvements

- Significant performance improvements. We saw a 66% improvement on a very large federated graph, from various optimizations, including iterating over flat data structures instead of BTrees.
- `Diagnostic::composite_schemas_error_code` is now exposed. Note that as the spec and this implementation evolve, more error codes will be added to this enum and its variants.
- Implemented some composite schemas spec validations for the `@override` directive, resulting in more consistent logic and better diagnostics (https://github.com/grafbase/grafbase/pull/3374)
- Implemented the composite schemas spec validation rules for `@shareable`. It makes the validation more relaxed: if any subgraph defines the field as shareable, then others don't need to annotate with `@shareable` as well. It should not make any schema that composes today fail to compose. The diagnostics have also been improved to list all the relevant subgraphs.
- Better diagnostic message when you try to compose zero subgraphs.
- Unknown override labels are no longer an error.
- `@extends` no longer triggers unknown directive warnings.
- Instances of `@key(field: "...")` (instead of "fields") now triggers a warning.
- Selection set validation errors now include the subgraph name.
- We now emit the `@join__enumValue` directive on enum values in the federated SDL (https://github.com/grafbase/grafbase/pull/3456).

### Fixes

- Fixed a panic in validation for `@provides` on fields returning a built-in scalar type, like `Int`.
- Fixed `Diagnostics::iter_warnings()` iterating over warnings instead of errors.
- Interfaces both defined in federation v1 subgraphs and as entity interfaces in federation v2 subgraphs do not force the federation v1 subgraphs to define all implementers of the entity interface anymore.
- Federation v1 subgraphs are no longer taken into account when composing entity interfaces.
- Fixed handling of entities with type extensions, where in some cases `@key`s would be missed for scenarios where the same entity is extended, then defined in the same subgraph, with other definitions in between. (https://github.com/grafbase/grafbase/pull/3454)

## Breaking changes

- Many types, fields and methods that are part of the `FederatedGraph` data structure are now private. `FederatedGraph` as a whole will become private as well, since the scope of this crate is only to render the federated SDL.
- `compose()` now takes an `&mut Subgraphs` argument instead of `&Subgraphs`.

