### PR TITLE
graphql-composition: emit `@composeDirective` directives on schema definitions

### DIFF
--- a/crates/graphql-composition/CHANGELOG.md
+++ b/crates/graphql-composition/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - There were inconsistencies in what types of subgraphs (no imports, federation v2 import, composite schemas import, with and without associated url) would recognize `@cost` and `@listSize` as built-in directives. This release fixes the inconsistency and treats them as built-ins everywhere. (https://github.com/grafbase/grafbase/pull/3485)
+- Directives composed with `@composeDirective` and located on a schema definition or extension are now properly propagated to the composed schema.
 
 ## 0.12.0 - 2025-08-29
 

--- a/crates/graphql-composition/src/emit_federated_graph.rs
+++ b/crates/graphql-composition/src/emit_federated_graph.rs
@@ -7,16 +7,7 @@ mod emit_linked_schemas;
 mod federation_builtins;
 mod field_types_map;
 
-use self::{
-    context::Context,
-    directive::{
-        emit_composite_spec_directive_definitions, emit_cost_directive_definition, emit_list_size_directive_definition,
-        transform_arbitray_type_directives, transform_enum_value_directives, transform_field_directives,
-        transform_input_value_directives, transform_type_directives,
-    },
-    directive_definitions::emit_directive_definitions,
-    emit_extensions::*,
-};
+use self::{context::Context, directive::*, directive_definitions::emit_directive_definitions, emit_extensions::*};
 use crate::{
     Subgraphs, VecExt,
     composition_ir::{CompositionIr, FieldIr, InputValueDefinitionIr},
@@ -48,6 +39,7 @@ pub(crate) fn emit_federated_graph(mut ir: CompositionIr, subgraphs: &Subgraphs)
             mutation: ir.mutation_type,
             subscription: ir.subscription_type,
         },
+        composed_directives_on_schema_definition: Vec::new(),
     };
 
     let mut ctx = Context::new(&mut ir, subgraphs, &mut out);
@@ -140,6 +132,7 @@ fn emit_directives_and_implements_interface(ctx: &mut Context<'_>, mut ir: Compo
     emit_list_size_directive_definition(ctx);
     emit_composite_spec_directive_definitions(ctx);
     emit_interface_after_directives(ctx);
+    emit_composed_directives_on_schema_definition(ctx);
 }
 
 fn emit_input_value_definitions(input_value_definitions: &[InputValueDefinitionIr], ctx: &mut Context<'_>) {

--- a/crates/graphql-composition/src/federated_graph.rs
+++ b/crates/graphql-composition/src/federated_graph.rs
@@ -60,6 +60,7 @@ pub struct FederatedGraph {
     pub(crate) input_objects: Vec<InputObject>,
     pub(crate) enum_values: Vec<EnumValueRecord>,
     pub(crate) linked_schemas: Vec<LinkDirective>,
+    pub(crate) composed_directives_on_schema_definition: Vec<directives::OtherDirective>,
 
     /// All [input value definitions](http://spec.graphql.org/October2021/#InputValueDefinition) in the federated graph. Concretely, these are arguments of output fields, and input object fields.
     pub(crate) input_value_definitions: Vec<InputValueDefinition>,

--- a/crates/graphql-composition/src/federated_graph/directives.rs
+++ b/crates/graphql-composition/src/federated_graph/directives.rs
@@ -25,43 +25,24 @@ pub(crate) use self::{
 #[derive(PartialEq, PartialOrd, Clone, Debug)]
 pub(crate) enum Directive {
     Authenticated,
-    CompositeLookup {
-        graph: SubgraphId,
-    },
-    CompositeDerive {
-        graph: SubgraphId,
-    },
-    CompositeInternal {
-        graph: SubgraphId,
-    },
-    CompositeRequire {
-        graph: SubgraphId,
-        field: StringId,
-    },
-    CompositeIs {
-        graph: SubgraphId,
-        field: StringId,
-    },
-    Deprecated {
-        reason: Option<StringId>,
-    },
+    CompositeLookup { graph: SubgraphId },
+    CompositeDerive { graph: SubgraphId },
+    CompositeInternal { graph: SubgraphId },
+    CompositeRequire { graph: SubgraphId, field: StringId },
+    CompositeIs { graph: SubgraphId, field: StringId },
+    Deprecated { reason: Option<StringId> },
     OneOf,
     Inaccessible,
     Policy(Vec<Vec<StringId>>),
     RequiresScopes(Vec<Vec<StringId>>),
-    Cost {
-        weight: i32,
-    },
+    Cost { weight: i32 },
     JoinGraph(JoinGraphDirective),
     JoinField(JoinFieldDirective),
     JoinType(JoinTypeDirective),
     JoinUnionMember(JoinUnionMemberDirective),
     JoinImplements(JoinImplementsDirective),
     JoinEnumValue(JoinEnumValueDirective),
-    Other {
-        name: StringId,
-        arguments: Vec<(StringId, Value)>,
-    },
+    Other(OtherDirective),
     ListSize(ListSize),
 
     ExtensionDirective(ExtensionDirective),
@@ -86,6 +67,12 @@ impl Directive {
             _ => None,
         }
     }
+}
+
+#[derive(PartialEq, PartialOrd, Debug, Clone)]
+pub(crate) struct OtherDirective {
+    pub(crate) name: StringId,
+    pub(crate) arguments: Vec<(StringId, Value)>,
 }
 
 #[cfg(test)]

--- a/crates/graphql-composition/src/federated_graph/from_sdl/directive.rs
+++ b/crates/graphql-composition/src/federated_graph/from_sdl/directive.rs
@@ -1,15 +1,7 @@
-use std::str::FromStr;
-
+use super::*;
 use cynic_parser::type_system::{self as ast};
 use cynic_parser_deser::ConstDeserializer;
-
-use super::{
-    CostDirective, Definition, DeprecatedDirective, Directive, DomainError, EXTENSION_DIRECTIVE_DIRECTIVE,
-    ExtensionDirective, ExtensionLinkSchemaDirective, FieldId, GetArgumentsExt, InputValueDefinitionId, IntoJson,
-    JoinFieldDirective, JoinImplementsDirective, JoinTypeDirective, JoinUnionMemberDirective, ListSize,
-    ListSizeDirective, OverrideLabel, OverrideSource, State, StringId, Value, attach_selection_set,
-    parse_selection_set,
-};
+use std::str::FromStr;
 
 pub(super) fn collect_definition_directives<'a>(
     definition_id: Definition,
@@ -199,7 +191,7 @@ fn parse_other<'a>(directive: ast::Directive<'a>, state: &mut State<'a>) -> Dire
         .arguments()
         .map(|arg| -> (StringId, Value) { (state.insert_string(arg.name()), state.insert_value(arg.value(), None)) })
         .collect();
-    Directive::Other { name, arguments }
+    Directive::Other(OtherDirective { name, arguments })
 }
 
 fn parse_join_type_directive<'a>(

--- a/crates/graphql-composition/src/federated_graph/render_sdl/directive.rs
+++ b/crates/graphql-composition/src/federated_graph/render_sdl/directive.rs
@@ -90,7 +90,7 @@ pub(crate) fn write_directive<'a, 'b: 'a>(
                 directive.arg("url", Value::String(*url))?;
             }
         }
