### PR TITLE
operation-checks: return the path and kind of the change in diagnostics

### DIFF
--- a/crates/operation-checks/src/check.rs
+++ b/crates/operation-checks/src/check.rs
@@ -11,6 +11,10 @@ pub struct CheckDiagnostic {
     pub message: String,
     /// See [Severity].
     pub severity: Severity,
+    /// The path where the change occurred (e.g., "Type.field.argument").
+    pub path: String,
+    /// The kind of change that triggered this diagnostic.
+    pub change_kind: graphql_schema_diff::ChangeKind,
 }
 
 /// The severity of a [CheckDiagnostic].

--- a/crates/operation-checks/src/check/rules.rs
+++ b/crates/operation-checks/src/check/rules.rs
@@ -38,6 +38,8 @@ pub(super) fn remove_field<T: UsageProvider>(
                     change.path
                 ),
                 severity: Severity::Error,
+                path: change.path.clone(),
+                change_kind: change.kind,
             }
         } else {
             CheckDiagnostic {
@@ -46,6 +48,8 @@ pub(super) fn remove_field<T: UsageProvider>(
                     change.path
                 ),
                 severity: Severity::Warning,
+                path: change.path.clone(),
+                change_kind: change.kind,
             }
         };
 
@@ -57,6 +61,8 @@ pub(super) fn remove_field<T: UsageProvider>(
                 change.path
             ),
             severity: Severity::Error,
+            path: change.path.clone(),
+            change_kind: change.kind,
         })
     } else {
         None
@@ -93,6 +99,8 @@ pub(super) fn add_field_argument<T: UsageProvider>(
             change.path
         ),
         severity: Severity::Error,
+        path: change.path.clone(),
+        change_kind: change.kind,
     })
 }
 
@@ -125,6 +133,8 @@ pub(super) fn add_field<T: UsageProvider>(
                 change.path
             ),
             severity: Severity::Error,
+            path: change.path.clone(),
+            change_kind: change.kind,
         })
     } else {
         None
@@ -169,6 +179,8 @@ pub(super) fn change_field_argument_type<T: UsageProvider>(
                             change.path
                         ),
                         severity: Severity::Error,
+                        path: change.path.clone(),
+                        change_kind: change.kind,
                     });
                 }
                 crate::schema::WrapperTypesComparison::NoChange
@@ -184,6 +196,8 @@ pub(super) fn change_field_argument_type<T: UsageProvider>(
     Some(CheckDiagnostic {
         message: format!("The argument `{}` changed type but it is used by clients.", change.path),
         severity: Severity::Error,
+        path: change.path.clone(),
+        change_kind: change.kind,
     })
 }
 
@@ -202,6 +216,8 @@ pub(super) fn remove_field_argument<T: UsageProvider>(
             change.path
         ),
         severity: Severity::Error,
+        path: change.path.clone(),
+        change_kind: change.kind,
     })
 }
 
@@ -251,6 +267,8 @@ pub(super) fn change_field_type<T: UsageProvider>(
                 target_field.render_type()
             ),
             severity: Severity::Error,
+            path: change.path.clone(),
+            change_kind: change.kind,
         });
     }
 
@@ -262,6 +280,8 @@ pub(super) fn change_field_type<T: UsageProvider>(
                     change.path
                 ),
                 severity: Severity::Warning, // warning because we can't tell if they are providing it or not
+                path: change.path.clone(),
+                change_kind: change.kind,
             })
         }
         (false, crate::schema::WrapperTypesComparison::RemovedNonNull) => Some(CheckDiagnostic {
@@ -270,6 +290,8 @@ pub(super) fn change_field_type<T: UsageProvider>(
                 change.path
             ),
             severity: Severity::Error,
+            path: change.path.clone(),
+            change_kind: change.kind,
         }),
         _ => None,
     }
@@ -297,6 +319,8 @@ pub(super) fn remove_interface_implementation<T: UsageProvider>(
             "The interface implementation for `{interface_name}` on `{type_name}` was removed but it is still used by clients."
         ),
         severity: Severity::Error,
+        path: change.path.clone(),
+        change_kind: change.kind,
     })
 }
 
@@ -317,6 +341,8 @@ pub(super) fn remove_union_member<T: UsageProvider>(
             change.path
         ),
         severity: Severity::Error,
