### PR TITLE
feat(gateway): Avoid string allocations

### DIFF
--- a/crates/engine/src/resolver/graphql/federation/with_cache.rs
+++ b/crates/engine/src/resolver/graphql/federation/with_cache.rs
@@ -103,17 +103,16 @@ where
 
             // We use RawValue underneath, so can't use sonic_rs. RawValue doesn't do any copies
             // compared to sonic_rs::LazyValue
-            let status = match state
-                .deserialize_data_with(Deserializable::JsonWithRawValues(http_response.body().as_ref()), seed)
-            {
-                Ok(status) => Some(status),
-                Err(err) => {
-                    if let Some(error) = err {
-                        state.insert_error_updates(cache_misses.map(|miss| &parent_objects[miss.id]), [error]);
+            let status =
+                match state.deserialize_data_with(Deserializable::JsonWithRawValues(http_response.body()), seed) {
+                    Ok(status) => Some(status),
+                    Err(err) => {
+                        if let Some(error) = err {
+                            state.insert_error_updates(cache_misses.map(|miss| &parent_objects[miss.id]), [error]);
+                        }
+                        None
                     }
-                    None
-                }
-            };
+                };
 
             (status, state.into_response_part())
         };

--- a/crates/engine/src/resolver/graphql/federation/without_cache.rs
+++ b/crates/engine/src/resolver/graphql/federation/without_cache.rs
@@ -52,7 +52,7 @@ impl ResponseIngester for EntityIngester {
             ),
         );
 
