### PR TITLE
Adding a de-duplication id in the query-solver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2963,6 +2963,7 @@ dependencies = [
  "petgraph",
  "pretty_assertions",
  "priority-queue",
+ "rapidhash",
  "serde",
  "serde_json",
  "similar",

--- a/crates/engine/codegen/domain/operation.graphql
+++ b/crates/engine/codegen/domain/operation.graphql
@@ -41,7 +41,7 @@ type DataField @meta(module: "field/data", debug: false) @indexed(id_size: "u16"
   directives: [ExecutableDirective!]!
   definition: FieldDefinition!
   "Ordered by input value definition id"
-  arguments: [FieldArgument!]!
+  sorted_arguments: [FieldArgument!]!
   selection_set: SelectionSet!
 }
 

--- a/crates/engine/id-newtypes/src/bitset.rs
+++ b/crates/engine/id-newtypes/src/bitset.rs
@@ -51,11 +51,6 @@ where
         self.inner.set_range(start..end, value);
     }
 
-    pub fn push(&mut self, value: bool) {
-        self.inner.grow(self.inner.len() + 1);
-        self.inner.set(self.inner.len() - 1, value);
-    }
-
     pub fn grow(&mut self, n: usize) {
         self.inner.grow(n)
     }

--- a/crates/engine/operation/src/bind/operation.rs
+++ b/crates/engine/operation/src/bind/operation.rs
@@ -156,7 +156,7 @@ impl<'schema, 'p> OperationBinder<'schema, 'p> {
             }
         };
 
-        let argument_ids = self.bind_field_arguments(definition, field.name_span(), field.arguments());
+        let sorted_argument_ids = self.bind_field_arguments_sorted(definition, field.name_span(), field.arguments());
         let directive_ids = self.bind_executable_directive(field.directives());
         let response_key = self.response_keys.get_or_intern(field.alias().unwrap_or(field.name()));
 
@@ -165,14 +165,14 @@ impl<'schema, 'p> OperationBinder<'schema, 'p> {
             directive_ids,
             response_key,
             location: self.parsed_operation.span_to_location(field.name_span()),
-            argument_ids,
+            sorted_argument_ids,
             selection_set_record,
         });
 
         Ok((self.data_fields.len() - 1).into())
     }
 
