### PR TITLE
graphql-composition: detect grafbase extensions even without explicit namespace

### DIFF
--- a/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_file_url_are_extensions/api.graphql.snap
+++ b/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_file_url_are_extensions/api.graphql.snap
@@ -4,5 +4,6 @@ expression: "Very important in this test: no extensions.toml, composition should
 input_file: crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_file_url_are_extensions/test.md
 ---
 type Query {
+  amazing: Boolean!
   hello: String
 }

--- a/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_file_url_are_extensions/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_file_url_are_extensions/federated.graphql.snap
@@ -27,15 +27,19 @@ scalar join__FieldSet
 
 type Query
 {
+  amazing: Boolean! @extension__directive(graph: MY_OTHER_EXTENSION_WITHOUT_NAME, extension: SPARKLES, name: "sparkles", arguments: {}) @extension__directive(graph: MY_OTHER_EXTENSION_WITHOUT_NAME, extension: BUBBLES, name: "blub", arguments: {}) @join__field(graph: MY_OTHER_EXTENSION_WITHOUT_NAME)
   hello: String @join__field(graph: MY_EXTENSION_SUBGRAPH)
 }
 
 enum join__Graph
 {
   MY_EXTENSION_SUBGRAPH @join__graph(name: "my-extension-subgraph", url: "http://example.com/my-extension-subgraph")
+  MY_OTHER_EXTENSION_WITHOUT_NAME @join__graph(name: "my-other-extension-without-name", url: "http://example.com/my-other-extension-without-name")
 }
 
 enum extension__Link
 {
   REST @extension__link(url: "file:///rest-extension/test", schemaDirectives: [{graph: MY_EXTENSION_SUBGRAPH, name: "assured", arguments: {}}])
+  SPARKLES @extension__link(url: "file:///grafbase-extensions/sparkles")
+  BUBBLES @extension__link(url: "file:///grafbase-extensions/bubbles/build")
 }

--- a/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_file_url_are_extensions/subgraphs/my_other_extension_without_name.graphql
+++ b/crates/graphql-composition/tests/composition/grafbase_extensions/linked_schemas_with_file_url_are_extensions/subgraphs/my_other_extension_without_name.graphql
@@ -1,0 +1,10 @@
+extend schema
+  # This extension import does not have a namespace (`as:`). Composition should use the last path component as a namespace.
+  @link(url: "file:///grafbase-extensions/sparkles", import: ["@sparkles"])
+  # This extension import does not have a namespace (`as:`). Composition should use the last path component as a namespace, except it's "build", so it automatically tries the previous component as a more meaningful name.
+  @link(url: "file:///grafbase-extensions/bubbles/build", import: ["@blub"])
+  @link(url: "https://specs.grafbase.com/grafbase", import: ["InputvalueSet"])
+
+type Query {
+  amazing: Boolean! @sparkles @blub
+}


### PR DESCRIPTION
For `@link` imports with file urls without a namespace (`as:`), do not give up immediately on treating them as an extension, but try and infer an extension name from the path:

- if the directory name is "build/", this is probably a locally built extension, in which case the parent directory is a more informative name.
- in all other cases, use the directory name.