-        let status = match state.deserialize_data_with(Deserializable::Json(http_response.body().as_ref()), seed) {
+        let status = match state.deserialize_data_with(Deserializable::Json(http_response.body()), seed) {
             Ok(status) => Some(status),
             Err(err) => {
                 if let Some(error) = err {

--- a/crates/engine/src/resolver/introspection/writer.rs
+++ b/crates/engine/src/resolver/introspection/writer.rs
@@ -373,7 +373,10 @@ impl<'ctx, R: Runtime> IntrospectionWriter<'ctx, R> {
                 __InputValue::DefaultValue => target
                     .as_ref()
                     .default_value_id
-                    .map(|id| self.schema.walk(&self.schema[id]).to_string())
+                    .map(|id| {
+                        let value = self.schema.walk(&self.schema[id]).to_string();
+                        self.response.borrow_mut().data.push_string(value)
+                    })
                     .into(),
             },
         )

--- a/crates/engine/src/response/read/ser/data.rs
+++ b/crates/engine/src/response/read/ser/data.rs
@@ -88,18 +88,18 @@ impl serde::Serialize for SerializableResponseValue<'_> {
             ResponseValue::Null | ResponseValue::Inaccessible { .. } | ResponseValue::Unexpected => {
                 serializer.serialize_none()
             }
-            ResponseValue::Boolean { value, .. } => value.serialize(serializer),
-            ResponseValue::Int { value, .. } => value.serialize(serializer),
-            ResponseValue::Float { value, .. } => value.serialize(serializer),
-            ResponseValue::String { value, .. } => value.serialize(serializer),
-            ResponseValue::StringId { id, .. } => self.ctx.schema[*id].serialize(serializer),
-            ResponseValue::I64 { value, .. } => value.serialize(serializer),
-            ResponseValue::List { id, .. } => SerializableResponseList {
+            ResponseValue::Boolean { value } => value.serialize(serializer),
+            ResponseValue::Int { value } => value.serialize(serializer),
+            ResponseValue::Float { value } => value.serialize(serializer),
+            ResponseValue::String { ptr, len } => ptr.as_str(*len).serialize(serializer),
+            ResponseValue::StringId { id } => self.ctx.schema[*id].serialize(serializer),
+            ResponseValue::I64 { value } => value.serialize(serializer),
+            ResponseValue::List { id } => SerializableResponseList {
                 ctx: self.ctx,
                 value: &self.ctx.data[*id],
             }
             .serialize(serializer),
-            ResponseValue::Object { id, .. } => SerializableResponseObject {
+            ResponseValue::Object { id } => SerializableResponseObject {
                 ctx: self.ctx,
                 object: &self.ctx.data[*id],
             }

--- a/crates/engine/src/response/read/view/ser.rs
+++ b/crates/engine/src/response/read/view/ser.rs
@@ -196,13 +196,13 @@ where
                 view: self.view,
             }
             .serialize(serializer),
-            ResponseValue::Boolean { value, .. } => value.serialize(serializer),
-            ResponseValue::Int { value, .. } => value.serialize(serializer),
-            ResponseValue::Float { value, .. } => value.serialize(serializer),
-            ResponseValue::String { value, .. } => value.serialize(serializer),
-            ResponseValue::StringId { id, .. } => self.ctx.response.schema[*id].serialize(serializer),
-            ResponseValue::I64 { value, .. } => value.serialize(serializer),
-            &ResponseValue::List { id, .. } => {
+            ResponseValue::Boolean { value } => value.serialize(serializer),
+            ResponseValue::Int { value } => value.serialize(serializer),
+            ResponseValue::Float { value } => value.serialize(serializer),
+            ResponseValue::String { ptr, len } => ptr.as_str(*len).serialize(serializer),
+            ResponseValue::StringId { id } => self.ctx.response.schema[*id].serialize(serializer),
+            ResponseValue::I64 { value } => value.serialize(serializer),
+            &ResponseValue::List { id } => {
                 let values = &self.ctx.response.data_parts[id];
                 serializer.collect_seq(values.iter().map(|value| ResponseValueView {
                     ctx: self.ctx,
@@ -210,7 +210,7 @@ where
                     view: self.view,
                 }))
             }
-            &ResponseValue::Object { id, .. } => ResponseObjectView {
+            &ResponseValue::Object { id } => ResponseObjectView {
                 ctx: self.ctx,
                 response_object: &self.ctx.response.data_parts[id],
                 view: self.view.0,
@@ -373,7 +373,7 @@ impl<'a> serde::Serialize for ResponseValueView<'a, ForInjection<'_>> {
         S: serde::Serializer,
     {
         match self.value {
-            ResponseValue::Object { id, .. } => ResponseObjectView {
+            ResponseValue::Object { id } => ResponseObjectView {
                 ctx: self.ctx,
                 response_object: &self.ctx.response.data_parts[*id],
                 view: self.view,
@@ -386,31 +386,31 @@ impl<'a> serde::Serialize for ResponseValueView<'a, ForInjection<'_>> {
                 view: self.view,
             }
             .serialize(serializer),
-            ResponseValue::Boolean { value, .. } => {
+            ResponseValue::Boolean { value } => {
                 debug_assert!(matches!(self.view.injection, ValueInjection::Identity));
                 value.serialize(serializer)
             }
-            ResponseValue::Int { value, .. } => {
+            ResponseValue::Int { value } => {
                 debug_assert!(matches!(self.view.injection, ValueInjection::Identity));
                 value.serialize(serializer)
             }
-            ResponseValue::Float { value, .. } => {
+            ResponseValue::Float { value } => {
                 debug_assert!(matches!(self.view.injection, ValueInjection::Identity));
                 value.serialize(serializer)
             }
-            ResponseValue::String { value, .. } => {
+            ResponseValue::String { ptr, len } => {
                 debug_assert!(matches!(self.view.injection, ValueInjection::Identity));
-                value.serialize(serializer)
+                ptr.as_str(*len).serialize(serializer)
             }
-            ResponseValue::StringId { id, .. } => {
+            ResponseValue::StringId { id } => {
                 debug_assert!(matches!(self.view.injection, ValueInjection::Identity));
                 self.ctx.response.schema[*id].serialize(serializer)
             }
-            ResponseValue::I64 { value, .. } => {
+            ResponseValue::I64 { value } => {
                 debug_assert!(matches!(self.view.injection, ValueInjection::Identity));
                 value.serialize(serializer)
             }
-            ResponseValue::List { id, .. } => {
+            ResponseValue::List { id } => {
                 let values = &self.ctx.response.data_parts[*id];
                 serializer.collect_seq(values.iter().map(|value| ResponseValueView {
                     ctx: self.ctx,

--- a/crates/engine/src/response/value.rs
+++ b/crates/engine/src/response/value.rs
@@ -1,6 +1,8 @@
 use operation::{PositionedResponseKey, ResponseKey};
 use schema::{ObjectDefinitionId, StringId};
 
+use crate::response::PartStrPtr;
+
 use super::{ResponseInaccessibleValueId, ResponseListId, ResponseMapId, ResponseObjectId};
 
 #[derive(Debug, Default)]
@@ -61,7 +63,8 @@ pub(crate) enum ResponseValue {
         value: f64,
     },
     String {
-        value: String,
+        ptr: PartStrPtr,
+        len: u32,
     },
     StringId {
         id: StringId,
@@ -103,6 +106,12 @@ impl From<StringId> for ResponseValue {
     }
 }
 
+impl From<(PartStrPtr, u32)> for ResponseValue {
+    fn from((ptr, len): (PartStrPtr, u32)) -> Self {
+        Self::String { ptr, len }
+    }
+}
+
 impl From<bool> for ResponseValue {
     fn from(value: bool) -> Self {
         Self::Boolean { value }
@@ -127,12 +136,6 @@ impl From<f64> for ResponseValue {
     }
 }
 
-impl From<String> for ResponseValue {
-    fn from(value: String) -> Self {
-        Self::String { value }
-    }
-}
-
 impl From<ResponseListId> for ResponseValue {
     fn from(id: ResponseListId) -> Self {
         Self::List { id }
@@ -154,13 +157,11 @@ impl From<ResponseInaccessibleValueId> for ResponseValue {
 #[cfg(test)]
 #[test]
 fn check_response_value_size() {
-    assert_eq!(std::mem::size_of::<ResponseValue>(), 24);
-    assert_eq!(std::mem::align_of::<ResponseValue>(), 8);
+    assert_eq!(std::mem::size_of::<ResponseValue>(), 16);
 }
 
 #[cfg(test)]
 #[test]
 fn check_response_object_field_size() {
     assert_eq!(std::mem::size_of::<ResponseObjectField>(), 32);
-    assert_eq!(std::mem::align_of::<ResponseObjectField>(), 8);
 }

--- a/crates/engine/src/response/write/deserialize/mod.rs
+++ b/crates/engine/src/response/write/deserialize/mod.rs
@@ -8,6 +8,7 @@ mod root;
 mod scalar;
 mod state;
 
+use bytes::Bytes;
 use object::{ConcreteShapeFieldsSeed, ObjectFields};
 use runtime::extension::Data;
 use serde::de::DeserializeSeed;
@@ -22,9 +23,9 @@ pub(crate) use state::*;
 
 pub(crate) enum Deserializable<'a> {
     JsonValue(serde_json::Value),
-    Json(&'a [u8]),
-    JsonWithRawValues(&'a [u8]),
-    Cbor(&'a [u8]),
+    Json(&'a Bytes),
+    JsonWithRawValues(&'a Bytes),
+    Cbor(&'a Bytes),
 }
 
 impl<'de> From<&'de Data> for Deserializable<'de> {
@@ -49,27 +50,41 @@ impl<'parent> SeedState<'_, 'parent> {
         seed: Seed,
     ) -> Result<<Seed as DeserializeSeed<'de>>::Value, Option<GraphqlError>> {
         match data.into() {
-            Deserializable::Json(bytes) => seed
-                .deserialize(&mut sonic_rs::Deserializer::from_slice(bytes))
-                .map_err(|err| {
-                    if !self.bubbling_up_deser_error.get() {
-                        tracing::error!("Deserialization failure: {err}");
-                        Some(GraphqlError::invalid_subgraph_response())
-                    } else {
-                        None
-                    }
-                }),
-            Deserializable::JsonWithRawValues(bytes) => seed
-                .deserialize(&mut serde_json::Deserializer::from_slice(bytes))
-                .map_err(|err| {
-                    if !self.bubbling_up_deser_error.get() {
-                        tracing::error!("Deserialization failure: {err}");
-                        Some(GraphqlError::invalid_subgraph_response())
-                    } else {
-                        None
-                    }
-                }),
+            Deserializable::Json(bytes) => {
+                // SAFETY: The provided bytes are the ones we deserialize.
+                unsafe {
+                    self.response.borrow_mut().data.use_borrowed_strings(bytes.clone());
+                }
+                seed.deserialize(&mut sonic_rs::Deserializer::from_slice(bytes))
+                    .map_err(|err| {
+                        if !self.bubbling_up_deser_error.get() {
+                            tracing::error!("Deserialization failure: {err}");
+                            Some(GraphqlError::invalid_subgraph_response())
+                        } else {
+                            None
+                        }
+                    })
+            }
+            Deserializable::JsonWithRawValues(bytes) => {
+                // SAFETY: The provided bytes are the ones we deserialize.
+                unsafe {
+                    self.response.borrow_mut().data.use_borrowed_strings(bytes.clone());
+                }
+                seed.deserialize(&mut serde_json::Deserializer::from_slice(bytes))
+                    .map_err(|err| {
+                        if !self.bubbling_up_deser_error.get() {
+                            tracing::error!("Deserialization failure: {err}");
+                            Some(GraphqlError::invalid_subgraph_response())
+                        } else {
+                            None
+                        }
+                    })
+            }
             Deserializable::Cbor(bytes) => {
+                // SAFETY: The provided bytes are the ones we deserialize.
+                unsafe {
+                    self.response.borrow_mut().data.use_borrowed_strings(bytes.clone());
+                }
                 seed.deserialize(&mut minicbor_serde::Deserializer::new(bytes))
                     .map_err(|err| {
                         if !self.bubbling_up_deser_error.get() {


### PR DESCRIPTION
Today we always create a new string when we deserialize, but most of the time we could just keep a reference to the original data even in JSON.

So I've added the possibility to keep track of the original deserialized bytes which will only keep a pointer to the deserialized bytes. For Strings we're now pushing them into a sepearate Vec. This will allow me to make `ResponseValue` `Copy` in a further PR (have already written the code) and reduce its size from 24 bytes to 16.

I've ran two variants of the big response bench:
- with 1 VU we're roughly 10% faster, memory average is a bit worse, max is the same
- with 20 VUs and 100ms latency for a 2nd subgraph request, forcing multiple response data to be kept in memory in parallel, we consumme 10% less in avg & max memory and CPU is also roughly 10% faster