-    fn bind_field_arguments(
+    fn bind_field_arguments_sorted(
         &mut self,
         definition: FieldDefinition<'schema>,
         span: Span,

--- a/crates/engine/operation/src/model/generated/field/data.rs
+++ b/crates/engine/operation/src/model/generated/field/data.rs
@@ -24,7 +24,7 @@ use walker::{Iter, Walk};
 ///   directives: [ExecutableDirective!]!
 ///   definition: FieldDefinition!
 ///   "Ordered by input value definition id"
-///   arguments: [FieldArgument!]!
+///   sorted_arguments: [FieldArgument!]!
 ///   selection_set: SelectionSet!
 /// }
 /// ```
@@ -35,7 +35,7 @@ pub struct DataFieldRecord {
     pub directive_ids: Vec<ExecutableDirectiveId>,
     pub definition_id: FieldDefinitionId,
     /// Ordered by input value definition id
-    pub argument_ids: IdRange<FieldArgumentId>,
+    pub sorted_argument_ids: IdRange<FieldArgumentId>,
     pub selection_set_record: SelectionSetRecord,
 }
 
@@ -69,8 +69,8 @@ impl<'a> DataField<'a> {
         self.definition_id.walk(self.ctx)
     }
     /// Ordered by input value definition id
-    pub fn arguments(&self) -> impl Iter<Item = FieldArgument<'a>> + 'a {
-        self.as_ref().argument_ids.walk(self.ctx)
+    pub fn sorted_arguments(&self) -> impl Iter<Item = FieldArgument<'a>> + 'a {
+        self.as_ref().sorted_argument_ids.walk(self.ctx)
     }
     pub fn selection_set(&self) -> SelectionSet<'a> {
         self.as_ref().selection_set_record.walk(self.ctx)

--- a/crates/engine/operation/src/model/response_key.rs
+++ b/crates/engine/operation/src/model/response_key.rs
@@ -3,16 +3,16 @@ use std::num::NonZero;
 use walker::Walk;
 
 #[derive(Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, serde::Serialize, serde::Deserialize, id_derives::Id)]
-pub struct QueryPosition(NonZero<u32>);
+pub struct QueryPosition(NonZero<u16>);
 
 impl QueryPosition {
-    pub const MAX: QueryPosition = QueryPosition(NonZero::new(u32::MAX - 1).unwrap());
+    pub const MAX: QueryPosition = QueryPosition(NonZero::new(u16::MAX - 1).unwrap());
 
     pub fn cmp_with_none_last(a: Option<QueryPosition>, b: Option<QueryPosition>) -> std::cmp::Ordering {
         // None -> 0
         // Some(x) -> x
-        let mut a: u32 = zerocopy::transmute!(a.map(|qp| qp.0));
-        let mut b: u32 = zerocopy::transmute!(b.map(|qp| qp.0));
+        let mut a: u16 = zerocopy::transmute!(a.map(|qp| qp.0));
+        let mut b: u16 = zerocopy::transmute!(b.map(|qp| qp.0));
         // x -> x -1
         // 0 -> u32::MAX
         a = a.wrapping_sub(1);
@@ -30,9 +30,9 @@ pub struct PositionedResponseKey {
 
 impl PositionedResponseKey {
     pub fn with_query_position_if(self, included: bool) -> PositionedResponseKey {
-        let mut qp: u32 = zerocopy::transmute!(self.query_position.map(|qp| qp.0));
-        qp &= (!(included as u32)).wrapping_add(1);
-        let qp: Option<NonZero<u32>> = zerocopy::transmute!(qp);
+        let mut qp: u16 = zerocopy::transmute!(self.query_position.map(|qp| qp.0));
+        qp &= (!(included as u16)).wrapping_add(1);
+        let qp: Option<NonZero<u16>> = zerocopy::transmute!(qp);
         Self {
             query_position: qp.map(QueryPosition),
             response_key: self.response_key,
@@ -60,11 +60,27 @@ impl ResponseKey {
 /// performance by around 1% since we're doing a binary search for each
 /// incoming field name during deserialization.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
-pub struct ResponseKey(u16);
+pub struct ResponseKey(NonZero<u16>);
 
 impl From<ResponseKey> for usize {
     fn from(key: ResponseKey) -> usize {
-        key.0 as usize
+        (key.0.get() - 1) as usize
+    }
+}
+
+impl From<ResponseKey> for u32 {
+    fn from(key: ResponseKey) -> u32 {
+        (key.0.get() - 1) as u32
+    }
+}
+
+unsafe impl lasso2::Key for ResponseKey {
+    fn into_usize(self) -> usize {
+        usize::from(self)
+    }
+
+    fn try_from_usize(id: usize) -> Option<Self> {
+        u16::try_from(id + 1).ok().map(|n| Self(NonZero::new(n).unwrap()))
     }
 }
 
@@ -86,12 +102,6 @@ impl<'a> Walk<&'a ResponseKeys> for ResponseKey {
 /// Interns all of the response keys strings.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ResponseKeys(lasso2::Rodeo<ResponseKey>);
-
-impl From<ResponseKey> for u32 {
-    fn from(key: ResponseKey) -> u32 {
-        key.0 as u32
-    }
-}
 
 impl Default for ResponseKeys {
     fn default() -> Self {
@@ -127,16 +137,6 @@ impl std::ops::Index<ResponseKey> for ResponseKeys {
     fn index(&self, key: ResponseKey) -> &Self::Output {
         // SAFETY: SafeResponseKey are only created by ResponseKeys, either by `get_or_intern` or `ensure_safety`.
         unsafe { self.0.resolve_unchecked(&key) }
-    }
-}
-
-unsafe impl lasso2::Key for ResponseKey {
-    fn into_usize(self) -> usize {
-        self.0 as usize
-    }
-
-    fn try_from_usize(id: usize) -> Option<Self> {
-        u16::try_from(id).ok().map(Self)
     }
 }
 

--- a/crates/engine/operation/src/model/response_key.rs
+++ b/crates/engine/operation/src/model/response_key.rs
@@ -150,15 +150,12 @@ mod tests {
         let key = ResponseKey::try_from_usize(0).unwrap();
         assert_eq!(key.into_usize(), 0);
 
-        let key = ResponseKey::try_from_usize(u16::MAX as usize).unwrap();
-        assert_eq!(key.into_usize(), (u16::MAX as usize));
+        let key = ResponseKey::try_from_usize((u16::MAX - 1) as usize).unwrap();
+        assert_eq!(key.into_usize(), ((u16::MAX - 1) as usize));
     }
 
     #[test]
     fn field_name_value_out_of_range() {
-        let key = ResponseKey::try_from_usize(u64::MAX as usize);
-        assert!(key.is_none());
-
         let key = ResponseKey::try_from_usize(u32::MAX as usize);
         assert!(key.is_none());
     }

--- a/crates/engine/operation/src/validation/complexity.rs
+++ b/crates/engine/operation/src/validation/complexity.rs
@@ -108,7 +108,7 @@ fn field_complexity(
     let child_count = calculate_child_count(context, field, list_size_directive, preset_list_size)?;
 
     let argument_cost = field
-        .arguments()
+        .sorted_arguments()
         .map(|argument| cost_for_argument(argument, context.variables))
         .sum::<usize>();
 
@@ -226,7 +226,7 @@ fn calculate_child_count<'a>(
         let slicing_arguments = slicing_arguments
             .filter_map(|def| {
                 let value = field
-                    .arguments()
+                    .sorted_arguments()
                     .find(|arg| arg.definition().id == def.id)?
                     .value(context.variables);
                 Option::<usize>::deserialize(value).ok().flatten()

--- a/crates/engine/query-solver/Cargo.toml
+++ b/crates/engine/query-solver/Cargo.toml
@@ -24,6 +24,7 @@ itertools.workspace = true
 operation = { path = "../operation", package = "engine-operation" }
 petgraph.workspace = true
 priority-queue.workspace = true
+rapidhash.workspace = true
 schema = { path = "../schema", package = "engine-schema" }
 serde.workspace = true
 strum.workspace = true

--- a/crates/engine/query-solver/src/lib.rs
+++ b/crates/engine/query-solver/src/lib.rs
@@ -19,7 +19,7 @@ pub use query::*;
 use schema::Schema;
 pub(crate) use solution_space::*;
 
-pub fn solve(schema: &Schema, operation: &mut Operation) -> Result<SolvedQuery> {
+pub fn solve(schema: &Schema, operation: &mut Operation) -> Result<QuerySolution> {
     let query_solution_space = Query::generate_solution_space(schema, operation)?;
     let solution = solve::Solver::initialize(schema, operation, query_solution_space)?.solve()?;
     let crude_solved_query = solution.into_query(schema, operation)?;

--- a/crates/engine/query-solver/src/post_process/mutation_order.rs
+++ b/crates/engine/query-solver/src/post_process/mutation_order.rs
@@ -7,10 +7,10 @@ use schema::ResolverDefinitionId;
 
 use crate::{
     query::{Edge, Node},
-    solve::CrudeSolvedQuery,
+    solve::QuerySteinerSolution,
 };
 
-pub(super) fn ensure_mutation_execution_order(query: &mut CrudeSolvedQuery) -> Vec<NodeIndex> {
+pub(super) fn ensure_mutation_execution_order(query: &mut QuerySteinerSolution) -> Vec<NodeIndex> {
     struct Field {
         position: Option<QueryPosition>,
         original_partition_node_ix: NodeIndex,
@@ -25,9 +25,9 @@ pub(super) fn ensure_mutation_execution_order(query: &mut CrudeSolvedQuery) -> V
         } = query.graph[partition_node_ix]
         {
             for field_node_ix in query.graph.neighbors(partition_node_ix) {
-                if let Node::Field { id, .. } = query.graph[field_node_ix] {
+                if let Node::Field(node) = query.graph[field_node_ix] {
                     selection_set.push(Field {
-                        position: query[id].query_position,
+                        position: query[node.id].query_position,
                         original_partition_node_ix: partition_node_ix,
                         resolver_definition_id,
                         field_node_ix,

--- a/crates/engine/query-solver/src/post_process/partition_cycles.rs
+++ b/crates/engine/query-solver/src/post_process/partition_cycles.rs
@@ -6,10 +6,13 @@ use schema::ResolverDefinitionId;
 
 use crate::{
     query::{Edge, Node},
-    solve::CrudeSolvedQuery,
+    solve::QuerySteinerSolution,
 };
 
-pub(super) fn split_query_partition_dependency_cycles(query: &mut CrudeSolvedQuery, starting_nodes: Vec<NodeIndex>) {
+pub(super) fn split_query_partition_dependency_cycles(
+    query: &mut QuerySteinerSolution,
+    starting_nodes: Vec<NodeIndex>,
+) {
     struct Field {
         position: Option<QueryPosition>,
         original_partition_node_ix: NodeIndex,
@@ -39,9 +42,9 @@ pub(super) fn split_query_partition_dependency_cycles(query: &mut CrudeSolvedQue
                             continue;
                         }
                         let second_degree_node_ix = second_degree_edge.target();
-                        if let Node::Field { id, .. } = query.graph[second_degree_node_ix] {
+                        if let Node::Field(node) = query.graph[second_degree_node_ix] {
                             nested_patitions_fields.push(Field {
-                                position: query[id].query_position,
+                                position: query[node.id].query_position,
                                 original_partition_node_ix: node_ix,
                                 resolver_definition_id,
                                 query_field_node_ix: second_degree_node_ix,

--- a/crates/engine/query-solver/src/query/deduplication.rs
+++ b/crates/engine/query-solver/src/query/deduplication.rs
@@ -1,0 +1,138 @@
+use hashbrown::{HashTable, hash_table::Entry};
+use operation::OperationContext;
+use petgraph::visit::GraphBase;
+use rapidhash::fast::SeedableState;
+use schema::ResolverDefinitionId;
+use std::hash::{BuildHasher as _, Hash, Hasher};
+use walker::Walk as _;
+
+use crate::{
+    DeduplicationId, Query, QueryField, QueryFieldId, QueryOrSchemaSortedFieldArgumentIds, are_arguments_equivalent,
+};
+
+pub(crate) struct DeduplicationMap {
+    table: HashTable<DeduplicatedEntry>,
+    hash_seed: SeedableState<'static>,
+}
+
+struct DeduplicatedEntry {
+    hash: u64,
+    id: DeduplicationId,
+    record: Record,
+}
+
+#[derive(strum::EnumDiscriminants, Clone, Copy)]
+#[strum_discriminants(derive(Hash))]
+enum Record {
+    Field(QueryFieldId),
+    Resolver(schema::ResolverDefinitionId),
+}
+
+impl<G: GraphBase> Query<G, crate::steps::SolutionSpace> {
+    pub fn get_or_insert_field_deduplication_id(
+        &mut self,
+        ctx: OperationContext<'_>,
+        id: QueryFieldId,
+    ) -> DeduplicationId {
+        self.step.deduplication_map.get_or_insert_field(ctx, &self.fields, id)
+    }
+}
+
+impl DeduplicationMap {
+    pub fn with_capacity(size: usize) -> Self {
+        Self {
+            table: HashTable::with_capacity(size),
+            hash_seed: Default::default(),
+        }
+    }
+
+    pub fn get_or_insert_resolver(&mut self, id: ResolverDefinitionId) -> DeduplicationId {
+        let hash = {
+            let mut hasher = self.hash_seed.build_hasher();
+            RecordDiscriminants::Resolver.hash(&mut hasher);
+            id.hash(&mut hasher);
+            hasher.finish()
+        };
+
+        let n = self.table.len();
+        match self.table.entry(
+            hash,
+            |entry| match entry.record {
+                Record::Resolver(existing) => existing == id,
+                _ => false,
+            },
+            |entry| entry.hash,
+        ) {
+            Entry::Occupied(entry) => entry.get().id,
+            Entry::Vacant(entry) => {
+                let dedup_id = DeduplicationId::from(u16::try_from(n).expect("Too many entrys to deduplicate."));
+                entry.insert(DeduplicatedEntry {
+                    hash,
+                    id: dedup_id,
+                    record: Record::Resolver(id),
+                });
+                dedup_id
+            }
+        }
+    }
+
+    pub fn get_or_insert_field<'op>(
+        &mut self,
+        ctx: OperationContext<'op>,
+        fields: &[QueryField],
+        id: QueryFieldId,
+    ) -> DeduplicationId {
+        // Maybe we should avoid keeping this data in the table and have an id instead?
+        let field = &fields[usize::from(id)];
+        let hash = {
+            let mut hasher = self.hash_seed.build_hasher();
+            RecordDiscriminants::Field.hash(&mut hasher);
+            field.type_conditions.hash(&mut hasher);
+            field.flat_directive_id.hash(&mut hasher);
+            field.response_key.hash(&mut hasher);
+            field.definition_id.hash(&mut hasher);
+            field.sorted_argument_ids.len().hash(&mut hasher);
+            match field.sorted_argument_ids {
+                QueryOrSchemaSortedFieldArgumentIds::Query(ids) => {
+                    for arg in ids.walk(ctx) {
+                        arg.definition_id.hash(&mut hasher);
+                    }
+                }
+                QueryOrSchemaSortedFieldArgumentIds::Schema(ids) => {
+                    for arg in ids.walk(ctx) {
+                        arg.definition_id.hash(&mut hasher);
+                    }
+                }
+            }
+            hasher.finish()
+        };
+
+        let n = self.table.len();
+        match self.table.entry(
+            hash,
+            |entry| match entry.record {
+                Record::Field(id) => {
+                    let existing = &fields[usize::from(id)];
+                    ((existing.type_conditions == field.type_conditions)
+                        & (existing.response_key == field.response_key)
+                        & (existing.definition_id == field.definition_id)
+                        & (existing.flat_directive_id == field.flat_directive_id))
+                        && are_arguments_equivalent(ctx, existing.sorted_argument_ids, field.sorted_argument_ids)
+                }
+                _ => false,
+            },
+            |entry| entry.hash,
+        ) {
+            Entry::Occupied(entry) => entry.get().id,
+            Entry::Vacant(entry) => {
+                let dedup_id = DeduplicationId::from(u16::try_from(n).expect("Too many entrys to deduplicate."));
+                entry.insert(DeduplicatedEntry {
+                    hash,
+                    id: dedup_id,
+                    record: Record::Field(id),
+                });
+                dedup_id
+            }
+        }
+    }
+}

--- a/crates/engine/query-solver/src/solution_space/builder/operation_fields.rs
+++ b/crates/engine/query-solver/src/solution_space/builder/operation_fields.rs
@@ -20,6 +20,7 @@ use super::{SpaceEdge, SpaceNode, builder::QuerySolutionSpaceBuilder, providable
 struct IngestSelectionSet<'op> {
     parent_query_field_node_ix: NodeIndex,
     parent_output_type: CompositeTypeId,
+    depth: usize,
     selection_set: operation::SelectionSet<'op>,
 }
 
@@ -35,6 +36,7 @@ where
         let queue = vec![IngestSelectionSet {
             parent_query_field_node_ix: self.query.root_node_id,
             parent_output_type: CompositeTypeId::Object(self.operation.root_object_id),
+            depth: 0,
             selection_set: OperationContext {
                 schema: self.schema,
                 operation: self.operation,
@@ -47,6 +49,7 @@ where
             builder: self,
             queue,
             next_query_position: 0,
+            current_depth: 0,
             parent_type_conditions: Vec::new(),
             parent_directive_ids: Vec::new(),
             response_key_bloom_filter: 0,
@@ -62,7 +65,8 @@ struct OperationFieldsIngestor<'schema, 'op, 'builder> {
     builder: &'builder mut QuerySolutionSpaceBuilder<'schema, 'op>,
     // Needs to be a queue to have the right query_position for fields.
     queue: VecDeque<IngestSelectionSet<'op>>,
-    next_query_position: u32,
+    next_query_position: u16,
+    current_depth: usize,
     // Temporary structures for DFS
     parent_type_conditions: Vec<CompositeTypeId>,
     parent_directive_ids: Vec<ExecutableDirectiveId>,
@@ -79,11 +83,20 @@ where
             HashMap::with_capacity_and_hasher(self.builder.operation.data_fields.len() >> 2, Default::default());
         // We traverse in BFS to optimize our use of the QueryPosition which is a u16.
         while let Some(IngestSelectionSet {
+            depth,
             parent_query_field_node_ix,
             parent_output_type,
             selection_set,
         }) = self.queue.pop_front()
         {
+            debug_assert!(
+                self.current_depth <= depth,
+                "We should be iterating in BFS order, depth can only increase."
+            );
+            if self.current_depth < depth {
+                self.next_query_position = 0;
+                self.current_depth = depth;
+            }
             self.parent_type_conditions.clear();
             self.parent_directive_ids.clear();
             let bloom_filter = selection_set_to_response_key_bloom_filter
@@ -99,7 +112,10 @@ where
 
     fn next_query_position(&mut self) -> QueryPosition {
         let p = self.next_query_position;
-        self.next_query_position += 1;
+        // It doesn't really matter whether we wrap around. We're iterating on selection sets in
+        // BFS order and we reset whenever we go lower. So we there would need to be u16::MAX
+        // fields at a single level for us to provide inaccurate ordering.
+        self.next_query_position = self.next_query_position.wrapping_add(1);
         p.into()
     }
 
@@ -385,6 +401,7 @@ where
 
         if let Some(ty) = output_ty.and_then(|ty| ty.definition_id.as_composite_type()) {
             self.queue.push_back(IngestSelectionSet {
+                depth: self.current_depth + 1,
                 parent_query_field_node_ix: query_field_node_ix,
                 parent_output_type: ty,
                 selection_set: field.selection_set(),

--- a/crates/engine/query-solver/src/solution_space/builder/prune.rs
+++ b/crates/engine/query-solver/src/solution_space/builder/prune.rs
@@ -14,7 +14,7 @@ impl QuerySolutionSpaceBuilder<'_, '_> {
         let mut extra_leafs = Vec::new();
 
         for (node_ix, node) in self.query.graph.node_references() {
-            let SpaceNode::QueryField(node) = node else {
+            let SpaceNode::Field(node) = node else {
                 continue;
             };
             // Any resolver that can eventually provide a scalar/__typename must be kept
@@ -25,7 +25,7 @@ impl QuerySolutionSpaceBuilder<'_, '_> {
                     .edges_directed(node_ix, Direction::Incoming)
                     .find(|edge| {
                         matches!(edge.weight(), SpaceEdge::TypenameField)
-                            && matches!(self.query.graph[edge.source()], SpaceNode::QueryField(_))
+                            && matches!(self.query.graph[edge.source()], SpaceNode::Field(_))
                     })
                 else {
                     continue;
@@ -49,7 +49,7 @@ impl QuerySolutionSpaceBuilder<'_, '_> {
         }
 
         for leaf_node_ix in extra_leafs {
-            let SpaceNode::QueryField(field) = &mut self.query.graph[leaf_node_ix] else {
+            let SpaceNode::Field(field) = &mut self.query.graph[leaf_node_ix] else {
                 continue;
             };
             // If dispensable, how could it have a __typename?
@@ -76,7 +76,7 @@ impl QuerySolutionSpaceBuilder<'_, '_> {
         }
 
         self.query.graph.retain_nodes(|graph, ix| match graph[ix] {
-            SpaceNode::Root | SpaceNode::QueryField(_) => true,
+            SpaceNode::Root | SpaceNode::Field(_) => true,
             SpaceNode::Resolver(_) | SpaceNode::ProvidableField(_) => visited[ix.index()],
         });
     }

--- a/crates/engine/query-solver/src/solution_space/mod.rs
+++ b/crates/engine/query-solver/src/solution_space/mod.rs
@@ -17,12 +17,10 @@ use petgraph::{
 
 use crate::Query;
 
-pub(crate) struct SolutionSpace {}
-
 pub(crate) type SolutionSpaceGraph<'schema> = StableGraph<SpaceNode<'schema>, SpaceEdge>;
 pub(crate) type SpaceNodeId = <SolutionSpaceGraph<'static> as GraphBase>::NodeId;
 pub(crate) type SpaceEdgeId = <SolutionSpaceGraph<'static> as GraphBase>::EdgeId;
-pub(crate) type QuerySolutionSpace<'schema> = Query<SolutionSpaceGraph<'schema>, SolutionSpace>;
+pub(crate) type QuerySolutionSpace<'schema> = Query<SolutionSpaceGraph<'schema>, crate::steps::SolutionSpace>;
 
 impl<'schema> QuerySolutionSpace<'schema> {
     #[instrument(skip_all, level = Level::DEBUG)]

--- a/crates/engine/query-solver/src/solve/input/builder/mod.rs
+++ b/crates/engine/query-solver/src/solve/input/builder/mod.rs
@@ -121,7 +121,7 @@ pub(crate) fn build_input_and_terminals<'schema, 'op>(
         .graph
         .node_references()
         .filter_map(|(node_id, node)| match node {
-            SpaceNode::QueryField(field) if field.flags.contains(FieldFlags::INDISPENSABLE | FieldFlags::LEAF_NODE) => {
+            SpaceNode::Field(field) if field.flags.contains(FieldFlags::INDISPENSABLE | FieldFlags::LEAF_NODE) => {
                 Some(node_id)
             }
             _ => None,

--- a/crates/engine/query-solver/src/solve/mod.rs
+++ b/crates/engine/query-solver/src/solve/mod.rs
@@ -28,4 +28,4 @@ pub(crate) use solver::*;
 
 use crate::{Query, SolutionGraph};
 
-pub(crate) type CrudeSolvedQuery = Query<SolutionGraph, crate::query::steps::SteinerTreeSolution>;
+pub(crate) type QuerySteinerSolution = Query<SolutionGraph, crate::steps::SteinerSolution>;

--- a/crates/engine/query-solver/src/solve/solution.rs
+++ b/crates/engine/query-solver/src/solve/solution.rs
@@ -1,15 +1,17 @@
 use fixedbitset::FixedBitSet;
-use id_newtypes::IdToMany;
+use id_newtypes::{IdRange, IdToMany};
 use operation::{Operation, OperationContext};
 use petgraph::{
     Direction, Graph,
+    graph::NodeIndex,
     visit::{EdgeIndexable, EdgeRef},
 };
 use schema::Schema;
 use walker::Walk;
 
 use crate::{
-    Derive, QueryField, QueryFieldNode, SpaceNodeId,
+    Derive, FieldNode, QueryField, QueryFieldId, QueryOrSchemaSortedFieldArgumentIds, QuerySolutionSpace,
+    SolutionGraph, SpaceNodeId,
     query::{Edge, Node},
     solution_space::{SpaceEdge, SpaceNode},
     solve::{
@@ -18,7 +20,7 @@ use crate::{
     },
 };
 
-use super::CrudeSolvedQuery;
+use super::QuerySteinerSolution;
 
 pub(crate) struct Solution<'schema> {
     pub input: SteinerInput<'schema>,
@@ -26,7 +28,7 @@ pub(crate) struct Solution<'schema> {
 }
 
 impl Solution<'_> {
-    pub fn into_query(self, schema: &Schema, operation: &mut Operation) -> crate::Result<CrudeSolvedQuery> {
+    pub fn into_query(self, schema: &Schema, operation: &mut Operation) -> crate::Result<QuerySteinerSolution> {
         let Solution {
             input:
                 SteinerInput {
@@ -76,18 +78,10 @@ impl Solution<'_> {
                 // For now assign __typename fields to the root node, they will be later be added
                 // to an appropriate query partition.
                 SpaceEdge::TypenameField => {
-                    if let SpaceNode::QueryField(QueryFieldNode {
-                        id: query_field_id,
-                        flags,
-                        split_id: split,
-                    }) = space.graph[edge.target()]
-                        && space[query_field_id].definition_id.is_none()
+                    if let SpaceNode::Field(node) = space.graph[edge.target()]
+                        && space[node.id].definition_id.is_none()
                     {
-                        let typename_field_id = graph.add_node(Node::Field {
-                            id: query_field_id,
-                            split_id: split,
-                            flags,
-                        });
+                        let typename_field_id = graph.add_node(Node::Field(node));
                         graph.add_edge(root_node_id, typename_field_id, Edge::Field);
                     }
                 }
@@ -110,27 +104,25 @@ impl Solution<'_> {
             );
             let new_node_id = match &space.graph[space_node_id] {
                 SpaceNode::Resolver(resolver) => {
+                    let dedup_id = space
+                        .step
+                        .deduplication_map
+                        .get_or_insert_resolver(resolver.definition_id);
                     let id = graph.add_node(Node::QueryPartition {
                         entity_definition_id: resolver.entity_definition_id,
                         resolver_definition_id: resolver.definition_id,
+                        dedup_id,
                     });
                     graph.add_edge(parent_node_id, id, Edge::QueryPartition);
                     id
                 }
                 SpaceNode::ProvidableField(providable_field) => {
-                    let (
-                        field_space_node_id,
-                        &QueryFieldNode {
-                            id: query_field_id,
-                            split_id,
-                            flags,
-                        },
-                    ) = space
+                    let (field_space_node_id, &node) = space
                         .graph
                         .edges_directed(space_node_id, Direction::Outgoing)
                         .find_map(|edge| {
                             if matches!(edge.weight(), SpaceEdge::Provides) {
-                                if let SpaceNode::QueryField(field) = &space.graph[edge.target()] {
+                                if let SpaceNode::Field(field) = &space.graph[edge.target()] {
                                     Some((edge.target(), field))
                                 } else {
                                     None
@@ -141,153 +133,22 @@ impl Solution<'_> {
                         })
                         .expect("Providable field should have at least one outgoing provides edge");
 
-                    let field_node_id = graph.add_node(Node::Field {
-                        id: query_field_id,
-                        split_id,
-                        flags,
-                    });
+                    let field_node_id = graph.add_node(Node::Field(node));
                     graph.add_edge(parent_node_id, field_node_id, Edge::Field);
-                    query_field_to_node.push(((query_field_id, split_id), field_node_id));
+                    query_field_to_node.push(((node.id, node.split_id), field_node_id));
 
-                    // FIXME: Move this logic to the solution space.
                     if let Some(derive) = providable_field.derive {
-                        let derive_root = match derive {
-                            Derive::Root { id } => id,
-                            _ => space.graph[space_parent_node_id]
-                                .as_providable_field()
-                                .and_then(|field| field.derive)
-                                .and_then(Derive::into_root)
-                                .unwrap(),
-                        }
-                        .walk(schema);
-
-                        let (type_conditions, source_node_id) = if let Some(batch_field_id) = derive_root.batch_field_id
-                        {
-                            let source_node_id = if matches!(derive, Derive::Root { .. }) {
-                                let source_node_id = graph
-                                    .edges_directed(parent_node_id, Direction::Outgoing)
-                                    .find_map(|edge| {
-                                        if !matches!(edge.weight(), Edge::Field) {
-                                            return None;
-                                        }
-                                        let Node::Field { id, .. } = graph[edge.target()] else {
-                                            return None;
-                                        };
-                                        let field = &space[id];
-                                        if field.definition_id == Some(batch_field_id) {
-                                            return Some(edge.target());
-                                        }
-                                        None
-                                    })
-                                    .unwrap_or_else(|| {
-                                        let field = QueryField {
-                                            type_conditions: space[query_field_id].type_conditions,
-                                            query_position: None,
-                                            response_key: Some(
-                                                operation
-                                                    .response_keys
-                                                    .get_or_intern(batch_field_id.walk(schema).name()),
-                                            ),
-                                            subgraph_key: None,
-                                            definition_id: Some(batch_field_id),
-                                            matching_field_id: None,
-                                            argument_ids: Default::default(),
-                                            location: space[query_field_id].location,
-                                            flat_directive_id: None,
-                                        };
-                                        space.fields.push(field);
-                                        let node_id = graph.add_node(Node::Field {
-                                            id: (space.fields.len() - 1).into(),
-                                            split_id: Default::default(),
-                                            flags,
-                                        });
-                                        graph.add_edge(parent_node_id, node_id, Edge::Field);
-                                        node_id
-                                    });
-                                graph.add_edge(source_node_id, field_node_id, Edge::Derive);
-                                source_node_id
-                            } else {
-                                let grandparent_node_id = graph
-                                    .edges_directed(parent_node_id, Direction::Incoming)
-                                    .find(|edge| matches!(edge.weight(), Edge::Field))
-                                    .map(|edge| edge.source())
-                                    .unwrap();
-                                graph
-                                    .edges_directed(grandparent_node_id, Direction::Outgoing)
-                                    .find_map(|edge| {
-                                        if !matches!(edge.weight(), Edge::Field) {
-                                            return None;
-                                        }
-                                        let Node::Field { id, .. } = graph[edge.target()] else {
-                                            return None;
-                                        };
-                                        let field = &space[id];
-                                        if field.definition_id == Some(batch_field_id) {
-                                            return Some(edge.target());
-                                        }
-                                        None
-                                    })
-                                    .expect("Batch field id should be present")
-                            };
-                            (Default::default(), source_node_id)
-                        } else {
-                            let parent_query_field_id = graph[parent_node_id]
-                                .as_query_field()
-                                .expect("Could not be derived otherwise.");
-                            let grandparent_node_id = graph
-                                .edges_directed(parent_node_id, Direction::Incoming)
-                                .find(|edge| matches!(edge.weight(), Edge::Field))
-                                .map(|edge| edge.source())
-                                .unwrap();
-                            (space[parent_query_field_id].type_conditions, grandparent_node_id)
-                        };
-                        match derive {
-                            Derive::Field { from_id } => {
-                                let derived_from_node_id = graph
-                                    .edges_directed(source_node_id, Direction::Outgoing)
-                                    .find_map(|edge| {
-                                        if !matches!(edge.weight(), Edge::Field) {
-                                            return None;
-                                        }
-                                        let Node::Field { id, .. } = graph[edge.target()] else {
-                                            return None;
-                                        };
-                                        let field = &space[id];
-                                        if field.definition_id == Some(from_id) {
-                                            return Some(edge.target());
-                                        }
-                                        None
-                                    })
-                                    .unwrap_or_else(|| {
-                                        let field = QueryField {
-                                            type_conditions,
-                                            query_position: None,
-                                            response_key: Some(
-                                                operation.response_keys.get_or_intern(from_id.walk(schema).name()),
-                                            ),
-                                            subgraph_key: None,
-                                            definition_id: Some(from_id),
-                                            matching_field_id: None,
-                                            argument_ids: Default::default(),
-                                            location: space[query_field_id].location,
-                                            flat_directive_id: None,
-                                        };
-                                        space.fields.push(field);
-                                        let ix = graph.add_node(Node::Field {
-                                            id: (space.fields.len() - 1).into(),
-                                            split_id: Default::default(),
-                                            flags,
-                                        });
-                                        graph.add_edge(source_node_id, ix, Edge::Field);
-                                        ix
-                                    });
-                                graph.add_edge(derived_from_node_id, field_node_id, Edge::Derive);
-                            }
-                            Derive::ScalarAsField => {
-                                graph.add_edge(source_node_id, field_node_id, Edge::Derive);
-                            }
-                            Derive::Root { .. } => {}
-                        }
+                        insert_derived_field(
+                            schema,
+                            &mut space,
+                            &mut graph,
+                            operation,
+                            space_parent_node_id,
+                            parent_node_id,
+                            field_node_id,
+                            node,
+                            derive,
+                        );
                     }
 
                     for space_edge in space.graph.edges(field_space_node_id) {
@@ -301,18 +162,10 @@ impl Solution<'_> {
                             // parent field. There might be multiple with shared root fields.
                             SpaceEdge::TypenameField => {
                                 space_edges_to_remove.push(space_edge.id());
-                                if let SpaceNode::QueryField(QueryFieldNode {
-                                    id: query_field_id,
-                                    split_id: split,
-                                    flags,
-                                }) = space.graph[space_edge.target()]
-                                    && space[query_field_id].definition_id.is_none()
+                                if let SpaceNode::Field(node) = space.graph[space_edge.target()]
+                                    && space[node.id].definition_id.is_none()
                                 {
-                                    let typename_field_ix = graph.add_node(Node::Field {
-                                        id: query_field_id,
-                                        split_id: split,
-                                        flags,
-                                    });
+                                    let typename_field_ix = graph.add_node(Node::Field(node));
                                     graph.add_edge(field_node_id, typename_field_ix, Edge::Field);
                                 }
                             }
@@ -326,16 +179,8 @@ impl Solution<'_> {
 
                     field_node_id
                 }
-                SpaceNode::QueryField(QueryFieldNode {
-                    id: query_field_id,
-                    split_id: split,
-                    flags,
-                }) if space[*query_field_id].definition_id.is_none() => {
-                    let typename_field_ix = graph.add_node(Node::Field {
-                        id: *query_field_id,
-                        flags: *flags,
-                        split_id: *split,
-                    });
+                SpaceNode::Field(node) if space[node.id].definition_id.is_none() => {
+                    let typename_field_ix = graph.add_node(Node::Field(*node));
                     graph.add_edge(parent_node_id, typename_field_ix, Edge::Field);
                     typename_field_ix
                 }
@@ -376,7 +221,7 @@ impl Solution<'_> {
             target_space_node_id,
         } in required_edges
         {
-            let SpaceNode::QueryField(field) = &space.graph[target_space_node_id] else {
+            let SpaceNode::Field(field) = &space.graph[target_space_node_id] else {
                 unreachable!()
             };
             for node_id in field_to_node.find_all((field.id, field.split_id)).copied() {
@@ -384,8 +229,10 @@ impl Solution<'_> {
             }
         }
 
-        let query = CrudeSolvedQuery {
-            step: crate::query::steps::SteinerTreeSolution,
+        let query = QuerySteinerSolution {
+            step: crate::query::steps::SteinerSolution {
+                deduplication_map: space.step.deduplication_map,
+            },
             root_node_id,
             graph,
             fields: space.fields,
@@ -399,5 +246,158 @@ impl Solution<'_> {
         );
 
         Ok(query)
+    }
+}
+
+// TODO: Maybe move this logic to the post processing?
+#[allow(clippy::too_many_arguments)]
+fn insert_derived_field(
+    schema: &Schema,
+    space: &mut QuerySolutionSpace<'_>,
+    graph: &mut SolutionGraph,
+    operation: &mut Operation,
+    space_parent_node_id: SpaceNodeId,
+    parent_node_id: NodeIndex,
+    field_node_id: NodeIndex,
+    node: FieldNode,
+    derive: Derive,
+) {
+    let derive_root = match derive {
+        Derive::Root { id } => id,
+        _ => space.graph[space_parent_node_id]
+            .as_providable_field()
+            .and_then(|field| field.derive)
+            .and_then(Derive::into_root)
+            .unwrap(),
+    }
+    .walk(schema);
+
+    let (type_conditions, source_node_id) = if let Some(batch_field_id) = derive_root.batch_field_id {
+        let source_node_id = if matches!(derive, Derive::Root { .. }) {
+            let source_node_id = graph
+                .edges_directed(parent_node_id, Direction::Outgoing)
+                .find_map(|edge| {
+                    if !matches!(edge.weight(), Edge::Field) {
+                        return None;
+                    }
+                    let Node::Field(target) = graph[edge.target()] else {
+                        return None;
+                    };
+                    let field = &space[target.id];
+                    if field.definition_id == Some(batch_field_id) {
+                        return Some(edge.target());
+                    }
+                    None
+                })
+                .unwrap_or_else(|| {
+                    let field = QueryField {
+                        type_conditions: space[node.id].type_conditions,
+                        query_position: None,
+                        response_key: Some(
+                            operation
+                                .response_keys
+                                .get_or_intern(batch_field_id.walk(schema).name()),
+                        ),
+                        definition_id: Some(batch_field_id),
+                        matching_field_id: None,
+                        sorted_argument_ids: QueryOrSchemaSortedFieldArgumentIds::Query(IdRange::empty()),
+                        location: space[node.id].location,
+                        flat_directive_id: None,
+                    };
+                    space.fields.push(field);
+                    let id = QueryFieldId::from(space.fields.len() - 1);
+                    let dedup_id =
+                        space.get_or_insert_field_deduplication_id(OperationContext { schema, operation }, id);
+                    let node_id = graph.add_node(Node::Field(FieldNode {
+                        id: (space.fields.len() - 1).into(),
+                        dedup_id,
+                        ..node
+                    }));
+                    graph.add_edge(parent_node_id, node_id, Edge::Field);
+                    node_id
+                });
+            graph.add_edge(source_node_id, field_node_id, Edge::Derive);
+            source_node_id
+        } else {
+            let grandparent_node_id = graph
+                .edges_directed(parent_node_id, Direction::Incoming)
+                .find(|edge| matches!(edge.weight(), Edge::Field))
+                .map(|edge| edge.source())
+                .unwrap();
+            graph
+                .edges_directed(grandparent_node_id, Direction::Outgoing)
+                .find_map(|edge| {
+                    if !matches!(edge.weight(), Edge::Field) {
+                        return None;
+                    }
+                    let Node::Field(target) = graph[edge.target()] else {
+                        return None;
+                    };
+                    let field = &space[target.id];
+                    if field.definition_id == Some(batch_field_id) {
+                        return Some(edge.target());
+                    }
+                    None
+                })
+                .expect("Batch field id should be present")
+        };
+        (Default::default(), source_node_id)
+    } else {
+        let parent_query_field_id = graph[parent_node_id]
+            .as_query_field()
+            .expect("Could not be derived otherwise.");
+        let grandparent_node_id = graph
+            .edges_directed(parent_node_id, Direction::Incoming)
+            .find(|edge| matches!(edge.weight(), Edge::Field))
+            .map(|edge| edge.source())
+            .unwrap();
+        (space[parent_query_field_id].type_conditions, grandparent_node_id)
+    };
+    match derive {
+        Derive::Field { from_id } => {
+            let derived_from_node_id = graph
+                .edges_directed(source_node_id, Direction::Outgoing)
+                .find_map(|edge| {
+                    if !matches!(edge.weight(), Edge::Field) {
+                        return None;
+                    }
+                    let Node::Field(target) = graph[edge.target()] else {
+                        return None;
+                    };
+                    let field = &space[target.id];
+                    if field.definition_id == Some(from_id) {
+                        return Some(edge.target());
+                    }
+                    None
+                })
+                .unwrap_or_else(|| {
+                    let field = QueryField {
+                        type_conditions,
+                        query_position: None,
+                        response_key: Some(operation.response_keys.get_or_intern(from_id.walk(schema).name())),
+                        definition_id: Some(from_id),
+                        matching_field_id: None,
+                        sorted_argument_ids: QueryOrSchemaSortedFieldArgumentIds::Query(IdRange::empty()),
+                        location: space[node.id].location,
+                        flat_directive_id: None,
+                    };
+                    space.fields.push(field);
+                    let id = QueryFieldId::from(space.fields.len() - 1);
+                    let dedup_id =
+                        space.get_or_insert_field_deduplication_id(OperationContext { schema, operation }, id);
+                    let ix = graph.add_node(Node::Field(FieldNode {
+                        id: (space.fields.len() - 1).into(),
+                        dedup_id,
+                        ..node
+                    }));
+                    graph.add_edge(source_node_id, ix, Edge::Field);
+                    ix
+                });
+            graph.add_edge(derived_from_node_id, field_node_id, Edge::Derive);
+        }
+        Derive::ScalarAsField => {
+            graph.add_edge(source_node_id, field_node_id, Edge::Derive);
+        }
+        Derive::Root { .. } => {}
     }
 }

--- a/crates/engine/src/prepare/cached/builder/mod.rs
+++ b/crates/engine/src/prepare/cached/builder/mod.rs
@@ -6,14 +6,14 @@ mod response_object_sets;
 mod shapes;
 
 use operation::Operation;
-use query_solver::SolvedQuery;
+use query_solver::QuerySolution;
 use schema::Schema;
 
 use super::*;
 
 pub(super) struct Solver<'a> {
     schema: &'a Schema,
-    solution: SolvedQuery,
+    solution: QuerySolution,
     output: CachedOperation,
 }
 

--- a/crates/engine/src/prepare/cached/builder/modifiers.rs
+++ b/crates/engine/src/prepare/cached/builder/modifiers.rs
@@ -47,8 +47,8 @@ impl Solver<'_> {
             let Some(field_id) = field_id else {
                 continue;
             };
-            if let Node::Field { id, .. } = self.solution.graph[node_id]
-                && let Some(id) = self.solution[id].flat_directive_id
+            if let Node::Field(node) = self.solution.graph[node_id]
+                && let Some(id) = self.solution[node.id].flat_directive_id
             {
                 accumulator.query_modifiers[usize::from(id)]
                     .impacted_field_ids

--- a/crates/engine/src/prepare/cached/shape/mod.rs
+++ b/crates/engine/src/prepare/cached/shape/mod.rs
@@ -36,7 +36,7 @@ mod tests {
 
     #[test]
     fn check_field_size() {
-        assert_eq!(std::mem::size_of::<FieldShapeRecord>(), 24);
+        assert_eq!(std::mem::size_of::<FieldShapeRecord>(), 20);
         assert_eq!(std::mem::align_of::<FieldShapeRecord>(), 4);
     }
 

--- a/crates/engine/src/resolver/graphql/federation.rs
+++ b/crates/engine/src/resolver/graphql/federation.rs
@@ -118,8 +118,8 @@ impl std::fmt::Display for DisplayPath<'_> {
         f.write_fmt(format_args!(
             "{}",
             self.path.iter().format_with(".", |value_id, f| match value_id {
-                ResponseValueId::Field { response_key, .. } => {
-                    let field_key = &self.keys[*response_key];
+                ResponseValueId::Field { key, .. } => {
+                    let field_key = &self.keys[*key];
                     f(&format_args!("{field_key}"))
                 }
                 ResponseValueId::Index { index, .. } => f(&format_args!("{index}")),

--- a/crates/engine/src/response/data.rs
+++ b/crates/engine/src/response/data.rs
@@ -181,12 +181,11 @@ impl DataPart {
     pub fn make_inaccessible(&mut self, value_id: ResponseValueId) {
         match value_id {
             ResponseValueId::Field {
-                object_id: ResponseObjectId { part_id, object_id },
-                query_position,
-                response_key,
+                part_id,
+                object_id,
+                key,
                 nullable,
             } => {
-                let key = response_key.with_position(query_position);
                 debug_assert!(part_id == self.id && nullable, "{part_id} == {} && {nullable}", self.id);
                 match self[object_id]
                     .fields_sorted_by_key
@@ -219,7 +218,8 @@ impl DataPart {
                 }
             }
             ResponseValueId::Index {
-                list_id: ResponseListId { part_id, list_id },
+                part_id,
+                list_id,
                 index,
                 nullable,
             } => {

--- a/crates/engine/src/response/write/deserialize/list.rs
+++ b/crates/engine/src/response/write/deserialize/list.rs
@@ -94,11 +94,9 @@ where
         }
 
         loop {
-            state.local_path_mut().push(ResponseValueId::Index {
-                list_id,
-                index,
-                nullable: element_is_nullable,
-            });
+            state
+                .local_path_mut()
+                .push(ResponseValueId::index(list_id, index, element_is_nullable));
             let result = seq.next_element_seed(seed.clone());
             state.local_path_mut().pop();
             match result {

--- a/crates/engine/src/response/write/deserialize/object/derive.rs
+++ b/crates/engine/src/response/write/deserialize/object/derive.rs
@@ -118,11 +118,7 @@ fn handle_derive_scalar_list(
     let mut derive_list = Vec::with_capacity(list.len());
     let scalar_field_key = scalar_field.key();
     if !list.is_empty() {
-        ctx.local_path.push(ResponseValueId::Index {
-            list_id: id,
-            index: 0,
-            nullable: element_is_nullable,
-        });
+        ctx.local_path.push(ResponseValueId::index(id, 0, element_is_nullable));
         for &error_id in ctx
             .resp
             .operation
@@ -143,11 +139,8 @@ fn handle_derive_scalar_list(
         ctx.local_path.pop();
     }
     for (index, value) in list.iter().enumerate() {
-        ctx.local_path.push(ResponseValueId::Index {
-            list_id: id,
-            index: index as u32,
-            nullable: element_is_nullable,
-        });
+        ctx.local_path
+            .push(ResponseValueId::index(id, index as u32, element_is_nullable));
         match value {
             ResponseValue::Null => {
                 derive_list.push(ResponseValue::Null);
@@ -224,11 +217,8 @@ fn handle_derive_object_list(
     let list = std::mem::take(&mut ctx.resp.data[id.list_id]);
     let mut derive_list = Vec::with_capacity(list.len());
     for (index, value) in list.iter().enumerate() {
-        ctx.local_path.push(ResponseValueId::Index {
-            list_id: id,
-            index: index as u32,
-            nullable: element_is_nullable,
-        });
+        ctx.local_path
+            .push(ResponseValueId::index(id, index as u32, element_is_nullable));
         match value {
             ResponseValue::Null => {
                 derive_list.push(ResponseValue::Null);

--- a/crates/engine/src/response/write/deserialize/state.rs
+++ b/crates/engine/src/response/write/deserialize/state.rs
@@ -132,8 +132,8 @@ fn write_path(
     let mut values = values.into_iter();
     if let Some(first) = values.next() {
         match first {
-            ResponseValueId::Field { response_key, .. } => {
-                f.write_str(&keys[response_key])?;
+            ResponseValueId::Field { key, .. } => {
+                f.write_str(&keys[key])?;
             }
             ResponseValueId::Index { index, .. } => {
                 index.fmt(f)?;
@@ -142,8 +142,8 @@ fn write_path(
         for value in values {
             f.write_str(".")?;
             match value {
-                ResponseValueId::Field { response_key, .. } => {
-                    f.write_str(&keys[response_key])?;
+                ResponseValueId::Field { key, .. } => {
+                    f.write_str(&keys[key])?;
                 }
                 ResponseValueId::Index { index, .. } => {
                     index.fmt(f)?;


### PR DESCRIPTION
First step of the deduplication algorithm, adding an id that uniquely identifies equal fields/resolvers

Also reverting the query position to be a u16, wanted to separate but somehow got mixed. The GraphQL spec only specifies that fields _should_ be in the right order. So to maximize our chances, I'm resetting the query position at every new depth level when I'm generating those traversing the query in BFS order. So we'll only return incorrect order if there is more than `u16::MAX` fields at the same depth.

And I'm reducing the size of `ResponseValueId` used in response object paths even further.