### PR TITLE
cli: release 0.102.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3899,7 +3899,7 @@ dependencies = [
 
 [[package]]
 name = "grafbase"
-version = "0.102.4"
+version = "0.102.5"
 dependencies = [
  "anyhow",
  "askama",

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.102.5] - 2025-09-24
+
+[CHANGELOG](changelog/0.102.5.md)
+
 ## [0.102.4] - 2025-09-04
 
 [CHANGELOG](changelog/0.102.4.md)

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.102.4"
+version = "0.102.5"
 name = "grafbase"
 description = "The Grafbase command line interface"
 categories = ["command-line-utilities"]

--- a/cli/changelog/0.102.5.md
+++ b/cli/changelog/0.102.5.md
@@ -1,0 +1,4 @@
+## Improvements
+
+- If you explicitly pass `--virtual` to the `publish` command, and the subgraph already has a URL, it will now become virtual, instead of keeping its URL previously.
+- Clearer rules for composition extensions, that are now documented in [the online docs](https://grafbase.com/docs/gateway/extensions/composition) and the graphql-composition crate [`README`](https://github.com/grafbase/grafbase/blob/main/crates/graphql-composition/README.md). This release also includes propagating the `@link` directives to import directives composed with `@composeDirective` in the federated schema.

--- a/cli/changelog/unreleased.md
+++ b/cli/changelog/unreleased.md
@@ -1,3 +1,0 @@
-## Improvements
-
-- If you explicitly pass `--virtual` to the `publish` command, and the subgraph already has a URL, it will now become virtual, instead of keeping its URL previously.

--- a/cli/npm/aarch64-apple-darwin/package.json
+++ b/cli/npm/aarch64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-apple-darwin",
-  "version": "0.102.4",
+  "version": "0.102.5",
   "description": "aarch64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/aarch64-unknown-linux-musl/package.json
+++ b/cli/npm/aarch64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-aarch64-unknown-linux-musl",
-  "version": "0.102.4",
+  "version": "0.102.5",
   "description": "aarch64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/cli/package.json
+++ b/cli/npm/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafbase",
-  "version": "0.102.4",
+  "version": "0.102.5",
   "description": "The Grafbase command line interface",
   "keywords": [
     "grafbase"
@@ -27,10 +27,10 @@
     "jest": "30.1.3"
   },
   "optionalDependencies": {
-    "@grafbase/cli-aarch64-apple-darwin": "^0.102.4",
-    "@grafbase/cli-x86_64-apple-darwin": "^0.102.4",
-    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.102.4",
-    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.102.4",
-    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.102.4"
+    "@grafbase/cli-aarch64-apple-darwin": "^0.102.5",
+    "@grafbase/cli-x86_64-apple-darwin": "^0.102.5",
+    "@grafbase/cli-x86_64-pc-windows-msvc": "^0.102.5",
+    "@grafbase/cli-x86_64-unknown-linux-musl": "^0.102.5",
+    "@grafbase/cli-aarch64-unknown-linux-musl": "^0.102.5"
   }
 }

--- a/cli/npm/x86_64-apple-darwin/package.json
+++ b/cli/npm/x86_64-apple-darwin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-apple-darwin",
-  "version": "0.102.4",
+  "version": "0.102.5",
   "description": "x86_64-apple-darwin binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-pc-windows-msvc/package.json
+++ b/cli/npm/x86_64-pc-windows-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-pc-windows-msvc",
-  "version": "0.102.4",
+  "version": "0.102.5",
   "description": "x86_64-pc-windows-msvc binary for Grafbase CLI",
   "keywords": [
     "grafbase",

--- a/cli/npm/x86_64-unknown-linux-musl/package.json
+++ b/cli/npm/x86_64-unknown-linux-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafbase/cli-x86_64-unknown-linux-musl",
-  "version": "0.102.4",
+  "version": "0.102.5",
   "description": "x86_64-unknown-linux-musl binary for Grafbase CLI",
   "keywords": [
     "grafbase",


### PR DESCRIPTION
## Improvements

- If you explicitly pass `--virtual` to the `publish` command, and the subgraph already has a URL, it will now become virtual, instead of keeping its URL previously.
- Clearer rules for composition extensions, that are now documented in [the online docs](https://grafbase.com/docs/gateway/extensions/composition) and the graphql-composition crate [`README`](https://github.com/grafbase/grafbase/blob/main/crates/graphql-composition/README.md). This release also includes propagating the `@link` directives to import directives composed with `@composeDirective` in the federated schema.