### PR TITLE
cli: release 0.102.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3863,7 +3863,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "anyhow",
  "askama",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.102.2"
+version = "0.102.3"
 name = "grafbase"
 description = "The Grafbase command line interface"
 categories = ["command-line-utilities"]

--- a/cli/changelog/0.102.3.md
+++ b/cli/changelog/0.102.3.md
@@ -1,0 +1,3 @@
+## Fixes
+
+- Include the fixes in version 0.12.0 of graphql-composition ([changelog](https://github.com/grafbase/grafbase/blob/main/crates/graphql-composition/CHANGELOG.md)) as well as an unreleased fix about `@cost` and `@listSize` on federation v1 subgraphs.

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.102.2",
+  "version": "0.102.3",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.102.2",
+  "version": "0.102.3",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.102.2",
+  "version": "0.102.3",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "30.1.3"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.102.2",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.102.2",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.102.2",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.102.2",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.102.2"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.102.3",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.102.3",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.102.3",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.102.3",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.102.3"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.102.2",
+  "version": "0.102.3",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.102.2",
+  "version": "0.102.3",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.102.2",
+  "version": "0.102.3",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
Release the changes in 0.12 of graphql composition ([changelog](https://github.com/grafbase/grafbase/blob/main/crates/graphql-composition/CHANGELOG.md)) as well as some unreleased fixes.