### PR TITLE
graphql-composition: treat @cost and @listSize the same always

### DIFF
--- a/crates/graphql-composition/CHANGELOG.md
+++ b/crates/graphql-composition/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Fixes
+
+- There were inconsistencies in what types of subgraphs (no imports, federation v2 import, composite schemas import, with and without associated url) would recognize `@cost` and `@listSize` as built-in directives. This release fixes the inconsistency and treats them as built-ins everywhere. (https://github.com/grafbase/grafbase/pull/3485)
+
 ## 0.12.0 - 2025-08-29
 
 ### Improvements

--- a/crates/graphql-composition/src/ingest_subgraph/directives/match_name.rs
+++ b/crates/graphql-composition/src/ingest_subgraph/directives/match_name.rs
@@ -109,6 +109,8 @@ fn match_directive_name_inner(
         "deprecated" => return DirectiveNameMatch::Deprecated,
         "specifiedBy" => return DirectiveNameMatch::SpecifiedBy,
         "oneOf" => return DirectiveNameMatch::OneOf,
+        COST => return DirectiveNameMatch::Cost,
+        LIST_SIZE => return DirectiveNameMatch::ListSize,
         _ => (),
     }
 
@@ -144,13 +146,11 @@ fn match_federation_directive_by_original_name(original_name: &str) -> Directive
     match original_name {
         AUTHENTICATED => DirectiveNameMatch::Authenticated,
         COMPOSE_DIRECTIVE => DirectiveNameMatch::ComposeDirective,
-        COST => DirectiveNameMatch::Cost,
         EXTENDS => DirectiveNameMatch::Extends,
         EXTERNAL => DirectiveNameMatch::External,
         INACCESSIBLE => DirectiveNameMatch::Inaccessible,
         INTERFACE_OBJECT => DirectiveNameMatch::InterfaceObject,
         KEY => DirectiveNameMatch::Key,
-        LIST_SIZE => DirectiveNameMatch::ListSize,
         OVERRIDE => DirectiveNameMatch::Override,
         POLICY => DirectiveNameMatch::Policy,
         PROVIDES => DirectiveNameMatch::Provides,


### PR DESCRIPTION
We had some inconsistencies in what types of subgraphs (no imports, federation v2 import, composite schemas import, with and without associated url) would recognize `@cost` and `@listSize` as built-in directives. This commit fixes the inconsistency and treats them as built-ins everywhere.