+        path: change.path.clone(),
+        change_kind: change.kind,
     })
 }
 
@@ -340,6 +366,8 @@ pub(crate) fn remove_object_type<T: UsageProvider>(args: CheckArgs<'_, '_, T>) -
                     "The interface implementation for `{interface_name}` on `{type_name}` was removed but it is still used by clients."
                 ),
                 severity: Severity::Error,
+                path: args.change.path.clone(),
+                change_kind: args.change.kind,
             });
         }
     }
@@ -366,6 +394,8 @@ pub(crate) fn remove_object_type<T: UsageProvider>(args: CheckArgs<'_, '_, T>) -
     Some(CheckDiagnostic {
         message: format!("The root type `{type_name}` was removed but it is still used by clients."),
         severity: Severity::Error,
+        path: args.change.path.clone(),
+        change_kind: args.change.kind,
     })
 }
 
@@ -381,6 +411,8 @@ pub(crate) fn remove_enum_value<T: UsageProvider>(args: CheckArgs<'_, '_, T>) ->
             args.change.path
         ),
         severity: Severity::Error,
+        path: args.change.path.clone(),
+        change_kind: args.change.kind,
     })
 }
 
@@ -395,5 +427,7 @@ pub(crate) fn remove_field_argument_default<T: UsageProvider>(args: CheckArgs<'_
     Some(CheckDiagnostic {
         message: format!("The default value for required argument `{path}` was removed but some queries leave it out.",),
         severity: Severity::Error,
+        path: args.change.path.clone(),
+        change_kind: args.change.kind,
     })
 }

--- a/crates/operation-checks/tests/cases/add_optional_input_field.snapshot
+++ b/crates/operation-checks/tests/cases/add_optional_input_field.snapshot
@@ -6,5 +6,7 @@ Backward:
     CheckDiagnostic {
         message: "The field `GreetingParams.honorifics` was removed but it may still be used by clients.",
         severity: Warning,
+        path: "GreetingParams.honorifics",
+        change_kind: RemoveField,
     },
 ]

--- a/crates/operation-checks/tests/cases/add_required_argument_without_default.snapshot
+++ b/crates/operation-checks/tests/cases/add_required_argument_without_default.snapshot
@@ -3,6 +3,8 @@ Forward:
     CheckDiagnostic {
         message: "The new required argument at `Query.sayHi.name` would break clients that are not providing it.",
         severity: Error,
+        path: "Query.sayHi.name",
+        change_kind: AddFieldArgument,
     },
 ]
 

--- a/crates/operation-checks/tests/cases/add_required_input_field.snapshot
+++ b/crates/operation-checks/tests/cases/add_required_input_field.snapshot
@@ -3,6 +3,8 @@ Forward:
     CheckDiagnostic {
         message: "The new required field at `GreetingParams.honorifics` would break clients that are not providing it.",
         severity: Error,
+        path: "GreetingParams.honorifics",
+        change_kind: AddField,
     },
 ]
 
@@ -11,5 +13,7 @@ Backward:
     CheckDiagnostic {
         message: "The field `GreetingParams.honorifics` was removed but it is still used by clients.",
         severity: Error,
+        path: "GreetingParams.honorifics",
+        change_kind: RemoveField,
     },
 ]

--- a/crates/operation-checks/tests/cases/change_field_argument_type.snapshot
+++ b/crates/operation-checks/tests/cases/change_field_argument_type.snapshot
@@ -3,10 +3,14 @@ Forward:
     CheckDiagnostic {
         message: "The argument `Query.findAlbumsByArtist.yearRangeEnd` changed type but it is used by clients.",
         severity: Error,
+        path: "Query.findAlbumsByArtist.yearRangeEnd",
+        change_kind: ChangeFieldArgumentType,
     },
     CheckDiagnostic {
         message: "The argument `Query.findAlbumsByArtist.yearRangeStart` changed type but it is used by clients.",
         severity: Error,
+        path: "Query.findAlbumsByArtist.yearRangeStart",
+        change_kind: ChangeFieldArgumentType,
     },
 ]
 
