### PR TITLE
graphql-composition: automatically define local extensions

### DIFF
--- a/crates/graphql-composition/CHANGELOG.md
+++ b/crates/graphql-composition/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 0.12.0 - 2025-08-29
+
+### Improvements
+
+- Any `@link`ed schema with a `url` argument using the `file:` scheme is now automatically considered a Grafbase extension, without having to call `ingest_loaded_extensions()`,  with the `as:` argument used as the extension name. This makes defining private, local extensions smoother. (https://github.com/grafbase/grafbase/pull/3468)
+- Warnings on unknown directives are now more accurate, with more context and fewer false positives. (https://github.com/grafbase/grafbase/pull/3468)
+
 ## 0.11.0 - 2025-08-27
 
 ### Improvements

--- a/crates/graphql-composition/src/compose/directives.rs
+++ b/crates/graphql-composition/src/compose/directives.rs
@@ -90,13 +90,7 @@ pub(super) fn collect_composed_directives(
                             })
                         }
                         (None, true) => Some(ir::DirectiveProvenance::ComposeDirective),
-                        (None, false) => {
-                            ctx.diagnostics.push_warning(format!(
-                                "Directive `{}` is not defined in any extension or composed directive",
-                                &ctx[directive.name]
-                            ));
-                            None
-                        }
+                        (None, false) => None,
                     }
                 }
             };

--- a/crates/graphql-composition/src/subgraphs/directives/link.rs
+++ b/crates/graphql-composition/src/subgraphs/directives/link.rs
@@ -1,7 +1,7 @@
 pub(crate) struct LinkUrl {
-    #[expect(unused)]
     pub(crate) url: url::Url,
     pub(crate) name: Option<String>,
+    #[expect(unused)]
     pub(crate) version: Option<String>,
 }
 

--- a/crates/graphql-composition/src/subgraphs/extensions.rs
+++ b/crates/graphql-composition/src/subgraphs/extensions.rs
@@ -9,10 +9,18 @@ pub(crate) struct ExtensionRecord {
 }
 
 impl Subgraphs {
+    pub(crate) fn extension_is_defined(&self, name: StringId) -> bool {
+        self.extensions.iter().any(|extension| extension.name == name)
+    }
+
     pub(crate) fn iter_extensions(&self) -> impl ExactSizeIterator<Item = Extension<'_>> {
         self.extensions
             .iter()
             .enumerate()
             .map(|(idx, record)| View { id: idx.into(), record })
+    }
+
+    pub(crate) fn push_extension(&mut self, extension: ExtensionRecord) {
+        self.extensions.push(extension);
     }
 }

--- a/crates/graphql-composition/tests/composition/composed_directives_basic/diagnostics.snap
+++ b/crates/graphql-composition/tests/composition/composed_directives_basic/diagnostics.snap
@@ -5,4 +5,3 @@ input_file: crates/graphql-composition/tests/composition/composed_directives_bas
 ---
 - ⚠️ [observations]: Unknown directive `@id` at `BirdObservation`
 - ⚠️ [observations]: Unknown directive `@notComposed` at `ObserverDetails`
-- ⚠️ Directive `pelagic` is not defined in any extension or composed directive

--- a/crates/graphql-composition/tests/composition/grafbase_extensions/extensions_basic/diagnostics.snap
+++ b/crates/graphql-composition/tests/composition/grafbase_extensions/extensions_basic/diagnostics.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/graphql-composition/tests/composition_tests.rs
 expression: "A test with three extensions, used in different subgraphs with different imports. We expect to see the `extension__Link` enum and `extension__directive` instances in the right places.\n\nAlso note we have a facebook linked schema, that should not appear in the federated graph."
-input_file: crates/graphql-composition/tests/composition/extensions_basic/test.md
+input_file: crates/graphql-composition/tests/composition/grafbase_extensions/extensions_basic/test.md
 ---
-- ⚠️ Directive `add` is not defined in any extension or composed directive
+

--- a/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_file_url_are_extensions/api.graphql.snap
+++ b/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_file_url_are_extensions/api.graphql.snap
@@ -1,0 +1,8 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: "Very important in this test: no extensions.toml, composition should figure it out from the url."
+input_file: crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_file_url_are_extensions/test.md
+---
+type Query {
+  hello: String
+}

--- a/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_file_url_are_extensions/diagnostics.snap
+++ b/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_file_url_are_extensions/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: "Very important in this test: no extensions.toml, composition should figure it out from the url."
+input_file: crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_file_url_are_extensions/test.md
+---
+

--- a/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_file_url_are_extensions/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_file_url_are_extensions/federated.graphql.snap
@@ -1,0 +1,33 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: "Very important in this test: no extensions.toml, composition should figure it out from the url."
+input_file: crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_file_url_are_extensions/test.md
+---
+directive @join__unionMember(graph: join__Graph!, member: String!) on UNION
+
+directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT | INTERFACE
+
+directive @join__graph(name: String!, url: String) on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
+
+directive @join__owner(graph: join__Graph!) on OBJECT
+
+scalar join__FieldSet
+
+type Query
+{
+  hello: String @join__field(graph: MY_EXTENSION_SUBGRAPH)
+}
+
+enum join__Graph
+{
+  MY_EXTENSION_SUBGRAPH @join__graph(name: "my-extension-subgraph", url: "http://example.com/my-extension-subgraph")
+}
+
+enum extension__Link
+{
+  REST @extension__link(url: "file:///rest-extension/test", schemaDirectives: [{graph: MY_EXTENSION_SUBGRAPH, name: "assured", arguments: {}}])
+}

--- a/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_file_url_are_extensions/subgraphs/my_extension_subgraph.graphql
+++ b/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_file_url_are_extensions/subgraphs/my_extension_subgraph.graphql
@@ -1,0 +1,7 @@
+schema @link(url: "file:///rest-extension/test", as: "rest") @rest__assured {
+  query: Query
+}
+
+type Query {
+  hello: String
+}

--- a/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_file_url_are_extensions/test.md
+++ b/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_file_url_are_extensions/test.md
@@ -1,0 +1,1 @@
+Very important in this test: no extensions.toml, composition should figure it out from the url.

--- a/crates/graphql-composition/tests/composition/namespaced_directive_without_import_are_ignored/subgraphs/diagnostics.snap
+++ b/crates/graphql-composition/tests/composition/namespaced_directive_without_import_are_ignored/subgraphs/diagnostics.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/graphql-composition/tests/composition_tests.rs
-expression: Federated SDL
+expression: Diagnostics
 input_file: crates/graphql-composition/tests/composition/namespaced_directive_without_import_are_ignored/subgraphs/test.md
 ---
 - ⚠️ [alerts]: Unknown directive `@post` at `Mutation.createAlert`
-- ⚠️ Directive `post` is not defined in any extension or composed directive

--- a/crates/graphql-composition/tests/composition/namespaced_directives_basic/diagnostics.snap
+++ b/crates/graphql-composition/tests/composition/namespaced_directives_basic/diagnostics.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/graphql-composition/tests/composition_tests.rs
-expression: Federated SDL
+expression: Diagnostics
 input_file: crates/graphql-composition/tests/composition/namespaced_directives_basic/test.md
 ---
-- ⚠️ Directive `post` is not defined in any extension or composed directive
-- ⚠️ Directive `post` is not defined in any extension or composed directive
-- ⚠️ Directive `subscribe` is not defined in any extension or composed directive
+


### PR DESCRIPTION
When we encounter an `@link` directive with the `file` schema for its url, we now consider it an extension and use the namespace in `as:` as the extension name.

closes GB-9595