### PR TITLE
cli: allow making an existing subgraph virtual in `grafbase publish`

### DIFF
--- a/cli/changelog/unreleased.md
+++ b/cli/changelog/unreleased.md
@@ -1,0 +1,3 @@
+## Improvements
+
+- If you explicitly pass `--virtual` to the `publish` command, and the subgraph already has a URL, it will now become virtual, instead of keeping its URL previously.

--- a/cli/src/api/graphql/api.graphql
+++ b/cli/src/api/graphql/api.graphql
@@ -1579,10 +1579,26 @@ input PublishInput {
   accountSlug: String!
   graphSlug: String
   branch: String
+  """
+  The name of the subgraph
+  """
   subgraph: String!
+  """
+  The URL of the subgraph. Can be left blank if the subgraph already exist or when creating a virtual subgraph.
+  """
   url: String
+  """
+  The SDL of the subgraph
+  """
   schema: String!
+  """
+  Associated message (for humans)
+  """
   message: String
+  """
+  Whether this is a virtual subgraph (no URL)
+  """
+  virtual: Boolean
 }
 
 """

--- a/cli/src/api/graphql/types/mutations.rs
+++ b/cli/src/api/graphql/types/mutations.rs
@@ -218,6 +218,8 @@ pub struct PublishInput<'a> {
     pub schema: &'a str,
     pub subgraph: &'a str,
     pub url: Option<&'a str>,
+    #[cynic(rename = "virtual")]
+    pub r#virtual: Option<bool>,
 }
 
 #[derive(cynic::QueryFragment, Debug)]

--- a/cli/src/api/publish.rs
+++ b/cli/src/api/publish.rs
@@ -15,7 +15,8 @@ pub enum PublishOutcome {
     GraphDoesNotExist { account_slug: String, graph_slug: String },
 }
 
-pub async fn publish(
+#[expect(clippy::too_many_arguments)]
+pub(crate) async fn publish(
     account_slug: &str,
     graph_slug: &str,
     branch: Option<&str>,
@@ -23,6 +24,7 @@ pub async fn publish(
     url: Option<&str>,
     schema: &str,
     message: Option<&str>,
+    r#virtual: Option<bool>,
 ) -> Result<PublishOutcome, ApiError> {
     let platform_data = PlatformData::get();
     let client = create_client()?;
@@ -36,6 +38,7 @@ pub async fn publish(
             url,
             schema,
             message,
+            r#virtual,
         },
     });
 

--- a/cli/src/publish.rs
+++ b/cli/src/publish.rs
@@ -43,6 +43,7 @@ pub(crate) async fn publish(
         source.url.as_ref().map(|url| url.as_str()),
         &schema,
         message.as_deref(),
+        if source.r#virtual { Some(true) } else { None },
     )
     .await
     .map_err(CliError::BackendApiError)?;


### PR DESCRIPTION
If you explicitly pass `--virtual` to the `publish` command, and the subgraph already has a URL, it will now become virtual, instead of keeping its URL previously.

closes GB-9610