@@ -15,9 +19,13 @@ Backward:
     CheckDiagnostic {
         message: "The argument `Query.findAlbumsByArtist.yearRangeEnd` changed type but it is used by clients.",
         severity: Error,
+        path: "Query.findAlbumsByArtist.yearRangeEnd",
+        change_kind: ChangeFieldArgumentType,
     },
     CheckDiagnostic {
         message: "The argument `Query.findAlbumsByArtist.yearRangeStart` changed type but it is used by clients.",
         severity: Error,
+        path: "Query.findAlbumsByArtist.yearRangeStart",
+        change_kind: ChangeFieldArgumentType,
     },
 ]

--- a/crates/operation-checks/tests/cases/change_field_argument_type_requiredness.snapshot
+++ b/crates/operation-checks/tests/cases/change_field_argument_type_requiredness.snapshot
@@ -6,9 +6,13 @@ Backward:
     CheckDiagnostic {
         message: "The argument `Query.findAlbumsByArtist.yearRangeEnd` became required, but clients are not providing it.",
         severity: Error,
+        path: "Query.findAlbumsByArtist.yearRangeEnd",
+        change_kind: ChangeFieldArgumentType,
     },
     CheckDiagnostic {
         message: "The argument `Query.findAlbumsByArtist.yearRangeStart` became required, but clients are not providing it.",
         severity: Error,
+        path: "Query.findAlbumsByArtist.yearRangeStart",
+        change_kind: ChangeFieldArgumentType,
     },
 ]

--- a/crates/operation-checks/tests/cases/change_field_type_basic.snapshot
+++ b/crates/operation-checks/tests/cases/change_field_type_basic.snapshot
@@ -3,10 +3,14 @@ Forward:
     CheckDiagnostic {
         message: "The type of the field `Mammal.weight` changed from `Float!` to `Int!`.",
         severity: Error,
+        path: "Mammal.weight",
+        change_kind: ChangeFieldType,
     },
     CheckDiagnostic {
         message: "The type of the field `MammalInput.mweight` changed from `Float!` to `Int!`.",
         severity: Error,
+        path: "MammalInput.mweight",
+        change_kind: ChangeFieldType,
     },
 ]
 
@@ -15,9 +19,13 @@ Backward:
     CheckDiagnostic {
         message: "The type of the field `Mammal.weight` changed from `Int!` to `Float!`.",
         severity: Error,
+        path: "Mammal.weight",
+        change_kind: ChangeFieldType,
     },
     CheckDiagnostic {
         message: "The type of the field `MammalInput.mweight` changed from `Int!` to `Float!`.",
         severity: Error,
+        path: "MammalInput.mweight",
+        change_kind: ChangeFieldType,
     },
 ]

--- a/crates/operation-checks/tests/cases/change_field_type_requiredness_err.snapshot
+++ b/crates/operation-checks/tests/cases/change_field_type_requiredness_err.snapshot
@@ -3,10 +3,14 @@ Forward:
     CheckDiagnostic {
         message: "The field `Mammal.weight` became optional, but clients do not expect null.",
         severity: Error,
+        path: "Mammal.weight",
+        change_kind: ChangeFieldType,
     },
     CheckDiagnostic {
         message: "The field `MammalInput.mweight` became required, but clients may not be providing it.",
         severity: Warning,
+        path: "MammalInput.mweight",
+        change_kind: ChangeFieldType,
     },
 ]
 

--- a/crates/operation-checks/tests/cases/change_list_type_nesting.snapshot
+++ b/crates/operation-checks/tests/cases/change_list_type_nesting.snapshot
@@ -3,18 +3,26 @@ Forward:
     CheckDiagnostic {
         message: "The type of the field `HappyKoala.family` changed from `[String]` to `[[String]]`.",
         severity: Error,
+        path: "HappyKoala.family",
+        change_kind: ChangeFieldType,
     },
     CheckDiagnostic {
         message: "The type of the field `HappyKoala.familyRequired` changed from `[String!]` to `[[String!]]`.",
         severity: Error,
+        path: "HappyKoala.familyRequired",
+        change_kind: ChangeFieldType,
     },
     CheckDiagnostic {
         message: "The type of the field `KoalaInput.family` changed from `[String]` to `[[String]]`.",
         severity: Error,
+        path: "KoalaInput.family",
+        change_kind: ChangeFieldType,
     },
     CheckDiagnostic {
         message: "The argument `Query.koalaFeed.koalaInput` changed type but it is used by clients.",
         severity: Error,
+        path: "Query.koalaFeed.koalaInput",
+        change_kind: ChangeFieldArgumentType,
     },
 ]
 
