### PR TITLE
graphql-composition: auto-detect extensions from registry without as:

### DIFF
--- a/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_grafbase_url_are_extensions/api.graphql.snap
+++ b/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_grafbase_url_are_extensions/api.graphql.snap
@@ -7,3 +7,12 @@ type Query {
   hello: String
   world: String
 }
+
+type Mutation {
+  sellBook(input: SellBookInput!): Boolean!
+}
+
+input SellBookInput {
+  isbn: ID!
+  price: Int!
+}

--- a/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_grafbase_url_are_extensions/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_grafbase_url_are_extensions/federated.graphql.snap
@@ -23,6 +23,11 @@ type Query
   world: String @extension__directive(graph: EXTENSION_SUBGRAPH, extension: OPENAPI, name: "operation", arguments: {id: "getWorld"}) @join__field(graph: EXTENSION_SUBGRAPH)
 }
 
+type Mutation
+{
+  sellBook(input: SellBookInput!): Boolean! @extension__directive(graph: EXTENSION_SUBGRAPH, extension: NATS, name: "natsPublish", arguments: {subject: "bookSales", body: {selection: "*"}}) @join__field(graph: EXTENSION_SUBGRAPH)
+}
+
 enum join__Graph
 {
   EXTENSION_SUBGRAPH @join__graph(name: "extension-subgraph", url: "http://example.com/extension-subgraph")
@@ -32,4 +37,12 @@ enum extension__Link
 {
   REST @extension__link(url: "https://extensions.grafbase.com/rest/v1", schemaDirectives: [{graph: EXTENSION_SUBGRAPH, name: "config", arguments: {baseUrl: "https://api.example.com"}}])
   OPENAPI @extension__link(url: "https://grafbase.com/extensions/openapi/v2", schemaDirectives: [{graph: EXTENSION_SUBGRAPH, name: "spec", arguments: {url: "https://api.example.com/spec.json"}}])
+  NATS @extension__link(url: "https://extensions.grafbase.com/extensions/nats/0.3.3")
+}
+
+input SellBookInput
+  @join__type(graph: EXTENSION_SUBGRAPH)
+{
+  isbn: ID!
+  price: Int!
 }

--- a/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_grafbase_url_are_extensions/subgraphs/extension_subgraph.graphql
+++ b/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_grafbase_url_are_extensions/subgraphs/extension_subgraph.graphql
@@ -1,13 +1,23 @@
-schema 
+schema
   @link(url: "https://extensions.grafbase.com/rest/v1", as: "rest")
   @link(url: "https://grafbase.com/extensions/openapi/v2", as: "openapi")
+  # Without `(as:)`
+  @link(url: "https://extensions.grafbase.com/extensions/nats/0.3.3", import: ["@natsPublish", "@natsSubscription"])
   @rest__config(baseUrl: "https://api.example.com")
-  @openapi__spec(url: "https://api.example.com/spec.json")
-{
+  @openapi__spec(url: "https://api.example.com/spec.json") {
   query: Query
 }
 
 type Query {
   hello: String @rest__endpoint(path: "/hello")
   world: String @openapi__operation(id: "getWorld")
+}
+
+input SellBookInput {
+  isbn: ID!
+  price: Int!
+}
+
+type Mutation {
+  sellBook(input: SellBookInput!): Boolean! @natsPublish(subject: "bookSales", body: { selection: "*" })
 }


### PR DESCRIPTION
Until now, we required the `as:` alias, but for well-formed `@link` urls that point to the Grafbase extensions registry, we don't need it.