-        Directive::Other { name, arguments } => {
+        Directive::Other(OtherDirective { name, arguments }) => {
             let mut directive = DirectiveWriter::new(&graph[*name], f, graph)?;
 
             for (name, value) in arguments {

--- a/crates/graphql-composition/src/federated_graph/render_sdl/render_federated_sdl/schema_definition.rs
+++ b/crates/graphql-composition/src/federated_graph/render_sdl/render_federated_sdl/schema_definition.rs
@@ -42,6 +42,20 @@ pub(super) fn display_schema_definition(graph: &FederatedGraph, f: &mut fmt::For
         f.write_str("\n")?;
     }
 
+    for directive in &graph.composed_directives_on_schema_definition {
+        f.write_str(INDENT)?;
+
+        {
+            let mut writer = DirectiveWriter::new(&graph[directive.name], f, graph)?;
+
+            for (argument_name, argument_value) in &directive.arguments {
+                writer = writer.arg(&graph[*argument_name], argument_value.clone())?;
+            }
+        }
+
+        f.write_str("\n")?;
+    }
+
     if !query_root_defined {
         return f.write_str("\n");
     }

--- a/crates/graphql-composition/tests/composition/federation_v2/compose_directive/compose_directive_on_schema_definition/api.graphql.snap
+++ b/crates/graphql-composition/tests/composition/federation_v2/compose_directive/compose_directive_on_schema_definition/api.graphql.snap
@@ -1,0 +1,25 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: The directives on schema definitions and extensions should be propagated by @composeDirective
+input_file: crates/graphql-composition/tests/composition/federation_v2/compose_directive/compose_directive_on_schema_definition/test.md
+---
+type BirdObservation {
+  id: ID!
+  location: String!
+  species: String!
+  timestamp: String!
+}
+
+type BirdSighting {
+  id: ID!
+}
+
+type Query {
+  birdObservation(observationID: ID!): BirdObservation
+  birdObservations(filters: BirdObservationFilters): [BirdObservation]
+  sightings(sightingID: ID!): BirdSighting
+}
+
+input BirdObservationFilters {
+  id: ID
+}

--- a/crates/graphql-composition/tests/composition/federation_v2/compose_directive/compose_directive_on_schema_definition/diagnostics.snap
+++ b/crates/graphql-composition/tests/composition/federation_v2/compose_directive/compose_directive_on_schema_definition/diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: The directives on schema definitions and extensions should be propagated by @composeDirective
+input_file: crates/graphql-composition/tests/composition/federation_v2/compose_directive/compose_directive_on_schema_definition/test.md
+---
+

--- a/crates/graphql-composition/tests/composition/federation_v2/compose_directive/compose_directive_on_schema_definition/federated.graphql.snap
+++ b/crates/graphql-composition/tests/composition/federation_v2/compose_directive/compose_directive_on_schema_definition/federated.graphql.snap
@@ -1,0 +1,62 @@
+---
+source: crates/graphql-composition/tests/composition_tests.rs
+expression: The directives on schema definitions and extensions should be propagated by @composeDirective
+input_file: crates/graphql-composition/tests/composition/federation_v2/compose_directive/compose_directive_on_schema_definition/test.md
+---
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY)
+  @recorded
+  @sighted
+{
+  query: Query
+}
+
+directive @join__unionMember(graph: join__Graph!, member: String!) on UNION
+
+directive @join__implements(graph: join__Graph!, interface: String!) on OBJECT | INTERFACE
+
+directive @join__graph(name: String!, url: String) on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__type(graph: join__Graph, key: join__FieldSet, extension: Boolean = false, resolvable: Boolean = true, isInterfaceObject: Boolean = false) on SCALAR | OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT
+
+directive @join__owner(graph: join__Graph!) on OBJECT
+
+scalar join__FieldSet
+
+type BirdObservation
+  @join__type(graph: OBSERVATIONS)
+{
+  id: ID!
+  location: String!
+  species: String!
+  timestamp: String!
+}
+
+type BirdSighting
+  @join__type(graph: SIGHTINGS)
+{
+  id: ID!
+}
+
+type Query
+{
+  birdObservation(observationID: ID!): BirdObservation @join__field(graph: OBSERVATIONS)
+  birdObservations(filters: BirdObservationFilters): [BirdObservation] @join__field(graph: OBSERVATIONS)
+  sightings(sightingID: ID!): BirdSighting @join__field(graph: SIGHTINGS)
+}
+
+enum join__Graph
+{
+  OBSERVATIONS @join__graph(name: "observations", url: "http://example.com/observations")
+  SIGHTINGS @join__graph(name: "sightings", url: "http://example.com/sightings")
+}
+
+input BirdObservationFilters
+  @join__type(graph: OBSERVATIONS)
+{
+  id: ID
+}

--- a/crates/graphql-composition/tests/composition/federation_v2/compose_directive/compose_directive_on_schema_definition/subgraphs/observations.graphql
+++ b/crates/graphql-composition/tests/composition/federation_v2/compose_directive/compose_directive_on_schema_definition/subgraphs/observations.graphql
@@ -1,0 +1,24 @@
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@composeDirective"])
+  @link(url: "https://example.com/schema.graphql", import: ["@recorded"])
+  @recorded
+
+input BirdObservationFilters {
+  id: ID
+}
+
+type BirdObservation {
+  id: ID!
+  species: String!
+  location: String!
+  timestamp: String!
+}
+
+type Query {
+  birdObservations(filters: BirdObservationFilters): [BirdObservation]
+  birdObservation(observationID: ID!): BirdObservation
+}
+
+schema @composeDirective(name: "@recorded") {
+  query: Query
+}

--- a/crates/graphql-composition/tests/composition/federation_v2/compose_directive/compose_directive_on_schema_definition/subgraphs/sightings.graphql
+++ b/crates/graphql-composition/tests/composition/federation_v2/compose_directive/compose_directive_on_schema_definition/subgraphs/sightings.graphql
@@ -1,0 +1,15 @@
+extend schema
+  @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@composeDirective"])
+  @link(url: "https://example.com/spec/test/v2")
+
+type BirdSighting {
+  id: ID!
+}
+
+type Query {
+  sightings(sightingID: ID!): BirdSighting
+}
+
+schema @composeDirective(name: "@sighted") @test__sighted {
+  query: Query
+}

--- a/crates/graphql-composition/tests/composition/federation_v2/compose_directive/compose_directive_on_schema_definition/test.md
+++ b/crates/graphql-composition/tests/composition/federation_v2/compose_directive/compose_directive_on_schema_definition/test.md
@@ -1,0 +1,1 @@
+The directives on schema definitions and extensions should be propagated by @composeDirective


### PR DESCRIPTION
Directives composed with `@composeDirective` and located on a schema definition or extension are now properly propagated to the composed schema.