@@ -23,17 +31,25 @@ Backward:
     CheckDiagnostic {
         message: "The type of the field `HappyKoala.family` changed from `[[String]]` to `[String]`.",
         severity: Error,
+        path: "HappyKoala.family",
+        change_kind: ChangeFieldType,
     },
     CheckDiagnostic {
         message: "The type of the field `HappyKoala.familyRequired` changed from `[[String!]]` to `[String!]`.",
         severity: Error,
+        path: "HappyKoala.familyRequired",
+        change_kind: ChangeFieldType,
     },
     CheckDiagnostic {
         message: "The type of the field `KoalaInput.family` changed from `[[String]]` to `[String]`.",
         severity: Error,
+        path: "KoalaInput.family",
+        change_kind: ChangeFieldType,
     },
     CheckDiagnostic {
         message: "The argument `Query.koalaFeed.koalaInput` changed type but it is used by clients.",
         severity: Error,
+        path: "Query.koalaFeed.koalaInput",
+        change_kind: ChangeFieldArgumentType,
     },
 ]

--- a/crates/operation-checks/tests/cases/change_requiredness_of_nested_list_type.snapshot
+++ b/crates/operation-checks/tests/cases/change_requiredness_of_nested_list_type.snapshot
@@ -3,14 +3,20 @@ Forward:
     CheckDiagnostic {
         message: "The field `Mammal.vernacularNames` became optional, but clients do not expect null.",
         severity: Error,
+        path: "Mammal.vernacularNames",
+        change_kind: ChangeFieldType,
     },
     CheckDiagnostic {
         message: "The argument `Mutation.createMammals.input` became required, but clients are not providing it.",
         severity: Error,
+        path: "Mutation.createMammals.input",
+        change_kind: ChangeFieldArgumentType,
     },
     CheckDiagnostic {
         message: "The argument `Mutation.createMammals2.input` became required, but clients are not providing it.",
         severity: Error,
+        path: "Mutation.createMammals2.input",
+        change_kind: ChangeFieldArgumentType,
     },
 ]
 

--- a/crates/operation-checks/tests/cases/make_argument_with_default_nonnull_without_default.snapshot
+++ b/crates/operation-checks/tests/cases/make_argument_with_default_nonnull_without_default.snapshot
@@ -3,6 +3,8 @@ Forward:
     CheckDiagnostic {
         message: "The argument `Turtle.feed.food` became required, but clients are not providing it.",
         severity: Error,
+        path: "Turtle.feed.food",
+        change_kind: ChangeFieldArgumentType,
     },
 ]
 

--- a/crates/operation-checks/tests/cases/remove_argument_basic.snapshot
+++ b/crates/operation-checks/tests/cases/remove_argument_basic.snapshot
@@ -3,10 +3,14 @@ Forward:
     CheckDiagnostic {
         message: "The argument `Query.findAlbumsByArtist.yearRangeEnd` was removed but it is still used by clients.",
         severity: Error,
+        path: "Query.findAlbumsByArtist.yearRangeEnd",
+        change_kind: RemoveFieldArgument,
     },
     CheckDiagnostic {
         message: "The argument `Query.findAlbumsByArtist.yearRangeStart` was removed but it is still used by clients.",
         severity: Error,
+        path: "Query.findAlbumsByArtist.yearRangeStart",
+        change_kind: RemoveFieldArgument,
     },
 ]
 
@@ -15,9 +19,13 @@ Backward:
     CheckDiagnostic {
         message: "The new required argument at `Query.findAlbumsByArtist.yearRangeEnd` would break clients that are not providing it.",
         severity: Error,
+        path: "Query.findAlbumsByArtist.yearRangeEnd",
+        change_kind: AddFieldArgument,
     },
     CheckDiagnostic {
         message: "The new required argument at `Query.findAlbumsByArtist.yearRangeStart` would break clients that are not providing it.",
         severity: Error,
+        path: "Query.findAlbumsByArtist.yearRangeStart",
+        change_kind: AddFieldArgument,
     },
 ]

--- a/crates/operation-checks/tests/cases/remove_argument_basic_ok.snapshot
+++ b/crates/operation-checks/tests/cases/remove_argument_basic_ok.snapshot
@@ -6,9 +6,13 @@ Backward:
     CheckDiagnostic {
         message: "The new required argument at `Query.findAlbumsByArtist.yearRangeEnd` would break clients that are not providing it.",
         severity: Error,
+        path: "Query.findAlbumsByArtist.yearRangeEnd",
+        change_kind: AddFieldArgument,
     },
     CheckDiagnostic {
         message: "The new required argument at `Query.findAlbumsByArtist.yearRangeStart` would break clients that are not providing it.",
         severity: Error,
+        path: "Query.findAlbumsByArtist.yearRangeStart",
+        change_kind: AddFieldArgument,
     },
 ]

--- a/crates/operation-checks/tests/cases/remove_enum_value_used_in_argument.snapshot
+++ b/crates/operation-checks/tests/cases/remove_enum_value_used_in_argument.snapshot
@@ -3,6 +3,8 @@ Forward:
     CheckDiagnostic {
         message: "The enum value `Color.BLUE` was removed but it is still used by clients.",
         severity: Error,
+        path: "Color.BLUE",
+        change_kind: RemoveEnumValue,
     },
 ]
 

--- a/crates/operation-checks/tests/cases/remove_mutation_root.snapshot
+++ b/crates/operation-checks/tests/cases/remove_mutation_root.snapshot
@@ -3,6 +3,8 @@ Forward:
     CheckDiagnostic {
         message: "The root type `Mu` was removed but it is still used by clients.",
         severity: Error,
+        path: "Mu",
+        change_kind: RemoveObjectType,
     },
 ]
 

--- a/crates/operation-checks/tests/cases/remove_nonnull_argument_default.snapshot
+++ b/crates/operation-checks/tests/cases/remove_nonnull_argument_default.snapshot
@@ -3,6 +3,8 @@ Forward:
     CheckDiagnostic {
         message: "The default value for required argument `Turtle.feed.food` was removed but some queries leave it out.",
         severity: Error,
+        path: "Turtle.feed.food",
+        change_kind: RemoveFieldArgumentDefault,
     },
 ]
 

--- a/crates/operation-checks/tests/cases/remove_used_enum_value_in_variable_default.snapshot
+++ b/crates/operation-checks/tests/cases/remove_used_enum_value_in_variable_default.snapshot
@@ -3,6 +3,8 @@ Forward:
     CheckDiagnostic {
         message: "The enum value `Color.BLUE` was removed but it is still used by clients.",
         severity: Error,
+        path: "Color.BLUE",
+        change_kind: RemoveEnumValue,
     },
 ]
 

--- a/crates/operation-checks/tests/cases/remove_used_field.snapshot
+++ b/crates/operation-checks/tests/cases/remove_used_field.snapshot
@@ -3,6 +3,8 @@ Forward:
     CheckDiagnostic {
         message: "The field `Query.doB` was removed but it is still used by clients.",
         severity: Error,
+        path: "Query.doB",
+        change_kind: RemoveField,
     },
 ]
 

--- a/crates/operation-checks/tests/cases/remove_used_interface_implementer.snapshot
+++ b/crates/operation-checks/tests/cases/remove_used_interface_implementer.snapshot
@@ -3,6 +3,8 @@ Forward:
     CheckDiagnostic {
         message: "The interface implementation for `SpeechCondition` on `Lisp` was removed but it is still used by clients.",
         severity: Error,
+        path: "Lisp",
+        change_kind: RemoveObjectType,
     },
 ]
 

--- a/crates/operation-checks/tests/cases/remove_used_union_member.snapshot
+++ b/crates/operation-checks/tests/cases/remove_used_union_member.snapshot
@@ -3,6 +3,8 @@ Forward:
     CheckDiagnostic {
         message: "The union member `DogEars.PointyEars` was removed but it is still used by clients.",
         severity: Error,
+        path: "DogEars.PointyEars",
+        change_kind: RemoveUnionMember,
     },
 ]
 


### PR DESCRIPTION
Just more structured diagnostics, for the upcoming breaking change approvals feature.

closes GB-9697